### PR TITLE
Add document for otelhttp.WithPropagators

### DIFF
--- a/instrumentation/net/http/otelhttp/config.go
+++ b/instrumentation/net/http/otelhttp/config.go
@@ -105,7 +105,7 @@ func WithPublicEndpoint() Option {
 }
 
 // WithPropagators configures specific propagators. If this
-// option isn't specified then
+// option isn't specified, then the global TextMapPropagator is used.
 func WithPropagators(ps propagation.TextMapPropagator) Option {
 	return optionFunc(func(c *config) {
 		c.Propagators = ps


### PR DESCRIPTION
Because the document of otelhttp.WithPropagator was partially missing, I added the rest based on the current implementations.