### PR TITLE
Copy all coverage.html files into artifacts directory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,8 @@ jobs:
           name: "Precommit and Coverage Report"
           command: |
             make ci
-            find . -name 'coverage.html' | cpio -pLdm $(realpath $TEST_RESULTS/)
+            find . -name 'coverage.html' > "${TEST_RESULTS}/coverage.lst"
+            tar -n -cf - -T "${TEST_RESULTS}/coverage.lst" | tar -C /tmp/results -xvf -
 
       - save_cache:
           key: go-pkg-mod-{{ checksum "go.sum" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           name: "Precommit and Coverage Report"
           command: |
             make ci
-            mv coverage.html $TEST_RESULTS/
+            find . -name 'coverage.html' | cpio -pLdm $(realpath $TEST_RESULTS/)
 
       - save_cache:
           key: go-pkg-mod-{{ checksum "go.sum" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           command: |
             make ci
             find . -name 'coverage.html' > "${TEST_RESULTS}/coverage.lst"
-            tar -n -cf - -T "${TEST_RESULTS}/coverage.lst" | tar -C /tmp/results -xvf -
+            tar -n -cf - -T "${TEST_RESULTS}/coverage.lst" | tar -C "${TEST_RESULTS}" -xvf -
 
       - save_cache:
           key: go-pkg-mod-{{ checksum "go.sum" }}


### PR DESCRIPTION
Fixes #54 
This allows archiving/inspection of coverage for all submodules in opentelemetry-go-contrib.