### PR TITLE
Ignore auth_test for 386 builds

### DIFF
--- a/exporters/metric/cortex/auth_test.go
+++ b/exporters/metric/cortex/auth_test.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Remove when #310 is resolved.
+// +build !386
+
 package cortex
 
 import (


### PR DESCRIPTION
Temporary fix while #310 is addressed that unblocks other PR builds from failing.