### PR TITLE
Adding Security Workflows to GitHub Actions (2/2): gosec workflow

### DIFF
--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -1,0 +1,19 @@
+name: Run Gosec
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    env:
+      GO111MODULE: on
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v2
+      - name: Run Gosec Security Scanner
+        uses: securego/gosec@master
+        with:
+          args: ./...

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -1,10 +1,18 @@
 name: Run Gosec
 on:
   push:
-    branches: [master]
-  pull_request:
-    branches: [master]
   workflow_dispatch:
+  schedule:
+    #        ┌───────────── minute (0 - 59)
+    #        │  ┌───────────── hour (0 - 23)
+    #        │  │ ┌───────────── day of the month (1 - 31)
+    #        │  │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+    #        │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+    #        │  │ │ │ │
+    #        │  │ │ │ │
+    #        │  │ │ │ │
+    #        *  * * * *
+    - cron: '30 2 * * *'
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -1,6 +1,5 @@
 name: Run Gosec
 on:
-  push:
   workflow_dispatch:
   schedule:
     #        ┌───────────── minute (0 - 59)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - A new AWS X-Ray ID Generator (#459)
 - Migrate CircleCI jobs to GitHub Actions (#476)
 - Add CodeQL GitHub Action (#506)
+- Add gosec workflow to GitHub Actions (#507)
 
 ### Fixed
 


### PR DESCRIPTION
## Motivation

Related to PR https://github.com/open-telemetry/opentelemetry-go-contrib/pull/506 and issue https://github.com/open-telemetry/oteps/issues/144

[Gosec](https://github.com/securego/gosec) is a static analysis engine which scans go source code for security vulnerabilities. As the project grows and we near GA it might be useful to have a workflow which checks for security vulnerabilities with every PR so we can ensure every incremental change is following best development practices. Also passing basic security checks will also make sure that there aren't any glaring issues for our users. 

## Changes

* This PR adds [gosec](https://github.com/securego/gosec) security checks to the repo

**Workflow Triggers**
* cron job at 1:30am
* workflow_dispatch (in case maintainers want to trigger a security check manually)

cc- @alolita 