### PR TITLE
Fix YAML syntax in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -138,23 +138,23 @@ updates:
       interval: "weekly"
       day: "sunday"
   - package-ecosystem: "gomod"
-      directory: "/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws"
-      labels:
-        - dependencies
-        - go
-        - "Skip Changelog"
-      schedule:
-        interval: "weekly"
-        day: "sunday"
-        - package-ecosystem: "gomod"
-          directory: "/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/example"
-          labels:
-            - dependencies
-            - go
-            - "Skip Changelog"
-          schedule:
-            interval: "weekly"
-            day: "sunday"
+    directory: "/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws"
+    labels:
+      - dependencies
+      - go
+      - "Skip Changelog"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+  - package-ecosystem: "gomod"
+    directory: "/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/example"
+    labels:
+      - dependencies
+      - go
+      - "Skip Changelog"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
   -
     package-ecosystem: "gomod"
     directory: "/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache"


### PR DESCRIPTION
Not entirely sure how this has existed for 5+ months, but it looks to have been introduced in https://github.com/open-telemetry/opentelemetry-go-contrib/pull/621.