### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crl

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 * text=auto eol=lf
 *.{cmd,[cC][mM][dD]} text eol=crlf
-*.{bat,[bB][aA][tT]} text eol=crl
+*.{bat,[bB][aA][tT]} text eol=crlf


### PR DESCRIPTION
## Why

Get rid of false negatives on Windows like: 
```
File is not `gofmt`-ed with `-s` (gofmt)
```

Also, it helps to work on Windows in native, WSL and Development Container modes on the same repository.

## What

Add .gitattributes so that most files (especially `*.sh` ,`*.go`, `Makefile`) use LF and only Windows-specific have CLRF line ending.