### PR TITLE
Add tracing filter for otelgin based on request

### DIFF
--- a/instrumentation/github.com/gin-gonic/gin/otelgin/gintrace.go
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/gintrace.go
@@ -38,10 +38,10 @@ const (
 	tracerName = "go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
 )
 
-// FilterFunc allows to skip tracing the incoming requests based on
-// request characteristics. Returns true means the filter rule is hit
-// and this request will not be recorded.
-type FilterFunc func(req *http.Request) bool
+// Filter allows to skip tracing the incoming requests based on
+// request characteristics. Returns false means this request will
+// not be recorded.
+type Filter func(req *http.Request) bool
 
 // Middleware returns middleware that will trace incoming requests.
 // The service parameter should describe the name of the (virtual)
@@ -63,7 +63,7 @@ func Middleware(service string, opts ...Option) gin.HandlerFunc {
 	}
 	return func(c *gin.Context) {
 		for _, filter := range cfg.Filters {
-			if filter(c.Request) {
+			if !filter(c.Request) {
 				c.Set(skippedKey, true)
 				c.Next()
 				return

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/gintrace_test.go
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/gintrace_test.go
@@ -289,8 +289,8 @@ func (mt *mockTracer) Start(ctx context.Context, spanName string, opts ...oteltr
 
 func TestFilter(t *testing.T) {
 	otel.SetTracerProvider(&mockTracerProvider{TracerProvider: oteltest.NewTracerProvider(), tracers: make(map[string]*mockTracer)})
-	uaFilter := FilterFunc(func(req *http.Request) bool {
-		return req.UserAgent() == "some scanner"
+	uaFilter := Filter(func(req *http.Request) bool {
+		return req.UserAgent() != "some scanner"
 	})
 	router := gin.New()
 	router.Use(Middleware("foobar", WithFilter(uaFilter)))

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/option.go
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/option.go
@@ -24,7 +24,7 @@ import (
 type config struct {
 	TracerProvider oteltrace.TracerProvider
 	Propagators    propagation.TextMapPropagator
-	Filters        []FilterFunc
+	Filters        []Filter
 }
 
 // Option specifies instrumentation configuration options.
@@ -48,8 +48,8 @@ func WithTracerProvider(provider oteltrace.TracerProvider) Option {
 }
 
 // WithFilter add a filter func which returns true to skip recording the tracing.
-// When multiple filters are added, anyone of them returns true will result the skip
-func WithFilter(filters ...FilterFunc) Option {
+// When multiple filters are added, anyone of them returns false will result the skip
+func WithFilter(filters ...Filter) Option {
 	return func(cfg *config) {
 		cfg.Filters = append(cfg.Filters, filters...)
 	}

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/option.go
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/option.go
@@ -24,6 +24,7 @@ import (
 type config struct {
 	TracerProvider oteltrace.TracerProvider
 	Propagators    propagation.TextMapPropagator
+	Filters        []FilterFunc
 }
 
 // Option specifies instrumentation configuration options.
@@ -43,5 +44,13 @@ func WithPropagators(propagators propagation.TextMapPropagator) Option {
 func WithTracerProvider(provider oteltrace.TracerProvider) Option {
 	return func(cfg *config) {
 		cfg.TracerProvider = provider
+	}
+}
+
+// WithFilter add a filter func which returns true to skip recording the tracing.
+// When multiple filters are added, anyone of them returns true will result the skip
+func WithFilter(filters ...FilterFunc) Option {
+	return func(cfg *config) {
+		cfg.Filters = append(cfg.Filters, filters...)
 	}
 }

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/option.go
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/option.go
@@ -47,7 +47,7 @@ func WithTracerProvider(provider oteltrace.TracerProvider) Option {
 	}
 }
 
-// WithFilter add a filter func which returns true to skip recording the tracing.
+// WithFilter add a filter func which returns false to skip recording the tracing.
 // When multiple filters are added, anyone of them returns false will result the skip
 func WithFilter(filters ...Filter) Option {
 	return func(cfg *config) {


### PR DESCRIPTION
This PR allows otelgin to skip tracing the specific requests.

We add `WithFilter` API for the option to pass the user defined filter which returns false to skip tracing.

This is useful when you don't want to be annoyed by the robot requests like some security scans.