### PR TITLE
Add convertToTimeseries for Sum, LastValue, and MinMaxSumCount 

### DIFF
--- a/exporters/metric/cortex/testutil_test.go
+++ b/exporters/metric/cortex/testutil_test.go
@@ -1,0 +1,81 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cortex
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/otel/api/metric"
+	export "go.opentelemetry.io/otel/sdk/export/metric"
+	"go.opentelemetry.io/otel/sdk/export/metric/metrictest"
+	"go.opentelemetry.io/otel/sdk/metric/aggregator/aggregatortest"
+	"go.opentelemetry.io/otel/sdk/metric/aggregator/lastvalue"
+	"go.opentelemetry.io/otel/sdk/metric/aggregator/minmaxsumcount"
+	"go.opentelemetry.io/otel/sdk/metric/aggregator/sum"
+)
+
+// getValidCheckpointSet returns a valid checkpointset with several records
+func getValidCheckpointSet(t *testing.T) export.CheckpointSet {
+	return getSumCheckpoint(t, 321)
+}
+
+// getSumCheckpoint returns a checkpoint set with a sum aggregation record
+func getSumCheckpoint(t *testing.T, value int64) export.CheckpointSet {
+	// Create checkpoint set with resource and descriptor
+	checkpointSet := metrictest.NewCheckpointSet(testResource)
+	desc := metric.NewDescriptor("metric_name", metric.CounterKind, metric.Int64NumberKind)
+
+	// Create aggregation, add value, and update checkpointset
+	agg, ckpt := metrictest.Unslice2(sum.New(2))
+	aggregatortest.CheckedUpdate(t, agg, metric.NewInt64Number(value), &desc)
+	require.NoError(t, agg.SynchronizedMove(ckpt, &desc))
+	checkpointSet.Add(&desc, ckpt)
+
+	return checkpointSet
+}
+
+// getLastValueCheckpoint returns a checkpoint set with a last value aggregation record
+func getLastValueCheckpoint(t *testing.T, value int64) export.CheckpointSet {
+	// Create checkpoint set with resource and descriptor
+	checkpointSet := metrictest.NewCheckpointSet(testResource)
+	desc := metric.NewDescriptor("metric_name", metric.ValueObserverKind, metric.Int64NumberKind)
+
+	// Create aggregation, add value, and update checkpointset
+	agg, ckpt := metrictest.Unslice2(lastvalue.New(2))
+	aggregatortest.CheckedUpdate(t, agg, metric.NewInt64Number(value), &desc)
+	require.NoError(t, agg.SynchronizedMove(ckpt, &desc))
+	checkpointSet.Add(&desc, ckpt)
+
+	return checkpointSet
+}
+
+// getMMSCCheckpoint returns a checkpoint set with a minmaxsumcount aggregation record
+func getMMSCCheckpoint(t *testing.T, values ...float64) export.CheckpointSet {
+	// Create checkpoint set with resource and descriptor
+	checkpointSet := metrictest.NewCheckpointSet(testResource)
+	desc := metric.NewDescriptor("metric_name", metric.ValueRecorderKind, metric.Float64NumberKind)
+
+	// Create aggregation, add value, and update checkpointset
+	agg, ckpt := metrictest.Unslice2(minmaxsumcount.New(2, &desc))
+	for _, value := range values {
+		aggregatortest.CheckedUpdate(t, agg, metric.NewFloat64Number(value), &desc)
+	}
+	require.NoError(t, agg.SynchronizedMove(ckpt, &desc))
+	checkpointSet.Add(&desc, ckpt)
+
+	return checkpointSet
+}


### PR DESCRIPTION
This PR adds tests and code to convert Sum, LastValue, and MinMaxSumCount aggregated records to TimeSeries. It also finishes the Export function by creating and sending a request to the Cortex endpoint. 