### PR TITLE
[Prometheus Remote Write Exporter for Cortex] Restore auth_test for 386 builds

### DIFF
--- a/exporters/metric/cortex/auth_test.go
+++ b/exporters/metric/cortex/auth_test.go
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Remove when #310 is resolved.
-// +build !386
-
 package cortex
 
 import (


### PR DESCRIPTION
This PR removes the build tag preventing tests from running on 386 builds that was added in PR https://github.com/open-telemetry/opentelemetry-go-contrib/pull/312. The test timeout panic described in issue https://github.com/open-telemetry/opentelemetry-go-contrib/issues/310 was resolved by PR https://github.com/open-telemetry/opentelemetry-go-contrib/pull/315.