### PR TITLE
Fix/cortex export metric example

### DIFF
--- a/exporters/metric/cortex/example/README.md
+++ b/exporters/metric/cortex/example/README.md
@@ -32,9 +32,7 @@ Installation instructions can be found in the Docker
    * Look for a gear icon on the left sidebar and select Data Sources
 
 4. Add a new Prometheus Data Source
-   * Use
-     [http://host.docker.internal:9009/api/prom/](http://host.docker.internal:9009/api/prom/)
-     as the URL
+   * Use http://docker-host:9009/api/prom/ as the URL
    * Optionally, set the scrape interval to 3s to make updates appear quickly
    * Click `Save & Test`
   

--- a/exporters/metric/cortex/example/config.yml
+++ b/exporters/metric/cortex/example/config.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-url: http://host.docker.internal:9009/api/prom/push
+url: http://docker-host:9009/api/prom/push
 remote_timeout: 30s
 push_interval: 2s
 name: Test

--- a/exporters/metric/cortex/example/docker-compose.yml
+++ b/exporters/metric/cortex/example/docker-compose.yml
@@ -21,6 +21,15 @@ services:
       - .:/app
     working_dir: /app
     command: go run main.go
+    depends_on:
+      - docker-host
+      - cortex
+  docker-host:
+    image: qoomon/docker-host
+    cap_add: [ 'NET_ADMIN', 'NET_RAW' ]
+    restart: on-failure
+    environment:
+      - PORTS=9009
   cortex:
     image: quay.io/cortexproject/cortex:v1.3.0-rc.1
     command:

--- a/exporters/metric/cortex/example/go.mod
+++ b/exporters/metric/cortex/example/go.mod
@@ -2,11 +2,6 @@ module go.opentelemetry.io/contrib/exporters/metric/cortex/example
 
 go 1.14
 
-replace (
-	go.opentelemetry.io/contrib/exporters/metric/cortex => ../
-	go.opentelemetry.io/contrib/exporters/metric/cortex/utils => ../utils/
-)
-
 require (
 	go.opentelemetry.io/contrib/exporters/metric/cortex v0.13.0
 	go.opentelemetry.io/contrib/exporters/metric/cortex/utils v0.13.0

--- a/exporters/metric/cortex/example/go.sum
+++ b/exporters/metric/cortex/example/go.sum
@@ -185,8 +185,8 @@ github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
-github.com/spf13/afero v1.4.1 h1:asw9sl74539yqavKaglDM5hFpdJVK0Y5Dr/JOgQ89nQ=
-github.com/spf13/afero v1.4.1/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
+github.com/spf13/afero v1.4.0 h1:jsLTaI1zwYO3vjrzHalkVcIHXTNmdQFepW4OI8H3+x8=
+github.com/spf13/afero v1.4.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
 github.com/spf13/cast v1.3.0 h1:oget//CVOEoFewqQxwr0Ej5yjygnqGkvggSE/gB35Q8=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/jwalterweatherman v1.0.0 h1:XHEdyB+EcvlqZamSM4ZOMGlc93t6AcsBEu9Gc1vn7yk=
@@ -209,6 +209,10 @@ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
+go.opentelemetry.io/contrib/exporters/metric/cortex v0.13.0 h1:eg95jUInw/MD9imu6emFlbeAyReXkUrbKYvkhIBWil4=
+go.opentelemetry.io/contrib/exporters/metric/cortex v0.13.0/go.mod h1:UMPzSCScyLfnzslRH8PpbNOJACd4TMoba+yc96iDES0=
+go.opentelemetry.io/contrib/exporters/metric/cortex/utils v0.13.0 h1:JSsy8vOgHObms9w1E6B0BA2Byzy1K9RS/RC0Dh5FY2o=
+go.opentelemetry.io/contrib/exporters/metric/cortex/utils v0.13.0/go.mod h1:XRWKAiCbN7wfxqDagJyAb/wnSDEUBmuKXJ1a4blzmuk=
 go.opentelemetry.io/otel v0.13.0 h1:2isEnyzjjJZq6r2EKMsFj4TxiQiexsM04AVhwbR/oBA=
 go.opentelemetry.io/otel v0.13.0/go.mod h1:dlSNewoRYikTkotEnxdmuBHgzT+k/idJSfDv/FxEnOY=
 go.opentelemetry.io/otel/sdk v0.13.0 h1:4VCfpKamZ8GtnepXxMRurSpHpMKkcxhtO33z1S4rGDQ=


### PR DESCRIPTION
Just trying out https://aws.amazon.com/blogs/opensource/building-a-prometheus-remote-write-exporter-for-the-opentelemetry-go-sdk/
However, couldn't get docker-compose to run up successfully on Ubuntu.

One error:
```
/go.mod: no such file or directory
```
fixed with ab10ca0 - don't use Replace to a parent folder which is not mapped inside the container.

The other was with the use of `host.docker.internal` which is available on mac (and windows?) but not linux. This SO post to the rescue:
https://stackoverflow.com/a/49149020

I couldn't use the 172.x.x.x address because it keeps changing. The qoomon/docker-host solution seems better.