### PR TITLE
Fix import comment bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- The import comment in `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp` is now correctly quoted. (#379)
+
 ## [0.12.0] - 2020-09-25
 
 ### Added

--- a/instrumentation/net/http/otelhttp/doc.go
+++ b/instrumentation/net/http/otelhttp/doc.go
@@ -15,4 +15,4 @@
 // Package otelhttp provides an http.Handler and functions that are intended
 // to be used to add tracing by wrapping existing handlers (with Handler) and
 // routes WithRouteTag.
-package otelhttp // import go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
+package otelhttp // import "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"


### PR DESCRIPTION
The import of the go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp is failing when imported outside of a module because this comment did not have a syntactically valid import statement.

Replaces #371 