### PR TITLE
replaces golint by revive and fix newly reported linter issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,7 @@ linters:
   enable:
     - misspell
     - goimports
-    - golint
+    - revive
     - gofmt
 
 issues:
@@ -16,12 +16,12 @@ issues:
     - path: _test\.go
       text: "context.Context should be the first parameter of a function"
       linters:
-        - golint
+        - revive
     # Yes, they are, but it's okay in a test
     - path: _test\.go
       text: "exported func.*returns unexported type.*which can be annoying to use"
       linters:
-        - golint
+        - revive
 
 linters-settings:
   misspell:

--- a/detectors/aws/ecs/ecs.go
+++ b/detectors/aws/ecs/ecs.go
@@ -27,6 +27,7 @@ import (
 )
 
 const (
+	// TypeStr is AWS ECS type.
 	TypeStr           = "ecs"
 	metadataV3EnvVar  = "ECS_CONTAINER_METADATA_URI"
 	metadataV4EnvVar  = "ECS_CONTAINER_METADATA_URI_V4"

--- a/exporters/metric/cortex/cortex_test.go
+++ b/exporters/metric/cortex/cortex_test.go
@@ -67,7 +67,7 @@ var validConfig = Config{
 }
 
 var testResource = resource.NewWithAttributes(attribute.String("R", "V"))
-var mockTime int64 = int64(time.Nanosecond) * time.Time{}.UnixNano() / int64(time.Millisecond)
+var mockTime = int64(time.Nanosecond) * time.Time{}.UnixNano() / int64(time.Millisecond)
 
 func TestExportKindFor(t *testing.T) {
 	exporter := Exporter{}

--- a/exporters/metric/dogstatsd/internal/statsd/conn.go
+++ b/exporters/metric/dogstatsd/internal/statsd/conn.go
@@ -91,6 +91,7 @@ const (
 var (
 	_ export.Exporter = &Exporter{}
 
+	//nolint:revive // ignoring missing comments for unexported sentinel errors in an internal package.
 	ErrInvalidScheme = fmt.Errorf("invalid statsd transport")
 )
 

--- a/instrumentation/github.com/Shopify/sarama/otelsarama/example/init.go
+++ b/instrumentation/github.com/Shopify/sarama/otelsarama/example/init.go
@@ -24,6 +24,7 @@ import (
 )
 
 const (
+	// KafkaTopic name.
 	KafkaTopic = "sarama-instrumentation-example"
 )
 

--- a/instrumentation/github.com/astaxie/beego/otelbeego/beego.go
+++ b/instrumentation/github.com/astaxie/beego/otelbeego/beego.go
@@ -26,7 +26,7 @@ import (
 	"github.com/astaxie/beego"
 )
 
-// OTelBeegoHandler implements the http.Handler interface and provides
+// Handler implements the http.Handler interface and provides
 // trace and metrics to beego web apps.
 type Handler struct {
 	http.Handler

--- a/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/attributes.go
+++ b/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/attributes.go
@@ -16,6 +16,7 @@ package otelaws
 
 import "go.opentelemetry.io/otel/attribute"
 
+// AWS attributes.
 const (
 	OperationKey attribute.Key = "aws.operation"
 	RegionKey    attribute.Key = "aws.region"

--- a/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/db.go
+++ b/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/db.go
@@ -16,6 +16,7 @@ package otelmongo
 
 import "go.opentelemetry.io/otel/attribute"
 
+// Mongo DB attributes.
 const (
 	DBApplicationKey = attribute.Key("db.application")
 	DBNameKey        = attribute.Key("db.name")

--- a/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/peer.go
+++ b/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/peer.go
@@ -17,9 +17,9 @@ package otelmongo
 import "go.opentelemetry.io/otel/attribute"
 
 const (
-	// PeerHostname records the host name of the peer.
+	// PeerHostnameKey records the host name of the peer.
 	PeerHostnameKey = attribute.Key("peer.hostname")
-	// PeerPort records the port number of the peer.
+	// PeerPortKey records the port number of the peer.
 	PeerPortKey = attribute.Key("peer.port")
 )
 

--- a/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/tags.go
+++ b/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/tags.go
@@ -16,6 +16,7 @@ package otelmongo
 
 import "go.opentelemetry.io/otel/attribute"
 
+// Mongo tag attributes.
 const (
 	TargetHostKey  = attribute.Key("out.host")
 	TargetPortKey  = attribute.Key("out.port")

--- a/instrumentation/host/host.go
+++ b/instrumentation/host/host.go
@@ -66,6 +66,7 @@ func (o metricProviderOption) ApplyHost(c *config) {
 	c.MeterProvider = o.MeterProvider
 }
 
+// Attribute sets.
 var (
 	// Attribute sets for CPU time measurements.
 

--- a/instrumentation/net/http/httptrace/otelhttptrace/api.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/api.go
@@ -20,7 +20,7 @@ import (
 	"net/http/httptrace"
 )
 
-// Client
+// W3C client.
 func W3C(ctx context.Context, req *http.Request) (context.Context, *http.Request) {
 	ctx = httptrace.WithClientTrace(ctx, NewClientTrace(ctx))
 	req = req.WithContext(ctx)

--- a/instrumentation/net/http/httptrace/otelhttptrace/clienttrace.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/clienttrace.go
@@ -30,6 +30,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+// HTTP attributes.
 var (
 	HTTPStatus     = attribute.Key("http.status")
 	HTTPHeaderMIME = attribute.Key("http.mime")

--- a/instrumentation/net/http/httptrace/otelhttptrace/httptrace.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/httptrace.go
@@ -49,7 +49,7 @@ func WithPropagators(props propagation.TextMapPropagator) Option {
 	}
 }
 
-// Returns the Attributes, Context Entries, and SpanContext that were encoded by Inject.
+// Extract returns the Attributes, Context Entries, and SpanContext that were encoded by Inject.
 func Extract(ctx context.Context, req *http.Request, opts ...Option) ([]attribute.KeyValue, []attribute.KeyValue, trace.SpanContext) {
 	c := newConfig(opts)
 	ctx = c.propagators.Extract(ctx, propagation.HeaderCarrier(req.Header))

--- a/instrumentation/net/http/otelhttp/labeler.go
+++ b/instrumentation/net/http/otelhttp/labeler.go
@@ -35,7 +35,7 @@ func (l *Labeler) Add(ls ...attribute.KeyValue) {
 	l.attributes = append(l.attributes, ls...)
 }
 
-// Labels returns a copy of the attributes added to the Labeler.
+// Get returns a copy of the attributes added to the Labeler.
 func (l *Labeler) Get() []attribute.KeyValue {
 	l.mu.Lock()
 	defer l.mu.Unlock()

--- a/instrumentation/runtime/runtime.go
+++ b/instrumentation/runtime/runtime.go
@@ -150,11 +150,7 @@ func (r *runtime) register() error {
 		return err
 	}
 
-	if err := r.registerMemStats(); err != nil {
-		return err
-	}
-
-	return nil
+	return r.registerMemStats()
 }
 
 func (r *runtime) registerMemStats() error {


### PR DESCRIPTION
As [`golint` is deprecated](https://github.com/golang/go/issues/38968) this PR replaces `golint` by [`revive`](https://github.com/mgechev/revive#revive), a drop-in replacement for `golint` and also the one suggested by [`golangci-lint `](https://github.com/golangci/golangci-lint).
It's a followup on #792, closes #792 and relates to #1935

Even though `revive` is a drop-in replacement for `golint` one new lint issues rose after the change. I could not get golint to report it as well, anyway I fixed it.