### PR TITLE
Prepare for releasing v0.6.1

### DIFF
--- a/instrumentation/gin-gonic/gin/go.mod
+++ b/instrumentation/gin-gonic/gin/go.mod
@@ -7,7 +7,7 @@ replace go.opentelemetry.io/contrib => ../../..
 require (
 	github.com/gin-gonic/gin v1.6.2
 	github.com/stretchr/testify v1.4.0
-	go.opentelemetry.io/contrib v0.0.0-20200417154017-e4eb804471ca
+	go.opentelemetry.io/contrib v0.6.1
 	go.opentelemetry.io/otel v0.6.0
 	google.golang.org/grpc v1.28.1
 )

--- a/instrumentation/go.mongodb.org/mongo-driver/go.mod
+++ b/instrumentation/go.mongodb.org/mongo-driver/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/xdg/stringprep v1.0.0 // indirect
 	go.mongodb.org/mongo-driver v1.3.2
-	go.opentelemetry.io/contrib v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/contrib v0.6.1
 	go.opentelemetry.io/otel v0.6.0
 	golang.org/x/crypto v0.0.0-20191105034135-c7e5f84aec59 // indirect
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect

--- a/instrumentation/gorilla/mux/go.mod
+++ b/instrumentation/gorilla/mux/go.mod
@@ -7,6 +7,6 @@ replace go.opentelemetry.io/contrib => ../../..
 require (
 	github.com/gorilla/mux v1.7.4
 	github.com/stretchr/testify v1.4.0
-	go.opentelemetry.io/contrib v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/contrib v0.6.1
 	go.opentelemetry.io/otel v0.6.0
 )

--- a/instrumentation/labstack/echo/go.mod
+++ b/instrumentation/labstack/echo/go.mod
@@ -7,7 +7,7 @@ replace go.opentelemetry.io/contrib => ../../..
 require (
 	github.com/labstack/echo/v4 v4.1.16
 	github.com/stretchr/testify v1.4.0
-	go.opentelemetry.io/contrib v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/contrib v0.6.1
 	go.opentelemetry.io/otel v0.6.0
 	google.golang.org/grpc v1.28.1
 )

--- a/instrumentation/macaron/go.mod
+++ b/instrumentation/macaron/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/stretchr/testify v1.5.1
-	go.opentelemetry.io/contrib v0.0.0
+	go.opentelemetry.io/contrib v0.6.1
 	go.opentelemetry.io/otel v0.6.0
 	gopkg.in/macaron.v1 v1.3.5
 )


### PR DESCRIPTION
This is a quick fix to differentiate the `go.opentelemetry.io/contrib` version from the `go.opentelemetry.io/otel` version. The tags on this repository should reflect the `go.opentelemetry.io/contrib` version which is referenced inside the contributed instrumentation plugins.

The version of `go.opentelemetry.io/otel` that is used is usually, but not always in sync with this same version of `go.opentelemetry.io/contrib`