### PR TITLE
Dogstatsd exporter resource support (for 0.4.3 release)

### DIFF
--- a/exporters/metric/dogstatsd/dogstatsd_test.go
+++ b/exporters/metric/dogstatsd/dogstatsd_test.go
@@ -34,25 +34,62 @@ import (
 // whether or not the provided labels were encoded by a statsd label
 // encoder.
 func TestDogstatsLabels(t *testing.T) {
-	encoder := dogstatsd.NewLabelEncoder(resource.New(key.String("R", "S")))
-	ctx := context.Background()
-	checkpointSet := test.NewCheckpointSet(encoder)
+	type testCase struct {
+		resources []core.KeyValue
+		labels    []core.KeyValue
+		expected  string
+	}
 
-	desc := metric.NewDescriptor("test.name", metric.CounterKind, core.Int64NumberKind)
-	cagg := sum.New()
-	_ = cagg.Update(ctx, core.NewInt64Number(123), &desc)
-	cagg.Checkpoint(ctx, &desc)
+	kvs := func(kvs ...core.KeyValue) []core.KeyValue { return kvs }
 
-	checkpointSet.Add(&desc, cagg, key.New("A").String("B"))
+	cases := []testCase{
+		{
+			resources: nil,
+			labels:    nil,
+			expected:  "test.name:123|c\n",
+		},
+		{
+			resources: kvs(key.String("R", "S")),
+			labels:    nil,
+			expected:  "test.name:123|c|#R:S\n",
+		},
+		{
+			resources: nil,
+			labels:    kvs(key.String("A", "B")),
+			expected:  "test.name:123|c|#A:B\n",
+		},
+		{
+			resources: kvs(key.String("R", "S")),
+			labels:    kvs(key.String("A", "B")),
+			expected:  "test.name:123|c|#R:S,A:B\n",
+		},
+		{
+			resources: kvs(key.String("A", "R")),
+			labels:    kvs(key.String("A", "B")),
+			expected:  "test.name:123|c|#A:R,A:B\n",
+		},
+	}
+	for _, tc := range cases {
+		res := resource.New(tc.resources...)
+		ctx := context.Background()
+		checkpointSet := test.NewCheckpointSet()
 
-	var buf bytes.Buffer
-	exp, err := dogstatsd.NewRawExporter(dogstatsd.Config{
-		Writer: &buf,
-	})
-	require.Nil(t, err)
+		desc := metric.NewDescriptor("test.name", metric.CounterKind, core.Int64NumberKind)
+		cagg := sum.New()
+		_ = cagg.Update(ctx, core.NewInt64Number(123), &desc)
+		cagg.Checkpoint(ctx, &desc)
 
-	err = exp.Export(ctx, checkpointSet)
-	require.Nil(t, err)
+		checkpointSet.Add(&desc, cagg, tc.labels...)
 
-	require.Equal(t, "test.name:123|c|#R:S,A:B\n", buf.String())
+		var buf bytes.Buffer
+		exp, err := dogstatsd.NewRawExporter(dogstatsd.Config{
+			Writer: &buf,
+		})
+		require.Nil(t, err)
+
+		err = exp.Export(ctx, res, checkpointSet)
+		require.Nil(t, err)
+
+		require.Equal(t, tc.expected, buf.String())
+	}
 }

--- a/exporters/metric/dogstatsd/example_test.go
+++ b/exporters/metric/dogstatsd/example_test.go
@@ -25,6 +25,8 @@ import (
 	"go.opentelemetry.io/contrib/exporters/metric/dogstatsd"
 	"go.opentelemetry.io/otel/api/key"
 	"go.opentelemetry.io/otel/api/metric"
+	"go.opentelemetry.io/otel/sdk/metric/controller/push"
+	"go.opentelemetry.io/otel/sdk/resource"
 )
 
 func ExampleNew() {
@@ -60,7 +62,7 @@ func ExampleNew() {
 		// In real code, use the URL field:
 		//
 		// URL: fmt.Sprint("unix://", path),
-	}, time.Minute)
+	}, time.Minute, push.WithResource(resource.New(key.String("host", "name"))))
 	if err != nil {
 		log.Fatal("Could not initialize dogstatsd exporter:", err)
 	}
@@ -73,7 +75,7 @@ func ExampleNew() {
 	meter := pusher.Meter("example")
 
 	// Create and update a single counter:
-	counter := metric.Must(meter).NewInt64Counter("a.counter", metric.WithKeys(key))
+	counter := metric.Must(meter).NewInt64Counter("a.counter")
 
 	counter.Add(ctx, 100, key.String("value"))
 
@@ -83,5 +85,5 @@ func ExampleNew() {
 	wg.Wait()
 
 	// Output:
-	// a.counter:100|c|#key:value
+	// a.counter:100|c|#host:name,key:value
 }

--- a/exporters/metric/dogstatsd/go.mod
+++ b/exporters/metric/dogstatsd/go.mod
@@ -4,5 +4,6 @@ go 1.14
 
 require (
 	github.com/stretchr/testify v1.5.1
-	go.opentelemetry.io/otel v0.4.2
+	go.opentelemetry.io/otel v0.4.3
 )
+

--- a/exporters/metric/dogstatsd/go.sum
+++ b/exporters/metric/dogstatsd/go.sum
@@ -34,8 +34,11 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+go.opentelemetry.io v0.1.0 h1:EANZoRCOP+A3faIlw/iN6YEWoYb1vleZRKm1EvH8T48=
 go.opentelemetry.io/otel v0.4.2 h1:nT+GOqqRR1cIY92xmo1DeiXLHtIlXH1KLRgnsnhuNrs=
 go.opentelemetry.io/otel v0.4.2/go.mod h1:OgNpQOjrlt33Ew6Ds0mGjmcTQg/rhUctsbkRdk/g1fw=
+go.opentelemetry.io/otel v0.4.3 h1:CroUX/0O1ZDcF0iWOO8gwYFWb5EbdSF0/C1yosO+Vhs=
+go.opentelemetry.io/otel v0.4.3/go.mod h1:jzBIgIzK43Iu1BpDAXwqOd6UPsSAk+ewVZ5ofSXw4Ek=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/exporters/metric/dogstatsd/labels_test.go
+++ b/exporters/metric/dogstatsd/labels_test.go
@@ -22,8 +22,7 @@ import (
 	"go.opentelemetry.io/contrib/exporters/metric/dogstatsd"
 	"go.opentelemetry.io/otel/api/core"
 	"go.opentelemetry.io/otel/api/key"
-	export "go.opentelemetry.io/otel/sdk/export/metric"
-	"go.opentelemetry.io/otel/sdk/resource"
+	"go.opentelemetry.io/otel/api/label"
 )
 
 var testLabels = []core.KeyValue{
@@ -38,20 +37,20 @@ var testResources = []core.KeyValue{
 }
 
 func TestLabelSyntax(t *testing.T) {
-	encoder := dogstatsd.NewLabelEncoder(resource.New())
+	encoder := dogstatsd.NewLabelEncoder()
 
-	require.Equal(t, `|#A:B,C:D,E:1.5`, encoder.Encode(export.LabelSlice(testLabels).Iter()))
+	labels := label.NewSet(testLabels...)
+	require.Equal(t, `A:B,C:D,E:1.5`, encoder.Encode(labels.Iter()))
 
 	kvs := []core.KeyValue{
 		key.String("A", "B"),
 	}
-	require.Equal(t, `|#A:B`, encoder.Encode(export.LabelSlice(kvs).Iter()))
+	labels = label.NewSet(kvs...)
+	require.Equal(t, `A:B`, encoder.Encode(labels.Iter()))
 
-	require.Equal(t, "", encoder.Encode(export.LabelSlice(nil).Iter()))
-}
+	labels = label.NewSet()
+	require.Equal(t, "", encoder.Encode(labels.Iter()))
 
-func TestLabelResources(t *testing.T) {
-	encoder := dogstatsd.NewLabelEncoder(resource.New(testResources...))
-
-	require.Equal(t, `|#R1:V1,R2:V2,A:B,C:D,E:1.5`, encoder.Encode(export.LabelSlice(testLabels).Iter()))
+	labels = label.Set{}
+	require.Equal(t, "", encoder.Encode(labels.Iter()))
 }


### PR DESCRIPTION
This updates the exporter interface for the new Resource argument, added in the base library's 0.4.3 release.  This removes the former workaround.

Resolves #24.