### PR TITLE
Release v0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,26 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.10.1] - 2020-08-13
+
 ### Added
 
 - The `go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc` module has been added to replace the instrumentation that had previoiusly existed in the `go.opentelemetry.io/otel/instrumentation/grpctrace` package. (#189)
 - Instrumentation for the stdlib `net/http` and `net/http/httptrace` packages. (#190)
+- Initial Cortex exporter. (#202, #205, #210, #211)
+
+### Fixed
+
+- Bump google.golang.org/grpc from 1.30.0 to 1.31.0. (#166)
+- Bump go.mongodb.org/mongo-driver from 1.3.5 to 1.4.0 in /instrumentation/go.mongodb.org/mongo-driver. (#170)
+- Bump google.golang.org/grpc in /instrumentation/github.com/gin-gonic/gin. (#173)
+- Bump google.golang.org/grpc in /instrumentation/github.com/labstack/echo. (#176)
+- Bump google.golang.org/grpc from 1.30.0 to 1.31.0 in /instrumentation/github.com/Shopify/sarama. (#179)
+- Bump cloud.google.com/go from 0.61.0 to 0.63.0 in /detectors/gcp. (#181, #199)
+- Bump github.com/aws/aws-sdk-go from 1.33.15 to 1.34.1 in /detectors/aws. (#184, #192, #193, #198, #201, #203)
+- Bump github.com/golangci/golangci-lint from 1.29.0 to 1.30.0 in /tools. (#186)
+- Setup CI to run tests that require external resources (Cassandra and MongoDB). (#191)
+- Bump github.com/Shopify/sarama from 1.26.4 to 1.27.0 in /instrumentation/github.com/Shopify/sarama. (#206)
 
 ## [0.10.0] - 2020-07-31
 
@@ -111,7 +127,8 @@ First official tagged release of `contrib` repository.
 - Prefix support for dogstatsd (#34)
 - Update Go Runtime package to use batch observer (#44)
 
-[Unreleased]: https://github.com/open-telemetry/opentelemetry-go-contrib/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/open-telemetry/opentelemetry-go-contrib/compare/v0.10.1...HEAD
+[0.10.1]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v0.10.1
 [0.10.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v0.10.0
 [0.9.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v0.9.0
 [0.8.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v0.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - The `go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc` module has been added to replace the instrumentation that had previoiusly existed in the `go.opentelemetry.io/otel/instrumentation/grpctrace` package. (#189)
 - Instrumentation for the stdlib `net/http` and `net/http/httptrace` packages. (#190)
-- Initial Cortex exporter. (#202, #205, #210, #211)
+- Initial Cortex exporter. (#202, #205, #210, #211, #215)
 
 ### Fixed
 

--- a/exporters/metric/cortex/utils/go.mod
+++ b/exporters/metric/cortex/utils/go.mod
@@ -8,5 +8,5 @@ require (
 	github.com/spf13/afero v1.3.4
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/contrib/exporters/metric/cortex v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/contrib/exporters/metric/cortex v0.10.1
 )

--- a/instrumentation/github.com/Shopify/sarama/example/go.mod
+++ b/instrumentation/github.com/Shopify/sarama/example/go.mod
@@ -8,7 +8,7 @@ replace go.opentelemetry.io/contrib/instrumentation/github.com/Shopify/sarama =>
 
 require (
 	github.com/Shopify/sarama v1.27.0
-	go.opentelemetry.io/contrib/instrumentation/github.com/Shopify/sarama v0.10.0
+	go.opentelemetry.io/contrib/instrumentation/github.com/Shopify/sarama v0.10.1
 	go.opentelemetry.io/otel v0.10.0
 	go.opentelemetry.io/otel/exporters/stdout v0.10.0
 	go.opentelemetry.io/otel/sdk v0.10.0

--- a/instrumentation/github.com/Shopify/sarama/go.mod
+++ b/instrumentation/github.com/Shopify/sarama/go.mod
@@ -7,7 +7,7 @@ replace go.opentelemetry.io/contrib => ../../../..
 require (
 	github.com/Shopify/sarama v1.27.0
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/contrib v0.10.0
+	go.opentelemetry.io/contrib v0.10.1
 	go.opentelemetry.io/otel v0.10.0
 	google.golang.org/grpc v1.31.0
 )

--- a/instrumentation/github.com/emicklei/go-restful/go.mod
+++ b/instrumentation/github.com/emicklei/go-restful/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/emicklei/go-restful/v3 v3.2.0
 	github.com/json-iterator/go v1.1.10 // indirect
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/contrib v0.10.0
+	go.opentelemetry.io/contrib v0.10.1
 	go.opentelemetry.io/otel v0.10.0
 	go.opentelemetry.io/otel/exporters/stdout v0.10.0
 	go.opentelemetry.io/otel/sdk v0.10.0

--- a/instrumentation/github.com/gin-gonic/gin/go.mod
+++ b/instrumentation/github.com/gin-gonic/gin/go.mod
@@ -7,7 +7,7 @@ replace go.opentelemetry.io/contrib => ../../../..
 require (
 	github.com/gin-gonic/gin v1.6.3
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/contrib v0.10.0
+	go.opentelemetry.io/contrib v0.10.1
 	go.opentelemetry.io/otel v0.10.0
 	go.opentelemetry.io/otel/exporters/stdout v0.10.0
 	go.opentelemetry.io/otel/sdk v0.10.0

--- a/instrumentation/github.com/gocql/gocql/example/go.mod
+++ b/instrumentation/github.com/gocql/gocql/example/go.mod
@@ -9,7 +9,7 @@ replace (
 
 require (
 	github.com/gocql/gocql v0.0.0-20200624222514-34081eda590e
-	go.opentelemetry.io/contrib/instrumentation/github.com/gocql/gocql v0.10.0
+	go.opentelemetry.io/contrib/instrumentation/github.com/gocql/gocql v0.10.1
 	go.opentelemetry.io/otel v0.10.0
 	go.opentelemetry.io/otel/exporters/metric/prometheus v0.10.0
 	go.opentelemetry.io/otel/exporters/trace/zipkin v0.10.0

--- a/instrumentation/github.com/gocql/gocql/go.mod
+++ b/instrumentation/github.com/gocql/gocql/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gocql/gocql v0.0.0-20200624222514-34081eda590e
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/contrib v0.10.0
+	go.opentelemetry.io/contrib v0.10.1
 	go.opentelemetry.io/otel v0.10.0
 	go.opentelemetry.io/otel/sdk v0.10.0
 	google.golang.org/genproto v0.0.0-20200331122359-1ee6d9798940 // indirect

--- a/instrumentation/github.com/gorilla/mux/go.mod
+++ b/instrumentation/github.com/gorilla/mux/go.mod
@@ -7,7 +7,7 @@ replace go.opentelemetry.io/contrib => ../../../..
 require (
 	github.com/gorilla/mux v1.7.4
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/contrib v0.10.0
+	go.opentelemetry.io/contrib v0.10.1
 	go.opentelemetry.io/otel v0.10.0
 	go.opentelemetry.io/otel/exporters/stdout v0.10.0
 	go.opentelemetry.io/otel/sdk v0.10.0

--- a/instrumentation/github.com/labstack/echo/go.mod
+++ b/instrumentation/github.com/labstack/echo/go.mod
@@ -7,7 +7,7 @@ replace go.opentelemetry.io/contrib => ../../../..
 require (
 	github.com/labstack/echo/v4 v4.1.16
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/contrib v0.10.0
+	go.opentelemetry.io/contrib v0.10.1
 	go.opentelemetry.io/otel v0.10.0
 	go.opentelemetry.io/otel/exporters/stdout v0.10.0
 	go.opentelemetry.io/otel/sdk v0.10.0

--- a/instrumentation/go.mongodb.org/mongo-driver/go.mod
+++ b/instrumentation/go.mongodb.org/mongo-driver/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/xdg/stringprep v1.0.0 // indirect
 	go.mongodb.org/mongo-driver v1.4.0
-	go.opentelemetry.io/contrib v0.10.0
+	go.opentelemetry.io/contrib v0.10.1
 	go.opentelemetry.io/otel v0.10.0
 	golang.org/x/crypto v0.0.0-20191105034135-c7e5f84aec59 // indirect
 )

--- a/instrumentation/google.golang.org/grpc/example/go.mod
+++ b/instrumentation/google.golang.org/grpc/example/go.mod
@@ -6,7 +6,7 @@ replace go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc => ..
 
 require (
 	github.com/golang/protobuf v1.4.2
-	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc v0.10.0
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc v0.10.1
 	go.opentelemetry.io/otel v0.10.0
 	go.opentelemetry.io/otel/example/grpc v0.10.0
 	go.opentelemetry.io/otel/exporters/stdout v0.10.0

--- a/instrumentation/gopkg.in/macaron.v1/go.mod
+++ b/instrumentation/gopkg.in/macaron.v1/go.mod
@@ -6,7 +6,7 @@ replace go.opentelemetry.io/contrib => ../../..
 
 require (
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/contrib v0.10.0
+	go.opentelemetry.io/contrib v0.10.1
 	go.opentelemetry.io/otel v0.10.0
 	go.opentelemetry.io/otel/exporters/stdout v0.10.0
 	go.opentelemetry.io/otel/sdk v0.10.0

--- a/instrumentation/net/http/example/go.mod
+++ b/instrumentation/net/http/example/go.mod
@@ -8,7 +8,7 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/contrib/instrumentation/net/http v0.10.0
+	go.opentelemetry.io/contrib/instrumentation/net/http v0.10.1
 	go.opentelemetry.io/otel v0.10.0
 	go.opentelemetry.io/otel/exporters/stdout v0.10.0
 	go.opentelemetry.io/otel/sdk v0.10.0

--- a/instrumentation/net/http/go.mod
+++ b/instrumentation/net/http/go.mod
@@ -7,7 +7,7 @@ replace go.opentelemetry.io/contrib => ../../..
 require (
 	github.com/felixge/httpsnoop v1.0.1
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/contrib v0.10.0
+	go.opentelemetry.io/contrib v0.10.1
 	go.opentelemetry.io/otel v0.10.0
 	google.golang.org/grpc v1.31.0
 )

--- a/instrumentation/net/http/httptrace/example/go.mod
+++ b/instrumentation/net/http/httptrace/example/go.mod
@@ -9,8 +9,8 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/contrib/instrumentation/net/http v0.10.0
-	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace v0.10.0
+	go.opentelemetry.io/contrib/instrumentation/net/http v0.10.1
+	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace v0.10.1
 	go.opentelemetry.io/otel v0.10.0
 	go.opentelemetry.io/otel/exporters/stdout v0.10.0
 	go.opentelemetry.io/otel/sdk v0.10.0


### PR DESCRIPTION
## 0.10.1 - 2020-08-13

This release includes instrumentation moved from the main `go.opentelemetry.io/otel` project for the `google.golang.org/grpc`, `net/http`, and `net/http/httptrace` packages.

### Added

- The `go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc` module has been added to replace the instrumentation that had previoiusly existed in the `go.opentelemetry.io/otel/instrumentation/grpctrace` package. (#189)
- Instrumentation for the stdlib `net/http` and `net/http/httptrace` packages. (#190)
- Initial Cortex exporter. (#202, #205, #210, #211, #215)

### Fixed

- Bump google.golang.org/grpc from 1.30.0 to 1.31.0. (#166)
- Bump go.mongodb.org/mongo-driver from 1.3.5 to 1.4.0 in /instrumentation/go.mongodb.org/mongo-driver. (#170)
- Bump google.golang.org/grpc in /instrumentation/github.com/gin-gonic/gin. (#173)
- Bump google.golang.org/grpc in /instrumentation/github.com/labstack/echo. (#176)
- Bump google.golang.org/grpc from 1.30.0 to 1.31.0 in /instrumentation/github.com/Shopify/sarama. (#179)
- Bump cloud.google.com/go from 0.61.0 to 0.63.0 in /detectors/gcp. (#181, #199)
- Bump github.com/aws/aws-sdk-go from 1.33.15 to 1.34.1 in /detectors/aws. (#184, #192, #193, #198, #201, #203)
- Bump github.com/golangci/golangci-lint from 1.29.0 to 1.30.0 in /tools. (#186)
- Setup CI to run tests that require external resources (Cassandra and MongoDB). (#191)
- Bump github.com/Shopify/sarama from 1.26.4 to 1.27.0 in /instrumentation/github.com/Shopify/sarama. (#206)


Resolves https://github.com/open-telemetry/opentelemetry-go-contrib/issues/212