### PR TITLE
Prepare for releasing v0.1.0

### DIFF
--- a/instrumentation/gin-gonic/gin/go.mod
+++ b/instrumentation/gin-gonic/gin/go.mod
@@ -7,7 +7,7 @@ replace go.opentelemetry.io/contrib => ../../..
 require (
 	github.com/gin-gonic/gin v1.6.2
 	github.com/stretchr/testify v1.4.0
-	go.opentelemetry.io/contrib v0.0.0-20200417154017-e4eb804471ca
+	go.opentelemetry.io/contrib v0.1.0
 	go.opentelemetry.io/otel v0.5.0
 	google.golang.org/grpc v1.28.1
 )

--- a/instrumentation/go.mongodb.org/mongo-driver/go.mod
+++ b/instrumentation/go.mongodb.org/mongo-driver/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/xdg/stringprep v1.0.0 // indirect
 	go.mongodb.org/mongo-driver v1.3.2
-	go.opentelemetry.io/contrib v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/contrib v0.1.0
 	go.opentelemetry.io/otel v0.5.0
 	golang.org/x/crypto v0.0.0-20191105034135-c7e5f84aec59 // indirect
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect

--- a/instrumentation/gorilla/mux/go.mod
+++ b/instrumentation/gorilla/mux/go.mod
@@ -7,6 +7,6 @@ replace go.opentelemetry.io/contrib => ../../..
 require (
 	github.com/gorilla/mux v1.7.4
 	github.com/stretchr/testify v1.4.0
-	go.opentelemetry.io/contrib v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/contrib v0.1.0
 	go.opentelemetry.io/otel v0.5.0
 )

--- a/instrumentation/labstack/echo/go.mod
+++ b/instrumentation/labstack/echo/go.mod
@@ -7,7 +7,7 @@ replace go.opentelemetry.io/contrib => ../../..
 require (
 	github.com/labstack/echo/v4 v4.1.16
 	github.com/stretchr/testify v1.4.0
-	go.opentelemetry.io/contrib v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/contrib v0.1.0
 	go.opentelemetry.io/otel v0.6.0
 	google.golang.org/grpc v1.28.1
 )

--- a/instrumentation/macaron/go.mod
+++ b/instrumentation/macaron/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/stretchr/testify v1.5.1
-	go.opentelemetry.io/contrib v0.0.0
+	go.opentelemetry.io/contrib v0.1.0
 	go.opentelemetry.io/otel v0.5.0
 	gopkg.in/macaron.v1 v1.3.5
 )


### PR DESCRIPTION
This branch obtained by running `bump_and_tag.sh -t v0.1.0` from PR #52 

Fixes #45 

Thoughts on whether this should start at v0.1.0 of the contrib repo or v0.6.0 to match the main Otel-go repo?

In addition, should this wait until the 8-byte offset issues on 386 are fixed in #53 so that we can do that first? That would bring all these modules up to date with existing otel repo version prior to making any officially tagged release of this repo.