### PR TITLE
Prepare for releasing v0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -249,7 +249,8 @@ First official tagged release of `contrib` repository.
 - Prefix support for dogstatsd (#34)
 - Update Go Runtime package to use batch observer (#44)
 
-[Unreleased]: https://github.com/open-telemetry/opentelemetry-go-contrib/compare/v0.15.0...HEAD
+[Unreleased]: https://github.com/open-telemetry/opentelemetry-go-contrib/compare/v0.15.1...HEAD
+[0.15.1]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v0.15.1
 [0.15.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v0.15.0
 [0.14.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v0.14.0
 [0.13.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v0.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.15.1] - 2020-12-14
+
 ### Added
 
 - Add registry link check to `Makefile` and pre-release script. (#446)
+- A new AWS X-Ray ID Generator (#459)
+
+### Fixed
+
+- Fixes the body replacement in otelhttp to not to mutate a nil body. (#484)
 
 ## [0.15.0] - 2020-12-11
 
@@ -18,7 +25,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - A new Amazon EKS resource detector. (#465)
 - A new `gcp.CloudRun` detector for detecting resource from a Cloud Run instance. (#455)
-- A new AWS X-Ray ID Generator (#459)
 
 ## [0.14.0] - 2020-11-20
 

--- a/contrib.go
+++ b/contrib.go
@@ -18,7 +18,7 @@ package contrib // import "go.opentelemetry.io/contrib"
 
 // Version is the current release version of OpenTelemetry Contrib in use.
 func Version() string {
-	return "0.15.0"
+	return "0.15.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/exporters/metric/cortex/example/go.mod
+++ b/exporters/metric/cortex/example/go.mod
@@ -8,8 +8,8 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/contrib/exporters/metric/cortex v0.15.0
-	go.opentelemetry.io/contrib/exporters/metric/cortex/utils v0.15.0
+	go.opentelemetry.io/contrib/exporters/metric/cortex v0.15.1
+	go.opentelemetry.io/contrib/exporters/metric/cortex/utils v0.15.1
 	go.opentelemetry.io/otel v0.15.0
 	go.opentelemetry.io/otel/sdk v0.15.0
 	gopkg.in/yaml.v2 v2.2.5 // indirect

--- a/exporters/metric/cortex/utils/go.mod
+++ b/exporters/metric/cortex/utils/go.mod
@@ -8,5 +8,5 @@ require (
 	github.com/spf13/afero v1.5.1
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/contrib/exporters/metric/cortex v0.15.0
+	go.opentelemetry.io/contrib/exporters/metric/cortex v0.15.1
 )

--- a/instrumentation/github.com/Shopify/sarama/otelsarama/example/go.mod
+++ b/instrumentation/github.com/Shopify/sarama/otelsarama/example/go.mod
@@ -9,7 +9,7 @@ replace (
 
 require (
 	github.com/Shopify/sarama v1.27.2
-	go.opentelemetry.io/contrib/instrumentation/github.com/Shopify/sarama/otelsarama v0.15.0
+	go.opentelemetry.io/contrib/instrumentation/github.com/Shopify/sarama/otelsarama v0.15.1
 	go.opentelemetry.io/otel v0.15.0
 	go.opentelemetry.io/otel/exporters/stdout v0.15.0
 	go.opentelemetry.io/otel/sdk v0.15.0

--- a/instrumentation/github.com/Shopify/sarama/otelsarama/go.mod
+++ b/instrumentation/github.com/Shopify/sarama/otelsarama/go.mod
@@ -7,6 +7,6 @@ replace go.opentelemetry.io/contrib => ../../../../..
 require (
 	github.com/Shopify/sarama v1.27.2
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/contrib v0.15.0
+	go.opentelemetry.io/contrib v0.15.1
 	go.opentelemetry.io/otel v0.15.0
 )

--- a/instrumentation/github.com/astaxie/beego/otelbeego/example/go.mod
+++ b/instrumentation/github.com/astaxie/beego/otelbeego/example/go.mod
@@ -11,7 +11,7 @@ replace (
 
 require (
 	github.com/astaxie/beego v1.12.3
-	go.opentelemetry.io/contrib/instrumentation/github.com/astaxie/beego/otelbeego v0.15.0
+	go.opentelemetry.io/contrib/instrumentation/github.com/astaxie/beego/otelbeego v0.15.1
 	go.opentelemetry.io/otel v0.15.0
 	go.opentelemetry.io/otel/exporters/stdout v0.15.0
 	go.opentelemetry.io/otel/sdk v0.15.0

--- a/instrumentation/github.com/astaxie/beego/otelbeego/go.mod
+++ b/instrumentation/github.com/astaxie/beego/otelbeego/go.mod
@@ -11,8 +11,8 @@ replace (
 require (
 	github.com/astaxie/beego v1.12.3
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.15.0
-	go.opentelemetry.io/contrib/propagators v0.15.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.15.1
+	go.opentelemetry.io/contrib/propagators v0.15.1
 	go.opentelemetry.io/otel v0.15.0
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381 // indirect
 	golang.org/x/sys v0.0.0-20200803210538-64077c9b5642 // indirect

--- a/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache/example/go.mod
+++ b/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache/example/go.mod
@@ -9,7 +9,7 @@ replace (
 
 require (
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b
-	go.opentelemetry.io/contrib/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache v0.15.0
+	go.opentelemetry.io/contrib/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache v0.15.1
 	go.opentelemetry.io/otel v0.15.0
 	go.opentelemetry.io/otel/exporters/stdout v0.15.0
 	go.opentelemetry.io/otel/sdk v0.15.0

--- a/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache/go.mod
+++ b/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache/go.mod
@@ -7,6 +7,6 @@ replace go.opentelemetry.io/contrib => ../../../../../../
 require (
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/contrib v0.15.0
+	go.opentelemetry.io/contrib v0.15.1
 	go.opentelemetry.io/otel v0.15.0
 )

--- a/instrumentation/github.com/emicklei/go-restful/otelrestful/example/go.mod
+++ b/instrumentation/github.com/emicklei/go-restful/otelrestful/example/go.mod
@@ -10,7 +10,7 @@ replace (
 
 require (
 	github.com/emicklei/go-restful/v3 v3.4.0
-	go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful v0.15.0
+	go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful v0.15.1
 	go.opentelemetry.io/otel v0.15.0
 	go.opentelemetry.io/otel/exporters/stdout v0.15.0
 	go.opentelemetry.io/otel/sdk v0.15.0

--- a/instrumentation/github.com/emicklei/go-restful/otelrestful/go.mod
+++ b/instrumentation/github.com/emicklei/go-restful/otelrestful/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/emicklei/go-restful/v3 v3.4.0
 	github.com/json-iterator/go v1.1.10 // indirect
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/contrib v0.15.0
-	go.opentelemetry.io/contrib/propagators v0.15.0
+	go.opentelemetry.io/contrib v0.15.1
+	go.opentelemetry.io/contrib/propagators v0.15.1
 	go.opentelemetry.io/otel v0.15.0
 )

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/example/go.mod
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/example/go.mod
@@ -10,7 +10,7 @@ replace (
 
 require (
 	github.com/gin-gonic/gin v1.6.3
-	go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.15.0
+	go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.15.1
 	go.opentelemetry.io/otel v0.15.0
 	go.opentelemetry.io/otel/exporters/stdout v0.15.0
 	go.opentelemetry.io/otel/sdk v0.15.0

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/go.mod
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/go.mod
@@ -10,7 +10,7 @@ replace (
 require (
 	github.com/gin-gonic/gin v1.6.3
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/contrib v0.15.0
-	go.opentelemetry.io/contrib/propagators v0.15.0
+	go.opentelemetry.io/contrib v0.15.1
+	go.opentelemetry.io/contrib/propagators v0.15.1
 	go.opentelemetry.io/otel v0.15.0
 )

--- a/instrumentation/github.com/gocql/gocql/otelgocql/example/go.mod
+++ b/instrumentation/github.com/gocql/gocql/otelgocql/example/go.mod
@@ -9,7 +9,7 @@ replace (
 
 require (
 	github.com/gocql/gocql v0.0.0-20200624222514-34081eda590e
-	go.opentelemetry.io/contrib/instrumentation/github.com/gocql/gocql/otelgocql v0.15.0
+	go.opentelemetry.io/contrib/instrumentation/github.com/gocql/gocql/otelgocql v0.15.1
 	go.opentelemetry.io/otel v0.15.0
 	go.opentelemetry.io/otel/exporters/metric/prometheus v0.15.0
 	go.opentelemetry.io/otel/exporters/trace/zipkin v0.15.0

--- a/instrumentation/github.com/gocql/gocql/otelgocql/go.mod
+++ b/instrumentation/github.com/gocql/gocql/otelgocql/go.mod
@@ -8,6 +8,6 @@ require (
 	github.com/gocql/gocql v0.0.0-20200624222514-34081eda590e
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/contrib v0.15.0
+	go.opentelemetry.io/contrib v0.15.1
 	go.opentelemetry.io/otel v0.15.0
 )

--- a/instrumentation/github.com/gorilla/mux/otelmux/example/go.mod
+++ b/instrumentation/github.com/gorilla/mux/otelmux/example/go.mod
@@ -10,7 +10,7 @@ replace (
 
 require (
 	github.com/gorilla/mux v1.8.0
-	go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.15.0
+	go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.15.1
 	go.opentelemetry.io/otel v0.15.0
 	go.opentelemetry.io/otel/exporters/stdout v0.15.0
 	go.opentelemetry.io/otel/sdk v0.15.0

--- a/instrumentation/github.com/gorilla/mux/otelmux/go.mod
+++ b/instrumentation/github.com/gorilla/mux/otelmux/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.1
 	github.com/gorilla/mux v1.8.0
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/contrib v0.15.0
-	go.opentelemetry.io/contrib/propagators v0.15.0
+	go.opentelemetry.io/contrib v0.15.1
+	go.opentelemetry.io/contrib/propagators v0.15.1
 	go.opentelemetry.io/otel v0.15.0
 )

--- a/instrumentation/github.com/labstack/echo/otelecho/example/go.mod
+++ b/instrumentation/github.com/labstack/echo/otelecho/example/go.mod
@@ -10,7 +10,7 @@ replace (
 
 require (
 	github.com/labstack/echo/v4 v4.1.17
-	go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho v0.15.0
+	go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho v0.15.1
 	go.opentelemetry.io/otel v0.15.0
 	go.opentelemetry.io/otel/exporters/stdout v0.15.0
 	go.opentelemetry.io/otel/sdk v0.15.0

--- a/instrumentation/github.com/labstack/echo/otelecho/go.mod
+++ b/instrumentation/github.com/labstack/echo/otelecho/go.mod
@@ -10,7 +10,7 @@ replace (
 require (
 	github.com/labstack/echo/v4 v4.1.17
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/contrib v0.15.0
-	go.opentelemetry.io/contrib/propagators v0.15.0
+	go.opentelemetry.io/contrib v0.15.1
+	go.opentelemetry.io/contrib/propagators v0.15.1
 	go.opentelemetry.io/otel v0.15.0
 )

--- a/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/go.mod
+++ b/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/xdg/stringprep v1.0.0 // indirect
 	go.mongodb.org/mongo-driver v1.4.4
-	go.opentelemetry.io/contrib v0.15.0
+	go.opentelemetry.io/contrib v0.15.1
 	go.opentelemetry.io/otel v0.15.0
 	golang.org/x/crypto v0.0.0-20191105034135-c7e5f84aec59 // indirect
 )

--- a/instrumentation/google.golang.org/grpc/otelgrpc/example/go.mod
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/example/go.mod
@@ -9,7 +9,7 @@ replace (
 
 require (
 	github.com/golang/protobuf v1.4.3
-	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.15.0
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.15.1
 	go.opentelemetry.io/otel v0.15.0
 	go.opentelemetry.io/otel/exporters/stdout v0.15.0
 	go.opentelemetry.io/otel/sdk v0.15.0

--- a/instrumentation/google.golang.org/grpc/otelgrpc/go.mod
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/go.mod
@@ -7,7 +7,7 @@ replace go.opentelemetry.io/contrib => ../../../../
 require (
 	github.com/golang/protobuf v1.4.3
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/contrib v0.15.0
+	go.opentelemetry.io/contrib v0.15.1
 	go.opentelemetry.io/otel v0.15.0
 	google.golang.org/grpc v1.34.0
 )

--- a/instrumentation/gopkg.in/macaron.v1/otelmacaron/example/go.mod
+++ b/instrumentation/gopkg.in/macaron.v1/otelmacaron/example/go.mod
@@ -9,7 +9,7 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/contrib/instrumentation/gopkg.in/macaron.v1/otelmacaron v0.15.0
+	go.opentelemetry.io/contrib/instrumentation/gopkg.in/macaron.v1/otelmacaron v0.15.1
 	go.opentelemetry.io/otel v0.15.0
 	go.opentelemetry.io/otel/exporters/stdout v0.15.0
 	go.opentelemetry.io/otel/sdk v0.15.0

--- a/instrumentation/gopkg.in/macaron.v1/otelmacaron/go.mod
+++ b/instrumentation/gopkg.in/macaron.v1/otelmacaron/go.mod
@@ -9,8 +9,8 @@ replace (
 
 require (
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/contrib v0.15.0
-	go.opentelemetry.io/contrib/propagators v0.15.0
+	go.opentelemetry.io/contrib v0.15.1
+	go.opentelemetry.io/contrib/propagators v0.15.1
 	go.opentelemetry.io/otel v0.15.0
 	gopkg.in/macaron.v1 v1.4.0
 )

--- a/instrumentation/host/example/go.mod
+++ b/instrumentation/host/example/go.mod
@@ -8,7 +8,7 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/contrib/instrumentation/host v0.15.0
+	go.opentelemetry.io/contrib/instrumentation/host v0.15.1
 	go.opentelemetry.io/otel/exporters/stdout v0.15.0
 	go.opentelemetry.io/otel/sdk v0.15.0
 )

--- a/instrumentation/host/go.mod
+++ b/instrumentation/host/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/shirou/gopsutil v2.20.9+incompatible
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/contrib v0.15.0
+	go.opentelemetry.io/contrib v0.15.1
 	go.opentelemetry.io/otel v0.15.0
 	golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a // indirect
 )

--- a/instrumentation/net/http/httptrace/otelhttptrace/example/go.mod
+++ b/instrumentation/net/http/httptrace/otelhttptrace/example/go.mod
@@ -9,8 +9,8 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.15.0
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.15.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.15.1
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.15.1
 	go.opentelemetry.io/otel v0.15.0
 	go.opentelemetry.io/otel/exporters/stdout v0.15.0
 	go.opentelemetry.io/otel/sdk v0.15.0

--- a/instrumentation/net/http/httptrace/otelhttptrace/go.mod
+++ b/instrumentation/net/http/httptrace/otelhttptrace/go.mod
@@ -7,6 +7,6 @@ replace go.opentelemetry.io/contrib => ../../../../..
 require (
 	github.com/google/go-cmp v0.5.4
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/contrib v0.15.0
+	go.opentelemetry.io/contrib v0.15.1
 	go.opentelemetry.io/otel v0.15.0
 )

--- a/instrumentation/net/http/otelhttp/example/go.mod
+++ b/instrumentation/net/http/otelhttp/example/go.mod
@@ -8,7 +8,7 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.15.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.15.1
 	go.opentelemetry.io/otel v0.15.0
 	go.opentelemetry.io/otel/exporters/stdout v0.15.0
 	go.opentelemetry.io/otel/sdk v0.15.0

--- a/instrumentation/net/http/otelhttp/go.mod
+++ b/instrumentation/net/http/otelhttp/go.mod
@@ -7,6 +7,6 @@ replace go.opentelemetry.io/contrib => ../../../..
 require (
 	github.com/felixge/httpsnoop v1.0.1
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/contrib v0.15.0
+	go.opentelemetry.io/contrib v0.15.1
 	go.opentelemetry.io/otel v0.15.0
 )

--- a/instrumentation/runtime/example/go.mod
+++ b/instrumentation/runtime/example/go.mod
@@ -8,7 +8,7 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/contrib/instrumentation/runtime v0.15.0
+	go.opentelemetry.io/contrib/instrumentation/runtime v0.15.1
 	go.opentelemetry.io/otel/exporters/stdout v0.15.0
 	go.opentelemetry.io/otel/sdk v0.15.0
 )

--- a/instrumentation/runtime/go.mod
+++ b/instrumentation/runtime/go.mod
@@ -6,6 +6,6 @@ replace go.opentelemetry.io/contrib => ../..
 
 require (
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/contrib v0.15.0
+	go.opentelemetry.io/contrib v0.15.1
 	go.opentelemetry.io/otel v0.15.0
 )

--- a/propagators/opencensus/examples/go.mod
+++ b/propagators/opencensus/examples/go.mod
@@ -4,8 +4,8 @@ go 1.14
 
 require (
 	go.opencensus.io v0.22.6-0.20201102222123-380f4078db9f
-	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.15.0
-	go.opentelemetry.io/contrib/propagation/opencensus v0.15.0
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.15.1
+	go.opentelemetry.io/contrib/propagation/opencensus v0.15.1
 	go.opentelemetry.io/otel v0.15.0
 	go.opentelemetry.io/otel/exporters/stdout v0.15.0
 	go.opentelemetry.io/otel/sdk v0.15.0


### PR DESCRIPTION
## [0.15.1] - 2020-12-14

### Added

- Add registry link check to `Makefile` and pre-release script. (#446)
- A new AWS X-Ray ID Generator (#459)

### Fixed

- Fixes the body replacement in otelhttp to not to mutate a nil body. (#484)