### PR TITLE
Add code-coverage configuration to allow 1% delta

### DIFF
--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -1,0 +1,17 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 1
+  round: down
+  range: "70...100"
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: yes


### PR DESCRIPTION
Similar to https://github.com/open-telemetry/opentelemetry-go/blob/c56227771d4c3551cf4eec84a3a6d1881f5dbd9f/.github/codecov.yaml this configures the CI code coverage check to enforce at least 70% code coverage, but allows up to a 1% delta in code coverage for each PR.