### PR TITLE
Fix cortex example code

### DIFF
--- a/exporters/metric/cortex/example/main.go
+++ b/exporters/metric/cortex/example/main.go
@@ -45,7 +45,9 @@ func main() {
 	}
 
 	ctx := context.Background()
-	defer handleErr(pusher.Stop(ctx))
+	defer func() {
+		handleErr(pusher.Stop(ctx))
+	}()
 	fmt.Println("Success: Installed Exporter Pipeline")
 
 	// Create a counter and a value recorder


### PR DESCRIPTION
`pusher.Stop(ctx)` is called immediately after launch, background remote write is not keep running.
I think, it should be wrapped by `func() {}()`.