### PR TITLE
Using latest version of mod-tidier which supports go.{mod,sum} check

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -18,7 +18,7 @@ jobs:
       id: modtidy
       with:
         gomods: '**/go.mod'
-        gosum_only: true
+        gomodsum_only: true
     - uses: stefanzweifel/git-auto-commit-action@v4
       id: autocommit
       with:


### PR DESCRIPTION
`go mod tidy` does have occasion to change `go.mod` files in addition to `go.sum` (e.g. when a transitive dependency changes from an implicit to explicit dependency).

The latest beta of the mott-the-tidier action provides a new flag (`gomodsum_only`) which defaults to true, and allows the build to pass so long as the only files changed are either `go.mod` or `go.sum`.

The action is still restricted to running only on pull requests at the time a `dependencies` label is added to the PR.