### PR TITLE
Add the toplevel module (make `make` working again)

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,6 @@
+// This package provides all of its functionality through its
+// submodules. The submodules in the exporters directory provide
+// implementations for trace and metric exporters for third-party
+// collectors, and submodules in the plugins directory provide the
+// instrumentation for the popular go libraries.
+package contrib

--- a/exporters/metric/dogstatsd/dogstatsd.go
+++ b/exporters/metric/dogstatsd/dogstatsd.go
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package dogstatsd // import "github.com/open-telemetry/opentelemetry-go-contrib/exporters/metric/dogstatsd"
+package dogstatsd // import "go.opentelemetry.io/contrib/exporters/metric/dogstatsd"
 
 import (
 	"bytes"
 	"time"
 
-	"github.com/open-telemetry/opentelemetry-go-contrib/exporters/metric/dogstatsd/internal/statsd"
+	"go.opentelemetry.io/contrib/exporters/metric/dogstatsd/internal/statsd"
 	"go.opentelemetry.io/otel/api/global"
 	"go.opentelemetry.io/otel/api/metric"
 	export "go.opentelemetry.io/otel/sdk/export/metric"

--- a/exporters/metric/dogstatsd/dogstatsd_test.go
+++ b/exporters/metric/dogstatsd/dogstatsd_test.go
@@ -19,9 +19,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/open-telemetry/opentelemetry-go-contrib/exporters/metric/dogstatsd"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/contrib/exporters/metric/dogstatsd"
 	"go.opentelemetry.io/otel/api/core"
 	"go.opentelemetry.io/otel/api/key"
 	"go.opentelemetry.io/otel/api/metric"

--- a/exporters/metric/dogstatsd/example_test.go
+++ b/exporters/metric/dogstatsd/example_test.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/open-telemetry/opentelemetry-go-contrib/exporters/metric/dogstatsd"
+	"go.opentelemetry.io/contrib/exporters/metric/dogstatsd"
 	"go.opentelemetry.io/otel/api/key"
 	"go.opentelemetry.io/otel/api/metric"
 )

--- a/exporters/metric/dogstatsd/go.mod
+++ b/exporters/metric/dogstatsd/go.mod
@@ -1,4 +1,4 @@
-module github.com/open-telemetry/opentelemetry-go-contrib/exporters/metric/dogstatsd
+module go.opentelemetry.io/contrib/exporters/metric/dogstatsd
 
 go 1.14
 

--- a/exporters/metric/dogstatsd/internal/statsd/conn_test.go
+++ b/exporters/metric/dogstatsd/internal/statsd/conn_test.go
@@ -22,9 +22,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/open-telemetry/opentelemetry-go-contrib/exporters/metric/dogstatsd/internal/statsd"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/contrib/exporters/metric/dogstatsd/internal/statsd"
 	"go.opentelemetry.io/otel/api/core"
 	"go.opentelemetry.io/otel/api/key"
 	"go.opentelemetry.io/otel/api/metric"

--- a/exporters/metric/dogstatsd/labels_test.go
+++ b/exporters/metric/dogstatsd/labels_test.go
@@ -17,9 +17,9 @@ package dogstatsd_test
 import (
 	"testing"
 
-	"github.com/open-telemetry/opentelemetry-go-contrib/exporters/metric/dogstatsd"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/contrib/exporters/metric/dogstatsd"
 	"go.opentelemetry.io/otel/api/core"
 	"go.opentelemetry.io/otel/api/key"
 	export "go.opentelemetry.io/otel/sdk/export/metric"

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/open-telemetry/opentelemetry-go-contrib
+module go.opentelemetry.io/contrib
 
 go 1.14

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/open-telemetry/opentelemetry-go-contrib
+
+go 1.14

--- a/plugins/sample/trace/doc.go
+++ b/plugins/sample/trace/doc.go
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 // Package sample contains a sample plugin for OpenTelemetry distributed tracing.
-package trace // import "github.com/open-telemetry/opentelemetry-go-contrib/plugins/sample/trace"
+package trace // import "go.opentelemetry.io/contrib/plugins/sample/trace"

--- a/plugins/sample/trace/example_test.go
+++ b/plugins/sample/trace/example_test.go
@@ -15,7 +15,7 @@
 package trace_test
 
 import (
-	"github.com/open-telemetry/opentelemetry-go-contrib/plugins/sample/trace"
+	"go.opentelemetry.io/contrib/plugins/sample/trace"
 )
 
 func ExampleRegister() {

--- a/plugins/sample/trace/go.mod
+++ b/plugins/sample/trace/go.mod
@@ -1,4 +1,4 @@
-module github.com/open-telemetry/opentelemetry-go-contrib/plugins/sample/trace
+module go.opentelemetry.io/contrib/plugins/sample/trace
 
 go 1.13
 

--- a/plugins/sample/trace/sample_test.go
+++ b/plugins/sample/trace/sample_test.go
@@ -17,8 +17,9 @@ package trace_test
 import (
 	"testing"
 
-	"github.com/open-telemetry/opentelemetry-go-contrib/plugins/sample/trace"
 	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/contrib/plugins/sample/trace"
 )
 
 // Register registers sample plugin to instrument a Sample appliction.

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,4 +1,4 @@
-module go.opentelemetry.io/otel/tools
+module go.opentelemetry.io/contrib/tools
 
 go 1.13
 


### PR DESCRIPTION
So the go tooling stops throwing weird errors. Without that, running
make fails with the following message:

```
PATH="/…/.tools:${PATH}" go generate ./...

can't load package: package ./exporters/metric/dogstatsd: code in
directory /…/exporters/metric/dogstatsd expects import
"github.com/open-telemetry/opentelemetry-go-contrib/exporters/metric/dogstatsd"

can't load package: package ./plugins/sample/trace: code in directory
/…/plugins/sample/trace expects import
"github.com/open-telemetry/opentelemetry-go-contrib/plugins/sample/trace"

make: *** [Makefile:113: generate] Error 1
```

Also, we switch to the vanity URL, `go.opentelemetry.io/contrib`.

Closes #17.