### PR TITLE
chore: Add version to labstack/echo instrumentation

### DIFF
--- a/instrumentation/github.com/labstack/echo/echo.go
+++ b/instrumentation/github.com/labstack/echo/echo.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/labstack/echo/v4"
 
+	otelcontrib "go.opentelemetry.io/contrib"
+
 	otelglobal "go.opentelemetry.io/otel/api/global"
 	otelpropagation "go.opentelemetry.io/otel/api/propagation"
 	oteltrace "go.opentelemetry.io/otel/api/trace"
@@ -40,7 +42,10 @@ func Middleware(service string, opts ...Option) echo.MiddlewareFunc {
 	if cfg.TracerProvider == nil {
 		cfg.TracerProvider = otelglobal.TraceProvider()
 	}
-	tracer := cfg.TracerProvider.Tracer(tracerName)
+	tracer := cfg.TracerProvider.Tracer(
+		tracerName,
+		oteltrace.WithInstrumentationVersion(otelcontrib.SemVersion()),
+	)
 	if cfg.Propagators == nil {
 		cfg.Propagators = otelglobal.Propagators()
 	}


### PR DESCRIPTION
Part of #214 

This PR adds `"go.opentelemetry.io/contrib".SemVer()` as the instrumentation version for `labstack/echo`