### PR TITLE
mongo: use db.system instead of db.type

### DIFF
--- a/instrumentation/go.mongodb.org/mongo-driver/db.go
+++ b/instrumentation/go.mongodb.org/mongo-driver/db.go
@@ -19,7 +19,7 @@ import "go.opentelemetry.io/otel/label"
 const (
 	DBApplicationKey = label.Key("db.application")
 	DBNameKey        = label.Key("db.name")
-	DBTypeKey        = label.Key("db.type")
+	DBSystemKey      = label.Key("db.system")
 	DBInstanceKey    = label.Key("db.instance")
 	DBUserKey        = label.Key("db.user")
 	DBStatementKey   = label.Key("db.statement")
@@ -35,9 +35,9 @@ func DBName(dbName string) label.KeyValue {
 	return DBNameKey.String(dbName)
 }
 
-// DBType indicates the type of Database.
-func DBType(dbType string) label.KeyValue {
-	return DBTypeKey.String(dbType)
+// DBSystem indicates the system of Database.
+func DBSystem(dbType string) label.KeyValue {
+	return DBSystemKey.String(dbType)
 }
 
 // DBInstance indicates the instance name of Database.

--- a/instrumentation/go.mongodb.org/mongo-driver/mongo.go
+++ b/instrumentation/go.mongodb.org/mongo-driver/mongo.go
@@ -47,7 +47,7 @@ func (m *monitor) Started(ctx context.Context, evt *event.CommandStartedEvent) {
 		ResourceName("mongo." + evt.CommandName),
 		DBInstance(evt.DatabaseName),
 		DBStatement(string(b)),
-		DBType("mongo"),
+		DBSystem("mongodb"),
 		PeerHostname(hostname),
 		PeerPort(port),
 	}

--- a/instrumentation/go.mongodb.org/mongo-driver/mongo_test.go
+++ b/instrumentation/go.mongodb.org/mongo-driver/mongo_test.go
@@ -72,5 +72,5 @@ func Test(t *testing.T) {
 	assert.Equal(t, port, s.Attributes[PeerPortKey].AsString())
 	assert.Contains(t, s.Attributes[DBStatementKey].AsString(), `"test-item":"test-value"`)
 	assert.Equal(t, "test-database", s.Attributes[DBInstanceKey].AsString())
-	assert.Equal(t, "mongo", s.Attributes[DBTypeKey].AsString())
+	assert.Equal(t, "mongodb", s.Attributes[DBSystemKey].AsString())
 }


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/database.md has `db.system`, but no `db.type`. It also recommends to use `mongodb` as system.