### PR TITLE
added failure message - ECS resource detector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- Added failure message for AWS ECS resource detector for better debugging (#568)
+
 ## [0.16.0] - 2021-01-13
 
 ### Fixed

--- a/detectors/aws/ecs/ecs.go
+++ b/detectors/aws/ecs/ecs.go
@@ -35,11 +35,11 @@ const (
 )
 
 var (
-	empty                    = resource.Empty()
-	errCannotReadContainerID = errors.New("failed to read container ID from cGroupFile")
-	errCannotReadContainerName    = errors.New("failed to read hostname")
-	errCannotReadCGroupFile  = errors.New("ECS resource detector failed to read cGroupFile")
-	errNotOnECS              = errors.New("process is not on ECS, cannot detect environment variables from ECS")
+	empty                      = resource.Empty()
+	errCannotReadContainerID   = errors.New("failed to read container ID from cGroupFile")
+	errCannotReadContainerName = errors.New("failed to read hostname")
+	errCannotReadCGroupFile    = errors.New("ECS resource detector failed to read cGroupFile")
+	errNotOnECS                = errors.New("process is not on ECS, cannot detect environment variables from ECS")
 )
 
 // Create interface for methods needing to be mocked

--- a/detectors/aws/ecs/ecs.go
+++ b/detectors/aws/ecs/ecs.go
@@ -37,6 +37,7 @@ const (
 var (
 	empty                    = resource.Empty()
 	errCannotReadContainerID = errors.New("failed to read container ID from cGroupFile")
+	errCannotReadContainerName    = errors.New("failed to read hostname")
 	errCannotReadCGroupFile  = errors.New("ECS resource detector failed to read cGroupFile")
 	errNotOnECS              = errors.New("process is not on ECS, cannot detect environment variables from ECS")
 )
@@ -102,5 +103,9 @@ func (ecsUtils ecsDetectorUtils) getContainerID() (string, error) {
 
 // returns host name reported by the kernel
 func (ecsUtils ecsDetectorUtils) getContainerName() (string, error) {
-	return os.Hostname()
+	hostName, err := os.Hostname()
+	if err != nil {
+		return "", errCannotReadContainerName
+	}
+	return hostName, nil
 }

--- a/detectors/aws/ecs/ecs_test.go
+++ b/detectors/aws/ecs/ecs_test.go
@@ -81,6 +81,23 @@ func TestDetectCannotReadContainerID(t *testing.T) {
 	assert.Equal(t, 0, len(resource.Attributes()))
 }
 
+//returns empty resource when detector cannot read container Name
+func TestDetectCannotReadContainerName(t *testing.T) {
+	os.Clearenv()
+	os.Setenv(metadataV3EnvVar, "3")
+	os.Setenv(metadataV4EnvVar, "4")
+	detectorUtils := new(MockDetectorUtils)
+
+	detectorUtils.On("getContainerName").Return("", errCannotReadContainerName)
+	detectorUtils.On("getContainerID").Return("0123456789A", nil)
+
+	detector := ResourceDetector{detectorUtils}
+	resource, err := detector.Detect(context.Background())
+
+	assert.Equal(t, errCannotReadContainerName, err)
+	assert.Equal(t, 0, len(resource.Attributes()))
+}
+
 //returns empty resource when process is not running ECS
 func TestReturnsIfNoEnvVars(t *testing.T) {
 	os.Clearenv()


### PR DESCRIPTION
1. Added error message in case of failure to get hostname for better debugging as response to below issue:

https://github.com/aws-observability/aws-otel-go/issues/16 