### PR TITLE
Use SingleHeader format for unspecified B3 inject encoding

### DIFF
--- a/propagators/b3/b3_data_test.go
+++ b/propagators/b3/b3_data_test.go
@@ -541,9 +541,7 @@ var injectHeader = []injectTest{
 			TraceFlags: trace.FlagsSampled,
 		},
 		wantHeaders: map[string]string{
-			b3TraceID: traceIDStr,
-			b3SpanID:  spanIDStr,
-			b3Sampled: "1",
+			b3Context: fmt.Sprintf("%s-%s-%s", traceIDStr, spanIDStr, "1"),
 		},
 		doNotWantHeaders: []string{
 			b3ParentSpanID,
@@ -558,9 +556,7 @@ var injectHeader = []injectTest{
 			SpanID:  spanID,
 		},
 		wantHeaders: map[string]string{
-			b3TraceID: traceIDStr,
-			b3SpanID:  spanIDStr,
-			b3Sampled: "0",
+			b3Context: fmt.Sprintf("%s-%s-%s", traceIDStr, spanIDStr, "0"),
 		},
 		doNotWantHeaders: []string{
 			b3ParentSpanID,
@@ -576,8 +572,7 @@ var injectHeader = []injectTest{
 			TraceFlags: trace.FlagsDeferred,
 		},
 		wantHeaders: map[string]string{
-			b3TraceID: traceIDStr,
-			b3SpanID:  spanIDStr,
+			b3Context: fmt.Sprintf("%s-%s", traceIDStr, spanIDStr),
 		},
 		doNotWantHeaders: []string{
 			b3Sampled,
@@ -592,7 +587,7 @@ var injectHeader = []injectTest{
 			TraceFlags: trace.FlagsSampled,
 		},
 		wantHeaders: map[string]string{
-			b3Sampled: "1",
+			b3Context: "1",
 		},
 		doNotWantHeaders: []string{
 			b3TraceID,
@@ -610,9 +605,7 @@ var injectHeader = []injectTest{
 			TraceFlags: trace.FlagsDebug,
 		},
 		wantHeaders: map[string]string{
-			b3TraceID: traceIDStr,
-			b3SpanID:  spanIDStr,
-			b3Flags:   "1",
+			b3Context: fmt.Sprintf("%s-%s-%s", traceIDStr, spanIDStr, "d"),
 		},
 		doNotWantHeaders: []string{
 			b3Sampled,
@@ -628,9 +621,7 @@ var injectHeader = []injectTest{
 			TraceFlags: trace.FlagsSampled | trace.FlagsDebug,
 		},
 		wantHeaders: map[string]string{
-			b3TraceID: traceIDStr,
-			b3SpanID:  spanIDStr,
-			b3Flags:   "1",
+			b3Context: fmt.Sprintf("%s-%s-%s", traceIDStr, spanIDStr, "d"),
 		},
 		doNotWantHeaders: []string{
 			b3Sampled,

--- a/propagators/b3/b3_data_test.go
+++ b/propagators/b3/b3_data_test.go
@@ -545,6 +545,9 @@ var injectHeader = []injectTest{
 		},
 		doNotWantHeaders: []string{
 			b3ParentSpanID,
+			b3TraceID,
+			b3SpanID,
+			b3Sampled,
 			b3Flags,
 			b3Context,
 		},
@@ -560,6 +563,9 @@ var injectHeader = []injectTest{
 		},
 		doNotWantHeaders: []string{
 			b3ParentSpanID,
+			b3TraceID,
+			b3SpanID,
+			b3Sampled,
 			b3Flags,
 			b3Context,
 		},
@@ -576,6 +582,8 @@ var injectHeader = []injectTest{
 		},
 		doNotWantHeaders: []string{
 			b3Sampled,
+			b3TraceID,
+			b3SpanID,
 			b3ParentSpanID,
 			b3Flags,
 			b3Context,
@@ -609,6 +617,8 @@ var injectHeader = []injectTest{
 		},
 		doNotWantHeaders: []string{
 			b3Sampled,
+			traceIDStr,
+			spanIDStr,
 			b3ParentSpanID,
 			b3Context,
 		},
@@ -625,6 +635,9 @@ var injectHeader = []injectTest{
 		},
 		doNotWantHeaders: []string{
 			b3Sampled,
+			traceIDStr,
+			spanIDStr,
+			b3Flags,
 			b3ParentSpanID,
 			b3Context,
 		},

--- a/propagators/b3/b3_propagator.go
+++ b/propagators/b3/b3_propagator.go
@@ -104,7 +104,7 @@ var _ propagation.TextMapPropagator = B3{}
 func (b3 B3) Inject(ctx context.Context, carrier propagation.TextMapCarrier) {
 	sc := trace.SpanFromContext(ctx).SpanContext()
 
-	if b3.InjectEncoding.supports(B3SingleHeader) {
+	if b3.InjectEncoding.supports(B3SingleHeader) || b3.InjectEncoding == B3Unspecified {
 		header := []string{}
 		if sc.TraceID.IsValid() && sc.SpanID.IsValid() {
 			header = append(header, sc.TraceID.String(), sc.SpanID.String())
@@ -123,7 +123,7 @@ func (b3 B3) Inject(ctx context.Context, carrier propagation.TextMapCarrier) {
 		carrier.Set(b3ContextHeader, strings.Join(header, "-"))
 	}
 
-	if b3.InjectEncoding.supports(B3MultipleHeader) || b3.InjectEncoding == B3Unspecified {
+	if b3.InjectEncoding.supports(B3MultipleHeader) {
 		if sc.TraceID.IsValid() && sc.SpanID.IsValid() {
 			carrier.Set(b3TraceIDHeader, sc.TraceID.String())
 			carrier.Set(b3SpanIDHeader, sc.SpanID.String())


### PR DESCRIPTION
**Which problem is this PR solving?**

This PR changes default behavior when B3 inject encoding is unspecified from multi-header to single-header, per #613.

**Short description of the changes**

- Use single-header format when B3 inject encoding is unspecified
- Modify test data for cases involving unspecified B3 inject encoding