### PR TITLE
Ensure Integration Tests run with Github Actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -58,6 +58,8 @@ jobs:
           fetch-depth: 0
       - run: mkdir -p $TEST_RESULTS
       - name: Integration test ${{ matrix.target }}
+        env:
+          INTEGRATION: ${{ matrix.target }}
         run: |
           make ${{ matrix.target }}
           find . -name 'coverage.html' > "${TEST_RESULTS}/coverage.lst"


### PR DESCRIPTION
These have been "skipped" since  #476 was merged due to the lack of setting the `INTEGRATION` environment variable prior to running the test.

