### PR TITLE
Remove leftover error handlings in instrumentation examples.

### DIFF
--- a/instrumentation/github.com/Shopify/sarama/otelsarama/example/init.go
+++ b/instrumentation/github.com/Shopify/sarama/otelsarama/example/init.go
@@ -36,9 +36,6 @@ func InitTracer() {
 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 		sdktrace.WithSyncer(exporter),
 	)
-	if err != nil {
-		log.Fatal(err)
-	}
 	otel.SetTracerProvider(tp)
 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}))
 }

--- a/instrumentation/github.com/astaxie/beego/otelbeego/example/server/server.go
+++ b/instrumentation/github.com/astaxie/beego/otelbeego/example/server/server.go
@@ -63,9 +63,6 @@ func initTracer() {
 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 		sdktrace.WithSyncer(exporter),
 		sdktrace.WithResource(resource.NewWithAttributes(semconv.ServiceNameKey.String("ExampleService"))))
-	if err != nil {
-		log.Fatal(err)
-	}
 	otel.SetTracerProvider(tp)
 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
 }

--- a/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache/example/client.go
+++ b/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache/example/client.go
@@ -82,9 +82,6 @@ func initTracer() oteltrace.TracerProvider {
 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 		sdktrace.WithSyncer(exporter),
 	)
-	if err != nil {
-		log.Fatal(err)
-	}
 
 	return tp
 }

--- a/instrumentation/github.com/emicklei/go-restful/otelrestful/example/server.go
+++ b/instrumentation/github.com/emicklei/go-restful/otelrestful/example/server.go
@@ -69,9 +69,6 @@ func initTracer() {
 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 		sdktrace.WithSyncer(exporter),
 	)
-	if err != nil {
-		log.Fatal(err)
-	}
 	otel.SetTracerProvider(tp)
 	tracer = otel.GetTracerProvider().Tracer("go-restful-server", oteltrace.WithInstrumentationVersion("0.1"))
 }

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/example/server.go
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/example/server.go
@@ -60,9 +60,6 @@ func initTracer() {
 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 		sdktrace.WithSyncer(exporter),
 	)
-	if err != nil {
-		log.Fatal(err)
-	}
 	otel.SetTracerProvider(tp)
 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
 }

--- a/instrumentation/github.com/gorilla/mux/otelmux/example/server.go
+++ b/instrumentation/github.com/gorilla/mux/otelmux/example/server.go
@@ -57,9 +57,6 @@ func initTracer() {
 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 		sdktrace.WithSyncer(exporter),
 	)
-	if err != nil {
-		log.Fatal(err)
-	}
 	otel.SetTracerProvider(tp)
 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
 }

--- a/instrumentation/google.golang.org/grpc/otelgrpc/example/config/config.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/example/config/config.go
@@ -33,9 +33,6 @@ func Init() {
 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 		sdktrace.WithSyncer(exporter),
 	)
-	if err != nil {
-		log.Fatal(err)
-	}
 	otel.SetTracerProvider(tp)
 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
 }

--- a/instrumentation/gopkg.in/macaron.v1/otelmacaron/example/server.go
+++ b/instrumentation/gopkg.in/macaron.v1/otelmacaron/example/server.go
@@ -53,9 +53,6 @@ func initTracer() {
 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 		sdktrace.WithSyncer(exporter),
 	)
-	if err != nil {
-		log.Fatal(err)
-	}
 	otel.SetTracerProvider(tp)
 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
 }

--- a/instrumentation/net/http/httptrace/otelhttptrace/example/client/client.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/example/client/client.go
@@ -52,9 +52,6 @@ func initTracer() {
 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 		sdktrace.WithSyncer(exporter),
 	)
-	if err != nil {
-		log.Fatal(err)
-	}
 	otel.SetTracerProvider(tp)
 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
 }

--- a/instrumentation/net/http/httptrace/otelhttptrace/example/server/server.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/example/server/server.go
@@ -47,9 +47,6 @@ func initTracer() {
 		sdktrace.WithSyncer(exporter),
 		sdktrace.WithResource(resource.NewWithAttributes(semconv.ServiceNameKey.String("ExampleService"))),
 	)
-	if err != nil {
-		log.Fatal(err)
-	}
 	otel.SetTracerProvider(tp)
 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
 }

--- a/instrumentation/net/http/otelhttp/example/client/client.go
+++ b/instrumentation/net/http/otelhttp/example/client/client.go
@@ -50,9 +50,6 @@ func initTracer() {
 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 		sdktrace.WithSyncer(exporter),
 	)
-	if err != nil {
-		log.Fatal(err)
-	}
 	otel.SetTracerProvider(tp)
 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
 }

--- a/instrumentation/net/http/otelhttp/example/server/server.go
+++ b/instrumentation/net/http/otelhttp/example/server/server.go
@@ -47,9 +47,6 @@ func initTracer() {
 		sdktrace.WithSyncer(exporter),
 		sdktrace.WithResource(resource.NewWithAttributes(semconv.ServiceNameKey.String("ExampleService"))),
 	)
-	if err != nil {
-		log.Fatal(err)
-	}
 	otel.SetTracerProvider(tp)
 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
 }


### PR DESCRIPTION
These seem like leftovers from #363 where `trace.NewProvider` has been replaced by `trace.NewTracerProvider`