### PR TITLE
[propagator] Set sampling bit when sampling decision is debug

### DIFF
--- a/propagators/b3/b3_data_test.go
+++ b/propagators/b3/b3_data_test.go
@@ -144,7 +144,7 @@ var extractHeaders = []extractTest{
 		wantSc: trace.SpanContext{
 			TraceID:    traceID,
 			SpanID:     spanID,
-			TraceFlags: trace.FlagsDeferred | trace.FlagsDebug,
+			TraceFlags: trace.FlagsSampled | trace.FlagsDebug,
 		},
 	},
 	{
@@ -163,8 +163,7 @@ var extractHeaders = []extractTest{
 	},
 	{
 		// spec explicitly states "Debug implies an accept decision, so don't
-		// also send the X-B3-Sampled header", make sure sampling is
-		// deferred.
+		// also send the X-B3-Sampled header", make sure sampling is set in this case.
 		name: "multiple: debug flag set and sampling state is deny",
 		headers: map[string]string{
 			b3TraceID: traceIDStr,
@@ -175,7 +174,7 @@ var extractHeaders = []extractTest{
 		wantSc: trace.SpanContext{
 			TraceID:    traceID,
 			SpanID:     spanID,
-			TraceFlags: trace.FlagsDebug,
+			TraceFlags: trace.FlagsDebug | trace.FlagsSampled,
 		},
 	},
 	{
@@ -251,7 +250,7 @@ var extractHeaders = []extractTest{
 		wantSc: trace.SpanContext{
 			TraceID:    traceID,
 			SpanID:     spanID,
-			TraceFlags: trace.FlagsDebug,
+			TraceFlags: trace.FlagsDebug | trace.FlagsSampled,
 		},
 	},
 	{

--- a/propagators/b3/b3_propagator_test.go
+++ b/propagators/b3/b3_propagator_test.go
@@ -56,12 +56,12 @@ func TestExtractMultiple(t *testing.T) {
 		},
 		{
 			"", "", "", "", "1",
-			trace.SpanContext{TraceFlags: trace.FlagsDeferred | trace.FlagsDebug},
+			trace.SpanContext{TraceFlags: trace.FlagsSampled | trace.FlagsDebug},
 			nil,
 		},
 		{
 			"", "", "", "0", "1",
-			trace.SpanContext{TraceFlags: trace.FlagsDebug},
+			trace.SpanContext{TraceFlags: trace.FlagsDebug | trace.FlagsSampled},
 			nil,
 		},
 		{
@@ -214,7 +214,7 @@ func TestExtractSingle(t *testing.T) {
 	}{
 		{"0", trace.SpanContext{}, nil},
 		{"1", trace.SpanContext{TraceFlags: trace.FlagsSampled}, nil},
-		{"d", trace.SpanContext{TraceFlags: trace.FlagsDebug}, nil},
+		{"d", trace.SpanContext{TraceFlags: trace.FlagsDebug | trace.FlagsSampled}, nil},
 		{"a", empty, errInvalidSampledByte},
 		{"3", empty, errInvalidSampledByte},
 		{"000000000000007b", empty, errInvalidScope},


### PR DESCRIPTION
closes #367 

According to the spec. Debug sampling decision implies accept(sampled) decision.

But we didn't set sample bitmask. So when trace state is debug, `IsSampled` method will still return false, which is different from spec.

Now we make sure when debug bitmask is set, sample bitmask will also be set.