### PR TITLE
Update workflows to include main branch as trigger

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,7 +1,9 @@
 name: build_and_test
 on:
   push:
-    branches: [master]
+    branches:
+      - master
+      - main
   pull_request:
 env:
   TEST_RESULTS: /tmp/test-results # path to where test results will be saved


### PR DESCRIPTION
Prepare to rename `master` branch to `main` by adding `main` to the github action triggers. After the branch is renamed, `master` will be removed from the list.

Part of https://github.com/open-telemetry/opentelemetry-go/issues/1496