### PR TITLE
Remove service.name attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Removed
+
+- Remove service name from `otelmongodb` configuration and span attributes. (#763)
+
 ## [0.20.0] - 2021-04-23
 
 ### Changed

--- a/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/example_test.go
+++ b/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/example_test.go
@@ -27,7 +27,7 @@ import (
 func Example() {
 	// connect to MongoDB
 	opts := options.Client()
-	opts.Monitor = otelmongo.NewMonitor("test-service")
+	opts.Monitor = otelmongo.NewMonitor()
 	opts.ApplyURI("mongodb://localhost:27017")
 	client, err := mongo.Connect(context.Background(), opts)
 	if err != nil {

--- a/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/mongo.go
+++ b/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/mongo.go
@@ -35,7 +35,6 @@ type spanKey struct {
 type monitor struct {
 	sync.Mutex
 	spans       map[spanKey]trace.Span
-	serviceName string
 	cfg         config
 }
 
@@ -43,7 +42,6 @@ func (m *monitor) Started(ctx context.Context, evt *event.CommandStartedEvent) {
 	hostname, port := peerInfo(evt)
 
 	attrs := []attribute.KeyValue{
-		ServiceName(m.serviceName),
 		DBOperation(evt.CommandName),
 		DBInstance(evt.DatabaseName),
 		DBSystem("mongodb"),
@@ -100,11 +98,10 @@ func (m *monitor) Finished(evt *event.CommandFinishedEvent, err error) {
 }
 
 // NewMonitor creates a new mongodb event CommandMonitor.
-func NewMonitor(serviceName string, opts ...Option) *event.CommandMonitor {
+func NewMonitor(opts ...Option) *event.CommandMonitor {
 	cfg := newConfig(opts...)
 	m := &monitor{
 		spans:       make(map[spanKey]trace.Span),
-		serviceName: serviceName,
 		cfg:         cfg,
 	}
 	return &event.CommandMonitor{

--- a/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/mongo.go
+++ b/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/mongo.go
@@ -34,8 +34,8 @@ type spanKey struct {
 
 type monitor struct {
 	sync.Mutex
-	spans       map[spanKey]trace.Span
-	cfg         config
+	spans map[spanKey]trace.Span
+	cfg   config
 }
 
 func (m *monitor) Started(ctx context.Context, evt *event.CommandStartedEvent) {
@@ -101,8 +101,8 @@ func (m *monitor) Finished(evt *event.CommandFinishedEvent, err error) {
 func NewMonitor(opts ...Option) *event.CommandMonitor {
 	cfg := newConfig(opts...)
 	m := &monitor{
-		spans:       make(map[spanKey]trace.Span),
-		cfg:         cfg,
+		spans: make(map[spanKey]trace.Span),
+		cfg:   cfg,
 	}
 	return &event.CommandMonitor{
 		Started:   m.Started,

--- a/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/mongo_test.go
+++ b/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/mongo_test.go
@@ -63,7 +63,7 @@ func Test(t *testing.T) {
 
 			addr := "mongodb://localhost:27017/?connect=direct"
 			opts := options.Client()
-			opts.Monitor = NewMonitor("mongo", WithTracerProvider(provider), WithCommandAttributeDisabled(tc.commandAttributeDisabled))
+			opts.Monitor = NewMonitor(WithTracerProvider(provider), WithCommandAttributeDisabled(tc.commandAttributeDisabled))
 			opts.ApplyURI(addr)
 			client, err := mongo.Connect(ctx, opts)
 			if err != nil {
@@ -79,10 +79,9 @@ func Test(t *testing.T) {
 
 			spans := sr.Completed()
 			assert.Len(t, spans, 2)
-			assert.Equal(t, spans[0].SpanContext().TraceID, spans[1].SpanContext().TraceID)
+			assert.Equal(t, spans[0].SpanContext().TraceID(), spans[1].SpanContext().TraceID())
 
 			s := spans[0]
-			assert.Equal(t, "mongo", s.Attributes()[ServiceNameKey].AsString())
 			assert.Equal(t, "insert", s.Attributes()[DBOperationKey].AsString())
 			assert.Equal(t, hostname, s.Attributes()[PeerHostnameKey].AsString())
 			assert.Equal(t, port, s.Attributes()[PeerPortKey].AsString())

--- a/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/tags.go
+++ b/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/tags.go
@@ -19,7 +19,6 @@ import "go.opentelemetry.io/otel/attribute"
 const (
 	TargetHostKey  = attribute.Key("out.host")
 	TargetPortKey  = attribute.Key("out.port")
-	ServiceNameKey = attribute.Key("service.name")
 	DBOperationKey = attribute.Key("db.operation")
 	ErrorKey       = attribute.Key("error")
 	ErrorMsgKey    = attribute.Key("error.msg")
@@ -33,11 +32,6 @@ func TargetHost(targetHost string) attribute.KeyValue {
 // TargetPort sets the target host port.
 func TargetPort(targetPort string) attribute.KeyValue {
 	return TargetPortKey.String(targetPort)
-}
-
-// ServiceName defines the Service name for this Span.
-func ServiceName(serviceName string) attribute.KeyValue {
-	return ServiceNameKey.String(serviceName)
 }
 
 // DBOperation defines the name of the operation.


### PR DESCRIPTION
`service.name` should correspond to the Resource of the entity producing telemetry, not the remote service.

Relates to #454

This PR removes only the `service.name` related aspects of the otelmongodb instrumentation. Other issues identified in #460 will be left to a separate PR.