### PR TITLE
add ability to disable tracing ping requests in mongo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add registry link check to `Makefile` and pre-release script. (#446)
 - A new AWS X-Ray ID Generator (#459)
 - Migrate CircleCI jobs to GitHub Actions (#476)
+- Mongo driver - add ability to ignore Ping requests (#487)
+
 ### Fixed
 
 - Fixes the body replacement in otelhttp to not to mutate a nil body. (#484)

--- a/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/config.go
+++ b/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/config.go
@@ -27,6 +27,9 @@ type config struct {
 	TracerProvider trace.TracerProvider
 
 	Tracer trace.Tracer
+
+	// Ping, if set to true, will enable the creation of spans on Ping requests.
+	Ping bool
 }
 
 // newConfig returns a config with all Options set.
@@ -53,5 +56,12 @@ type Option func(*config)
 func WithTracerProvider(provider trace.TracerProvider) Option {
 	return func(cfg *config) {
 		cfg.TracerProvider = provider
+	}
+}
+
+// WithPing if set to true, will enable the creation of spans on Ping requests.
+func WithPing(b bool) Option {
+	return func(cfg *config) {
+		cfg.Ping = b
 	}
 }

--- a/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/mongo.go
+++ b/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/mongo.go
@@ -40,6 +40,11 @@ type monitor struct {
 }
 
 func (m *monitor) Started(ctx context.Context, evt *event.CommandStartedEvent) {
+
+	if strings.ToLower(evt.CommandName) == "ping" && !m.cfg.Ping {
+		return
+	}
+
 	hostname, port := peerInfo(evt)
 	b, _ := bson.MarshalExtJSON(evt.Command, false, false)
 	attrs := []label.KeyValue{


### PR DESCRIPTION
This PR allows the mongo instrumentor to ignore the traces for "ping" queries.

I've implemented it to ensure the default is to ignore 'ping' queries as we have found these traces to be of such low value as not to be of interest and the volume to be so great as to swamp out any generic algorithm to stop propagation.

I'm not too sure if that is the correct thing to do but figured I can change it quite easily.