### PR TITLE
Introduce a top-level `Version()` and `SemVersion()` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- Top-level `Version()` and `SemVersion()` functions defining the current version of the contrib package.
+
 ## [0.10.1] - 2020-08-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- Top-level `Version()` and `SemVersion()` functions defining the current version of the contrib package.
+- Top-level `Version()` and `SemVersion()` functions defining the current version of the contrib package. (#225)
 
 ## [0.10.1] - 2020-08-13
 

--- a/contrib.go
+++ b/contrib.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package contrib contains common values used across all
-// instrumentation, exporter, and detector contributions
+// instrumentation, exporter, and detector contributions.
 package contrib // import "go.opentelemetry.io/contrib"
 
 // Version is the current release version of OpenTelemetry Contrib in use.

--- a/contrib.go
+++ b/contrib.go
@@ -19,6 +19,7 @@ package contrib // import "go.opentelemetry.io/contrib"
 // Version is the current release version of OpenTelemetry Contrib in use.
 func Version() string {
 	return "0.10.1"
+	// This string is updated by the pre_release.sh script during release
 }
 
 // SemVersion is the semantic version to be supplied to tracer/meter creation.

--- a/contrib.go
+++ b/contrib.go
@@ -1,0 +1,27 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package contrib contains common values used across all
+// instrumentation, exporter, and detector contributions
+package contrib // import "go.opentelemetry.io/contrib"
+
+// Version is the current release version of OpenTelemetry Contrib in use.
+func Version() string {
+	return "0.10.1"
+}
+
+// SemVersion is the semantic version to be supplied to tracer/meter creation.
+func SemVersion() string {
+	return "semver:" + Version()
+}

--- a/pre_release.sh
+++ b/pre_release.sh
@@ -88,6 +88,11 @@ else
     CONTRIB_TAG=${OTEL_TAG}  # if contrib_tag not specified, but OTEL_TAG is, then set it to OTEL_TAG
 fi
 
+# Get version for contrib.go
+OTEL_CONTRIB_VERSION=$(echo "${CONTRIB_TAG}" | grep -o '^v[0-9]\+\.[0-9]\+\.[0-9]\+')
+# Strip leading v
+OTEL_CONTRIB_VERSION="${OTEL_CONTRIB_VERSION#v}"
+
 cd "$(dirname "$0")"
 
 if ! git diff --quiet; then \
@@ -96,6 +101,10 @@ if ! git diff --quiet; then \
     git diff
     exit 1
 fi
+
+# Update contrib.go version definition
+sed -i .bak "s/\(return \"\)[0-9]*\.[0-9]*\.[0-9]*\"/\1${OTEL_CONTRIB_VERSION}\"/" ./contrib.go
+rm -f ./contrib.go.bak
 
 declare -r BRANCH_NAME=pre_release_${CONTRIB_TAG}
 

--- a/pre_release.sh
+++ b/pre_release.sh
@@ -89,7 +89,7 @@ else
 fi
 
 # Get version for contrib.go
-OTEL_CONTRIB_VERSION=$(echo "${CONTRIB_TAG}" | grep -o '^v[0-9]\+\.[0-9]\+\.[0-9]\+')
+OTEL_CONTRIB_VERSION=$(echo "${CONTRIB_TAG}" | egrep -o "${SEMVER_REGEX}")
 # Strip leading v
 OTEL_CONTRIB_VERSION="${OTEL_CONTRIB_VERSION#v}"
 


### PR DESCRIPTION
These are intended to be used by submodules within the repo that need to specify an "instrumentation version" when creating a tracer or meter.

See https://github.com/open-telemetry/opentelemetry-go-contrib/issues/214

`SemVersion()` may not be required (opinions wanted), but it does enable creating a versioned tracer/meter simply while guaranteeing the correct `semver:` prefix is always applied.

```go
tracer := otelglobal.TracerProvider().Tracer(
			defaultTracerName,
			oteltrace.WithInstrumentationVersion(contrib.SemVersion()),
		)
```

Bikeshedding on file name and location also welcomed.