### PR TITLE
Switch from WithSyncer to WithBatcher in examples

### DIFF
--- a/instrumentation/github.com/Shopify/sarama/otelsarama/example/consumer/consumer.go
+++ b/instrumentation/github.com/Shopify/sarama/otelsarama/example/consumer/consumer.go
@@ -37,7 +37,12 @@ var (
 )
 
 func main() {
-	example.InitTracer()
+	tp := example.InitTracer()
+	defer func() {
+		if err := tp.Shutdown(context.Background()); err != nil {
+			log.Printf("Error shutting down tracer provider: %v", err)
+		}
+	}()
 	flag.Parse()
 
 	if *brokers == "" {

--- a/instrumentation/github.com/Shopify/sarama/otelsarama/example/init.go
+++ b/instrumentation/github.com/Shopify/sarama/otelsarama/example/init.go
@@ -28,15 +28,16 @@ const (
 	KafkaTopic = "sarama-instrumentation-example"
 )
 
-func InitTracer() {
+func InitTracer() *sdktrace.TracerProvider {
 	exporter, err := stdout.NewExporter(stdout.WithPrettyPrint())
 	if err != nil {
 		log.Fatal(err)
 	}
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
-		sdktrace.WithSyncer(exporter),
+		sdktrace.WithBatcher(exporter),
 	)
 	otel.SetTracerProvider(tp)
 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}))
+	return tp
 }

--- a/instrumentation/github.com/Shopify/sarama/otelsarama/example/producer/producer.go
+++ b/instrumentation/github.com/Shopify/sarama/otelsarama/example/producer/producer.go
@@ -38,7 +38,12 @@ var (
 )
 
 func main() {
-	example.InitTracer()
+	tp := example.InitTracer()
+	defer func() {
+		if err := tp.Shutdown(context.Background()); err != nil {
+			log.Printf("Error shutting down tracer provider: %v", err)
+		}
+	}()
 	flag.Parse()
 
 	if *brokers == "" {

--- a/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache/example/client.go
+++ b/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache/example/client.go
@@ -22,7 +22,6 @@ import (
 	"github.com/bradfitz/gomemcache/memcache"
 
 	"go.opentelemetry.io/contrib/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache"
-	oteltrace "go.opentelemetry.io/otel/trace"
 
 	oteltracestdout "go.opentelemetry.io/otel/exporters/stdout"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -32,6 +31,11 @@ func main() {
 	var host, port = os.Getenv("HOST"), "11211"
 
 	tp := initTracer()
+	defer func() {
+		if err := tp.Shutdown(context.Background()); err != nil {
+			log.Printf("Error shutting down tracer provider: %v", err)
+		}
+	}()
 	ctx := context.Background()
 
 	c := otelmemcache.NewClientWithTracing(
@@ -73,14 +77,14 @@ func doMemcacheOperations(ctx context.Context, c *otelmemcache.Client) {
 	}
 }
 
-func initTracer() oteltrace.TracerProvider {
+func initTracer() *sdktrace.TracerProvider {
 	exporter, err := oteltracestdout.NewExporter(oteltracestdout.WithPrettyPrint())
 	if err != nil {
 		log.Fatal(err)
 	}
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
-		sdktrace.WithSyncer(exporter),
+		sdktrace.WithBatcher(exporter),
 	)
 
 	return tp

--- a/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache/example/go.mod
+++ b/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache/example/go.mod
@@ -12,5 +12,4 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache v0.20.0
 	go.opentelemetry.io/otel/exporters/stdout v0.20.0
 	go.opentelemetry.io/otel/sdk v0.20.0
-	go.opentelemetry.io/otel/trace v0.20.0
 )

--- a/instrumentation/github.com/labstack/echo/otelecho/example/server.go
+++ b/instrumentation/github.com/labstack/echo/otelecho/example/server.go
@@ -33,7 +33,12 @@ import (
 var tracer = otel.Tracer("gin-server")
 
 func main() {
-	initTracer()
+	tp := initTracer()
+	defer func() {
+		if err := tp.Shutdown(context.Background()); err != nil {
+			log.Printf("Error shutting down tracer provider: %v", err)
+		}
+	}()
 	r := echo.New()
 	r.Use(otelecho.Middleware("my-server"))
 
@@ -51,17 +56,18 @@ func main() {
 	_ = r.Start(":8080")
 }
 
-func initTracer() {
+func initTracer() *sdktrace.TracerProvider {
 	exporter, err := stdout.NewExporter(stdout.WithPrettyPrint())
 	if err != nil {
 		log.Fatal(err)
 	}
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
-		sdktrace.WithSyncer(exporter),
+		sdktrace.WithBatcher(exporter),
 	)
 	otel.SetTracerProvider(tp)
 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
+	return tp
 }
 
 func getUser(ctx context.Context, id string) string {

--- a/instrumentation/google.golang.org/grpc/otelgrpc/example/client/main.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/example/client/main.go
@@ -30,7 +30,12 @@ import (
 )
 
 func main() {
-	config.Init()
+	tp := config.Init()
+	defer func() {
+		if err := tp.Shutdown(context.Background()); err != nil {
+			log.Printf("Error shutting down tracer provider: %v", err)
+		}
+	}()
 
 	var conn *grpc.ClientConn
 	conn, err := grpc.Dial(":7777", grpc.WithInsecure(),

--- a/instrumentation/google.golang.org/grpc/otelgrpc/example/config/config.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/example/config/config.go
@@ -24,15 +24,16 @@ import (
 )
 
 // Init configures an OpenTelemetry exporter and trace provider
-func Init() {
+func Init() *sdktrace.TracerProvider {
 	exporter, err := stdout.NewExporter(stdout.WithPrettyPrint())
 	if err != nil {
 		log.Fatal(err)
 	}
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
-		sdktrace.WithSyncer(exporter),
+		sdktrace.WithBatcher(exporter),
 	)
 	otel.SetTracerProvider(tp)
 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
+	return tp
 }

--- a/instrumentation/google.golang.org/grpc/otelgrpc/example/server/main.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/example/server/main.go
@@ -109,7 +109,12 @@ func (s *server) SayHelloBidiStream(stream api.HelloService_SayHelloBidiStreamSe
 }
 
 func main() {
-	config.Init()
+	tp := config.Init()
+	defer func() {
+		if err := tp.Shutdown(context.Background()); err != nil {
+			log.Printf("Error shutting down tracer provider: %v", err)
+		}
+	}()
 
 	lis, err := net.Listen("tcp", port)
 	if err != nil {

--- a/instrumentation/net/http/otelhttp/example/client/client.go
+++ b/instrumentation/net/http/otelhttp/example/client/client.go
@@ -36,7 +36,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-func initTracer() {
+func initTracer() *sdktrace.TracerProvider {
 	// Create stdout exporter to be able to retrieve
 	// the collected spans.
 	exporter, err := stdout.NewExporter(stdout.WithPrettyPrint())
@@ -48,14 +48,20 @@ func initTracer() {
 	// In a production application, use sdktrace.ProbabilitySampler with a desired probability.
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
-		sdktrace.WithSyncer(exporter),
+		sdktrace.WithBatcher(exporter),
 	)
 	otel.SetTracerProvider(tp)
 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
+	return tp
 }
 
 func main() {
-	initTracer()
+	tp := initTracer()
+	defer func() {
+		if err := tp.Shutdown(context.Background()); err != nil {
+			log.Printf("Error shutting down tracer provider: %v", err)
+		}
+	}()
 	url := flag.String("server", "http://localhost:7777/hello", "server url")
 	flag.Parse()
 

--- a/propagators/opencensus/examples/opentelemetry_server/server.go
+++ b/propagators/opencensus/examples/opentelemetry_server/server.go
@@ -57,9 +57,14 @@ func main() {
 		log.Fatal(err)
 	}
 	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithSyncer(otExporter),
+		sdktrace.WithBatcher(otExporter),
 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 	)
+	defer func() {
+		if err := tp.Shutdown(context.Background()); err != nil {
+			log.Printf("Error shutting down tracer provider: %v", err)
+		}
+	}()
 	otel.SetTracerProvider(tp)
 
 	// Set up a new server with the OpenCensus


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-go/issues/1039, and similar to https://github.com/open-telemetry/opentelemetry-go/pull/2007, but for contrib.

A user accidentally used WithSyncer in their application (though not from this example), which added extra unexplainable latency in their request path. Use WithBatcher and ForceFlush in examples to make it explicit that we are waiting for spans to be sent to stdout at each point, and to discourage the use of WithSyncer.