### PR TITLE
Create bump_and_tag.sh script to prepare tagged releases and otel upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # opentelemetry-go-contrib
 
-This repo contains packages that facilitates instrumenting libraries with Opentelemetry for
-distributed tracing and monitoring.
+This repo contains packages that facilitate instrumenting commonly
+used libraries with OpenTelemetry for distributed tracing and
+monitoring.
 
 

--- a/bump_and_tag.sh
+++ b/bump_and_tag.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# This script is used for
+# a) creating a new tagged release of go.opentelemetry.io/contrib
+# b) bumping the referenced version of go.opentelemetry.io/otel
+#
+# The options can be used together or individually.
+#
+set -e
+
+help()
+{
+   printf "\n"
+   printf "Usage: %s [-o otel_tag] [-t tag]\n" "$0"
+   printf "\t-o Otel release tag. Update all go.mod to reference go.opentelemetry.io/otel <otel_tag>.\n"
+   printf "\t-t New unreleased tag. Update all go.mod with this tag.\n"
+   exit 1 # Exit script after printing help
+}
+
+while getopts "t:o:" opt
+do
+   case "$opt" in
+      t ) TAG="$OPTARG" ;;
+      o ) OTEL_TAG="$OPTARG" ;;
+      ? ) help ;; # Print help
+   esac
+done
+
+
+validate_tag() {
+    local tag_=$1
+    SEMVER_REGEX="^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(\\-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+    if [[ "${tag_}" =~ ${SEMVER_REGEX} ]]; then
+	    printf "%s is valid semver tag.\n" "${tag_}"
+    else
+	    printf "%s is not a valid semver tag.\n" "${tag_}"
+	    return 1
+    fi
+}
+
+# Print help in case parameters are empty
+if [[ -z "$TAG" && -z "$OTEL_TAG" ]]
+then
+    printf "At least one of '-o' or '-t' must be specified.\n"
+    help
+fi
+
+
+## Validate tags first
+if [ -n "${OTEL_TAG}" ]; then
+    validate_tag "${OTEL_TAG}" || exit $?
+    # check that OTEL_TAG is a currently released tag for go.opentelemetry.io/otel
+    TMPDIR=$(mktemp -d "/tmp/otel-contrib.XXXXXX") || exit 1
+    trap "rm -fr ${TMPDIR}" EXIT
+    (cd "${TMPDIR}" && go mod init tagtest)
+    # requires go 1.14 for support of '-modfile'
+    if ! go get -modfile="${TMPDIR}/go.mod" -d -v "go.opentelemetry.io/otel@${OTEL_TAG}"; then
+        printf "Otel tag %s does not appear to exist.\n" "${OTEL_TAG}"
+        exit 1
+    fi
+fi
+if [ -n "${TAG}" ]; then
+    validate_tag "${TAG}" || exit $?
+    TAG_FOUND=$(git tag --list "${TAG}")
+    if [[ ${TAG_FOUND} = "${TAG}" ]] ; then
+        printf "Tag %s already exists\n" "${TAG}"
+        exit 1
+    fi
+fi
+
+cd $(dirname $0)
+
+if ! git diff --quiet; then \
+    printf "Working tree is not clean, can't proceed\n"
+    git status
+    git diff
+    exit 1
+fi
+
+declare BRANCH_NAME=pre_release_${TAG}
+if [ -z "${TAG}" ]; then
+    BRANCH_NAME=bump_otel_${OTEL_TAG}
+fi
+
+patch_gomods() {
+    local pkg_=$1
+    local tag_=$2
+    # now do the same for all the directories underneath
+    PACKAGE_DIRS=$(find . -mindepth 2 -type f -name 'go.mod' -exec dirname {} \; | egrep -v 'tools' | sed 's|^\.\/||' | sort)
+    # quote any '.' characters in the pkg name
+    local quoted_pkg_=${pkg_//./\\.}
+    for dir in $PACKAGE_DIRS; do
+	    cp "${dir}/go.mod" "${dir}/go.mod.bak"
+	    sed "s|${quoted_pkg_}\([^ ]*\) v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*[^0-9]*.*$|${pkg_}\1 ${tag_}|" "${dir}/go.mod.bak" >"${dir}/go.mod"
+	    rm -f "${dir}/go.mod.bak"
+    done
+}
+
+# Update go.mods
+git checkout -b "${BRANCH_NAME}"
+
+if [ -n "${OTEL_TAG}" ]; then
+    # first update the top most module
+    go get "go.opentelemetry.io/otel@${OTEL_TAG}"
+    patch_gomods go.opentelemetry.io/otel "${OTEL_TAG}"
+fi
+
+if [ -n "${TAG}" ]; then
+    patch_gomods go.opentelemetry.io/contrib "${TAG}"
+fi
+
+git diff
+# Run lint to update go.sum
+make lint
+
+# Add changes and commit.
+git add .
+make ci
+declare COMMIT_MSG="Prepare for releasing $TAG"
+if [ -z "${TAG}" ]; then
+    COMMIT_MSG="Bumping otel version to ${OTEL_TAG}"
+fi
+git commit -m "${COMMIT_MSG}"
+
+printf "Now run following to verify the changes.\ngit diff master\n"
+printf "\nThen push the changes to upstream\n"

--- a/bump_and_tag.sh
+++ b/bump_and_tag.sh
@@ -40,10 +40,10 @@ do
    esac
 done
 
+declare -r SEMVER_REGEX="^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(\\-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
 
 validate_tag() {
     local tag_=$1
-    SEMVER_REGEX="^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(\\-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
     if [[ "${tag_}" =~ ${SEMVER_REGEX} ]]; then
 	    printf "%s is valid semver tag.\n" "${tag_}"
     else
@@ -69,7 +69,7 @@ if [ -n "${OTEL_TAG}" ]; then
     (cd "${TMPDIR}" && go mod init tagtest)
     # requires go 1.14 for support of '-modfile'
     if ! go get -modfile="${TMPDIR}/go.mod" -d -v "go.opentelemetry.io/otel@${OTEL_TAG}"; then
-        printf "Otel tag %s does not appear to exist.\n" "${OTEL_TAG}"
+        printf "go.opentelemetry.io/otel %s does not exist. Please supply a valid tag\n" "${OTEL_TAG}"
         exit 1
     fi
 fi

--- a/bump_and_tag.sh
+++ b/bump_and_tag.sh
@@ -110,9 +110,10 @@ patch_gomods() {
     done
 }
 
-# Update go.mods
-git checkout -b "${BRANCH_NAME}"
+# branch off from existing master
+git checkout -b "${BRANCH_NAME}" master
 
+# Update go.mods
 if [ -n "${OTEL_TAG}" ]; then
     # first update the top most module
     go get "go.opentelemetry.io/otel@${OTEL_TAG}"

--- a/bump_and_tag.sh
+++ b/bump_and_tag.sh
@@ -23,8 +23,7 @@
 #
 set -e
 
-help()
-{
+help() {
    printf "\n"
    printf "Usage: %s [-o otel_tag] [-t tag]\n" "$0"
    printf "\t-o Otel release tag. Update all go.mod to reference go.opentelemetry.io/otel <otel_tag>.\n"
@@ -83,7 +82,7 @@ if [ -n "${TAG}" ]; then
     fi
 fi
 
-cd $(dirname $0)
+cd "$(dirname "$0")"
 
 if ! git diff --quiet; then \
     printf "Working tree is not clean, can't proceed\n"


### PR DESCRIPTION
Fixes #51.
This release script is modeled off [that used for the primary repo](https://github.com/open-telemetry/opentelemetry-go/blob/a43367a7a4516b94ede2f31b9788484bd279cefa/pre_release.sh). 

In addition, the '-o' option supports bumping the version of `go.opentelemetry.io/otel` used by the modules in this repo. 
   * If used by itself, the `-o` option will create a branch named `bump_otel_<otel_tag_version>`. 
   * If used by itself or in conjunction with `-o`, the `-t` option will create a branch named `pre_release_<tag>`.