### PR TITLE
updated macaron go module declaration

### DIFF
--- a/instrumentation/gopkg.in/macaron.v1/config.go
+++ b/instrumentation/gopkg.in/macaron.v1/config.go
@@ -30,7 +30,7 @@ type Option func(*config)
 
 // WithTracer specifies a tracer to use for creating spans. If none is
 // specified, a tracer named
-// "go.opentelemetry.io/contrib/instrumentation/macaron" from the global
+// "go.opentelemetry.io/contrib/instrumentation/gopkg.in/macaron.v1" from the global
 // provider is used.
 func WithTracer(tracer trace.Tracer) Option {
 	return func(cfg *config) {

--- a/instrumentation/gopkg.in/macaron.v1/doc.go
+++ b/instrumentation/gopkg.in/macaron.v1/doc.go
@@ -17,4 +17,4 @@
 //
 // Currently only the routing of a received message can be
 // instrumented. To do it, use the Middleware function.
-package macaron // import "go.opentelemetry.io/contrib/instrumentation/macaron"
+package macaron // import "go.opentelemetry.io/contrib/instrumentation/gopkg.in/macaron.v1"

--- a/instrumentation/gopkg.in/macaron.v1/example/server.go
+++ b/instrumentation/gopkg.in/macaron.v1/example/server.go
@@ -20,7 +20,7 @@ import (
 
 	"gopkg.in/macaron.v1"
 
-	macarontrace "go.opentelemetry.io/contrib/instrumentation/macaron"
+	macarontrace "go.opentelemetry.io/contrib/instrumentation/gopkg.in/macaron.v1"
 
 	otelglobal "go.opentelemetry.io/otel/api/global"
 	oteltrace "go.opentelemetry.io/otel/api/trace"

--- a/instrumentation/gopkg.in/macaron.v1/go.mod
+++ b/instrumentation/gopkg.in/macaron.v1/go.mod
@@ -1,4 +1,4 @@
-module go.opentelemetry.io/contrib/instrumentation/macaron
+module go.opentelemetry.io/contrib/instrumentation/gopkg.in/macaron.v1
 
 go 1.14
 

--- a/instrumentation/gopkg.in/macaron.v1/macaron.go
+++ b/instrumentation/gopkg.in/macaron.v1/macaron.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	tracerName = "go.opentelemetry.io/contrib/instrumentation/macaron"
+	tracerName = "go.opentelemetry.io/contrib/instrumentation/gopkg.in/macaron.v1"
 )
 
 // Middleware returns a macaron Handler to trace requests to the server.

--- a/instrumentation/gopkg.in/macaron.v1/macaron_test.go
+++ b/instrumentation/gopkg.in/macaron.v1/macaron_test.go
@@ -43,7 +43,7 @@ func TestChildSpanFromGlobalTracer(t *testing.T) {
 		spanTracer := span.Tracer()
 		mockTracer, ok := spanTracer.(*mocktrace.Tracer)
 		require.True(t, ok)
-		assert.Equal(t, "go.opentelemetry.io/contrib/instrumentation/macaron", mockTracer.Name)
+		assert.Equal(t, "go.opentelemetry.io/contrib/instrumentation/gopkg.in/macaron.v1", mockTracer.Name)
 		ctx.Resp.WriteHeader(http.StatusOK)
 	})
 


### PR DESCRIPTION
Simple bug fix, the module declaration was not previously updated to match the updated file hierarchy. Fixes issue open-telemetry#352