### PR TITLE
Fix error in GitHub Actions integration tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -54,6 +54,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - run: mkdir -p $TEST_RESULTS
       - name: Integration test ${{ matrix.target }}
         run: |


### PR DESCRIPTION
Integration tests can't actually compare to `origin/master` because the entire git tree wasn't being cloned in the action 😞 I fixed this by setting [`fetch-depth` to 0](https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches). 
![Screen Shot 2020-12-17 at 5 29 51 PM](https://user-images.githubusercontent.com/20804975/102553311-ac975800-4090-11eb-8705-a25bed04e9d8.png)

Missed this because the failure was silent and the job is actually passing because the makefile continues onto the last step (and returns a success exit code) instead of aborting at the fatal error. 
