### PR TITLE
net/http: add requests count metric with status code label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [0.21.0] - 2021-06-18
 
+### Added
+
+- Add total requests counter by response status code for the `net/http` instrumentation. (#771)
+
 ### Fixed
 
 - Dockerfile based examples for `otelgin` and `otelmacaron`. (#767)

--- a/instrumentation/net/http/otelhttp/handler.go
+++ b/instrumentation/net/http/otelhttp/handler.go
@@ -102,11 +102,15 @@ func (h *Handler) createMeasures() {
 	responseBytesCounter, err := h.meter.NewInt64Counter(ResponseContentLength)
 	handleErr(err)
 
+	requestCount, err := h.meter.NewInt64Counter(RequestCount)
+	handleErr(err)
+
 	serverLatencyMeasure, err := h.meter.NewInt64ValueRecorder(ServerLatency)
 	handleErr(err)
 
 	h.counters[RequestContentLength] = requestBytesCounter
 	h.counters[ResponseContentLength] = responseBytesCounter
+	h.counters[RequestCount] = requestCount
 	h.valueRecorders[ServerLatency] = serverLatencyMeasure
 }
 
@@ -184,6 +188,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	attributes := append(labeler.Get(), semconv.HTTPServerMetricAttributesFromHTTPRequest(h.operation, r)...)
 	h.counters[RequestContentLength].Add(ctx, bw.read, attributes...)
 	h.counters[ResponseContentLength].Add(ctx, rww.written, attributes...)
+
+	// Count of request to record errors ratio
+	requestCountAttributes := append(attributes, semconv.HTTPStatusCodeKey.Int(rww.statusCode))
+	h.counters[RequestCount].Add(ctx, 1, requestCountAttributes...)
 
 	elapsedTime := time.Since(requestStartTime).Microseconds()
 


### PR DESCRIPTION
Closes #711

This PR adds a counter for the total amount of requests with the http_status_code label. It will help us to be aware of the ratio of errors. 

P.S. I decided to avoid adding status code to other metrics because it looks excessive. Instead, counting the number of requests seems more sensible.