### PR TITLE
Add missing directory parameter to find command in dependabot-check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ license-check:
 .PHONY: dependabot-check
 dependabot-check:
 	@result=$$( \
-		for f in $$( find -type f -name go.mod -exec dirname {} \; | sed 's/^.\/\?/\//' ); \
+		for f in $$( find . -type f -name go.mod -exec dirname {} \; | sed 's/^.\/\?/\//' ); \
 			do grep -q "$$f" .github/dependabot.yml \
 			|| echo "$$f"; \
 		done; \


### PR DESCRIPTION
Same change for the contrib repo as in https://github.com/open-telemetry/opentelemetry-go/pull/1116