### PR TITLE
Remove tracer as a parameter of gRPC instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ This release upgrades its [go.opentelemetry.io/otel](https://github.com/open-tel
 - Instrumentation for the Cassandra client github.com/gocql/gocql. (#137)
 - A detector that generate resources from GKE clusters. (#154)
 
+### Changed
+
+- Remove tracer as a parameter of gRPC instrumentation. (#209)
+
 ### Fixed
 
 - Bump github.com/aws/aws-sdk-go from 1.33.8 to 1.33.15 in /detectors/aws. (#155, #157, #159, #162)

--- a/instrumentation/google.golang.org/grpc/example/client/main.go
+++ b/instrumentation/google.golang.org/grpc/example/client/main.go
@@ -20,9 +20,8 @@ import (
 	"log"
 	"time"
 
-	"go.opentelemetry.io/otel/api/global"
-	"go.opentelemetry.io/otel/example/grpc/api"
-	"go.opentelemetry.io/otel/example/grpc/config"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/example/api"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/example/config"
 
 	grpcotel "go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc"
 
@@ -35,8 +34,8 @@ func main() {
 
 	var conn *grpc.ClientConn
 	conn, err := grpc.Dial(":7777", grpc.WithInsecure(),
-		grpc.WithUnaryInterceptor(grpcotel.UnaryClientInterceptor(global.Tracer(""))),
-		grpc.WithStreamInterceptor(grpcotel.StreamClientInterceptor(global.Tracer(""))),
+		grpc.WithUnaryInterceptor(grpcotel.UnaryClientInterceptor()),
+		grpc.WithStreamInterceptor(grpcotel.StreamClientInterceptor()),
 	)
 
 	if err != nil {

--- a/instrumentation/google.golang.org/grpc/example/go.mod
+++ b/instrumentation/google.golang.org/grpc/example/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/golang/protobuf v1.4.2
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc v0.10.0
 	go.opentelemetry.io/otel v0.10.0
-	go.opentelemetry.io/otel/example/grpc v0.10.0
 	go.opentelemetry.io/otel/exporters/stdout v0.10.0
 	go.opentelemetry.io/otel/sdk v0.10.0
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381

--- a/instrumentation/google.golang.org/grpc/example/go.sum
+++ b/instrumentation/google.golang.org/grpc/example/go.sum
@@ -48,8 +48,6 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 go.opentelemetry.io/otel v0.10.0 h1:2y/HYj1dIfG1nPh0Z15X4se8WwYWuTyKHLSgRb/mbQ0=
 go.opentelemetry.io/otel v0.10.0/go.mod h1:n3v1JGUBpn5DafiF1UeoDs5fr5XZMG+43kigDtFB8Vk=
-go.opentelemetry.io/otel/example/grpc v0.10.0 h1:YTeYhq5zgFNSjqHrXs6+SLSwAIJoA39JxjxF5Mv75L4=
-go.opentelemetry.io/otel/example/grpc v0.10.0/go.mod h1:J3WIuF7m8Tz5+cQWbXZuT2IJBlka49xn6RJZDD/lxqs=
 go.opentelemetry.io/otel/exporters/stdout v0.10.0 h1:5dhUv/AMKF+9p2igV0pAmS7sWQvX0r+eimf7uiEDWd8=
 go.opentelemetry.io/otel/exporters/stdout v0.10.0/go.mod h1:c7hVyiDzqbxgcerYbLreBNI0+MNE8x/hbekVx3lu+gM=
 go.opentelemetry.io/otel/sdk v0.10.0 h1:iQWVDfmGB+5TjbrO9yFlezGCWBaJ73vxJTHB+ttdTQk=

--- a/instrumentation/google.golang.org/grpc/example/server/main.go
+++ b/instrumentation/google.golang.org/grpc/example/server/main.go
@@ -22,9 +22,8 @@ import (
 	"net"
 	"time"
 
-	"go.opentelemetry.io/otel/api/global"
-	"go.opentelemetry.io/otel/example/grpc/api"
-	"go.opentelemetry.io/otel/example/grpc/config"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/example/api"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/example/config"
 
 	grpcotel "go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc"
 
@@ -118,8 +117,8 @@ func main() {
 	}
 
 	s := grpc.NewServer(
-		grpc.UnaryInterceptor(grpcotel.UnaryServerInterceptor(global.Tracer(""))),
-		grpc.StreamInterceptor(grpcotel.StreamServerInterceptor(global.Tracer(""))),
+		grpc.UnaryInterceptor(grpcotel.UnaryServerInterceptor()),
+		grpc.StreamInterceptor(grpcotel.StreamServerInterceptor()),
 	)
 
 	api.RegisterHelloServiceServer(s, &server{})

--- a/instrumentation/google.golang.org/grpc/example_interceptor_test.go
+++ b/instrumentation/google.golang.org/grpc/example_interceptor_test.go
@@ -16,36 +16,30 @@ package grpc
 
 import (
 	"google.golang.org/grpc"
-
-	"go.opentelemetry.io/otel/api/global"
 )
 
 func ExampleStreamClientInterceptor() {
-	tracer := global.Tracer("client-instrumentation")
 	_, _ = grpc.Dial(
 		"localhost",
-		grpc.WithStreamInterceptor(StreamClientInterceptor(tracer)),
+		grpc.WithStreamInterceptor(StreamClientInterceptor()),
 	)
 }
 
 func ExampleUnaryClientInterceptor() {
-	tracer := global.Tracer("client-instrumentation")
 	_, _ = grpc.Dial(
 		"localhost",
-		grpc.WithUnaryInterceptor(UnaryClientInterceptor(tracer)),
+		grpc.WithUnaryInterceptor(UnaryClientInterceptor()),
 	)
 }
 
 func ExampleStreamServerInterceptor() {
-	tracer := global.Tracer("server-instrumentation")
 	_ = grpc.NewServer(
-		grpc.StreamInterceptor(StreamServerInterceptor(tracer)),
+		grpc.StreamInterceptor(StreamServerInterceptor()),
 	)
 }
 
 func ExampleUnaryServerInterceptor() {
-	tracer := global.Tracer("server-instrumentation")
 	_ = grpc.NewServer(
-		grpc.UnaryInterceptor(UnaryServerInterceptor(tracer)),
+		grpc.UnaryInterceptor(UnaryServerInterceptor()),
 	)
 }

--- a/instrumentation/google.golang.org/grpc/interceptor_test.go
+++ b/instrumentation/google.golang.org/grpc/interceptor_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"go.opentelemetry.io/otel/api/global"
 	"go.opentelemetry.io/otel/api/standard"
 	"go.opentelemetry.io/otel/api/trace/testtrace"
 
@@ -89,7 +90,7 @@ func TestUnaryClientInterceptor(t *testing.T) {
 	sr := NewSpanRecorder()
 	tp := testtrace.NewProvider(testtrace.WithSpanRecorder(sr))
 	tracer := tp.Tracer("grpc/client")
-	unaryInterceptor := UnaryClientInterceptor(tracer)
+	unaryInterceptor := UnaryClientInterceptor(WithTracer(tracer))
 
 	req := &mockProtoMessage{}
 	reply := &mockProtoMessage{}
@@ -259,7 +260,7 @@ func TestStreamClientInterceptor(t *testing.T) {
 	sr := NewSpanRecorder()
 	tp := testtrace.NewProvider(testtrace.WithSpanRecorder(sr))
 	tracer := tp.Tracer("grpc/Server")
-	streamCI := StreamClientInterceptor(tracer)
+	streamCI := StreamClientInterceptor(WithTracer(tracer))
 
 	var mockClStr mockClientStream
 	method := "/github.com.serviceName/bar"
@@ -342,8 +343,8 @@ func TestStreamClientInterceptor(t *testing.T) {
 func TestServerInterceptorError(t *testing.T) {
 	sr := NewSpanRecorder()
 	tp := testtrace.NewProvider(testtrace.WithSpanRecorder(sr))
-	tracer := tp.Tracer("grpc/Server")
-	usi := UnaryServerInterceptor(tracer)
+	global.SetTraceProvider(tp)
+	usi := UnaryServerInterceptor()
 	deniedErr := status.Error(codes.PermissionDenied, "PERMISSION_DENIED_TEXT")
 	handler := func(_ context.Context, _ interface{}) (interface{}, error) {
 		return nil, deniedErr

--- a/instrumentation/google.golang.org/grpc/propagation/propagation.go
+++ b/instrumentation/google.golang.org/grpc/propagation/propagation.go
@@ -1,0 +1,81 @@
+package grpcpropagation
+
+import (
+	"context"
+
+	"google.golang.org/grpc/metadata"
+
+	"go.opentelemetry.io/otel/api/correlation"
+	"go.opentelemetry.io/otel/api/global"
+	"go.opentelemetry.io/otel/api/kv"
+	"go.opentelemetry.io/otel/api/propagation"
+	"go.opentelemetry.io/otel/api/trace"
+)
+
+// Option is a function that allows configuration of the grpc Extract()
+// and Inject() functions
+type Option func(*config)
+
+type config struct {
+	propagators propagation.Propagators
+}
+
+func newConfig(opts []Option) *config {
+	c := &config{propagators: global.Propagators()}
+	for _, o := range opts {
+		o(c)
+	}
+	return c
+}
+
+// WithPropagators sets the propagators to use for Extraction and Injection
+func WithPropagators(props propagation.Propagators) Option {
+	return func(c *config) {
+		c.propagators = props
+	}
+}
+
+type metadataSupplier struct {
+	metadata *metadata.MD
+}
+
+func (s *metadataSupplier) Get(key string) string {
+	values := s.metadata.Get(key)
+	if len(values) == 0 {
+		return ""
+	}
+	return values[0]
+}
+
+func (s *metadataSupplier) Set(key string, value string) {
+	s.metadata.Set(key, value)
+}
+
+// Inject injects correlation context and span context into the gRPC
+// metadata object. This function is meant to be used on outgoing
+// requests.
+func Inject(ctx context.Context, metadata *metadata.MD, opts ...Option) {
+	c := newConfig(opts)
+	propagation.InjectHTTP(ctx, c.propagators, &metadataSupplier{
+		metadata: metadata,
+	})
+}
+
+// Extract returns the correlation context and span context that
+// another service encoded in the gRPC metadata object with Inject.
+// This function is meant to be used on incoming requests.
+func Extract(ctx context.Context, metadata *metadata.MD, opts ...Option) ([]kv.KeyValue, trace.SpanContext) {
+	c := newConfig(opts)
+	ctx = propagation.ExtractHTTP(ctx, c.propagators, &metadataSupplier{
+		metadata: metadata,
+	})
+
+	spanContext := trace.RemoteSpanContextFromContext(ctx)
+	var correlationCtxKVs []kv.KeyValue
+	correlation.MapFromContext(ctx).Foreach(func(kv kv.KeyValue) bool {
+		correlationCtxKVs = append(correlationCtxKVs, kv)
+		return true
+	})
+
+	return correlationCtxKVs, spanContext
+}


### PR DESCRIPTION
*tracer* should be an optional parameter in gRPC instrumentation instead of a must-have parameter.