### PR TITLE
[WIP] Replace `golint` with `revive`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,7 @@ linters:
   enable:
     - misspell
     - goimports
-    - golint
+    - revive
     - gofmt
 
 issues:
@@ -16,12 +16,12 @@ issues:
     - path: _test\.go
       text: "context.Context should be the first parameter of a function"
       linters:
-        - golint
+        - revive
     # Yes, they are, but it's okay in a test
     - path: _test\.go
       text: "exported func.*returns unexported type.*which can be annoying to use"
       linters:
-        - golint
+        - revive
 
 linters-settings:
   misspell:


### PR DESCRIPTION
## Why

`golint` is officially deprecated: https://github.com/golang/go/issues/38968
It is deprecated in `golangci-lint` as well: https://github.com/golangci/golangci-lint/releases/tag/v1.40.1

## What

Use `revive` instead of like OTel Collector:
- https://github.com/open-telemetry/opentelemetry-collector/pull/3182
- https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3391