### PR TITLE
Add Inject Response Header in gin middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Migrated EC2 resource detector support from root module `go.opentelemetry.io/contrib/detectors/aws` to a separate EC2 resource detector module `go.opentelemetry.io/contrib/detectors/aws/ec2` (#1017)
 - Add `cloud.provider` and `cloud.platform` to AWS detectors. (#1043)
 - `otelhttptrace.NewClientTrace` now redacts known sensitive headers by default. (#879)
+- Add inject response header gin middleware. (#1049)
 
 ### Fixed
 

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/gintrace.go
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/gintrace.go
@@ -74,7 +74,7 @@ func Middleware(service string, opts ...Option) gin.HandlerFunc {
 		}
 		ctx, span := tracer.Start(ctx, spanName, opts...)
 		defer span.End()
-
+		cfg.Propagators.Inject(ctx, propagation.HeaderCarrier(c.Writer.Header()))
 		// pass the span through the request context
 		c.Request = c.Request.WithContext(ctx)
 

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/test/go.mod
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/test/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/gin-gonic/gin v1.7.4
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.22.0
-	go.opentelemetry.io/otel v1.0.0-RC2.0.20210812161231-a8bb0bf89f3b
+	go.opentelemetry.io/otel v1.0.0-RC3
 	go.opentelemetry.io/otel/sdk v1.0.0-RC2.0.20210812161231-a8bb0bf89f3b
-	go.opentelemetry.io/otel/trace v1.0.0-RC2
+	go.opentelemetry.io/otel/trace v1.0.0-RC3
 )
 
 replace go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin => ../

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/test/go.sum
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/test/go.sum
@@ -42,12 +42,13 @@ github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLY
 go.opentelemetry.io/contrib v0.22.0 h1:0F7gDEjgb1WGn4ODIjaCAg75hmqF+UN0LiVgwxsCodc=
 go.opentelemetry.io/contrib v0.22.0/go.mod h1:EH4yDYeNoaTqn/8yCWQmfNB78VHfGX2Jt2bvnvzBlGM=
 go.opentelemetry.io/otel v1.0.0-RC2/go.mod h1:w1thVQ7qbAy8MHb0IFj8a5Q2QU0l2ksf8u/CN8m3NOM=
-go.opentelemetry.io/otel v1.0.0-RC2.0.20210812161231-a8bb0bf89f3b h1:mVdpWpFdeOeGPCpwO95rocgtrkE12gZhDU4LA9K9TNE=
-go.opentelemetry.io/otel v1.0.0-RC2.0.20210812161231-a8bb0bf89f3b/go.mod h1:WrhiZahmIBdsXGO6mYjS6eW6kZzI/9GfGHFpRi8X/Yg=
+go.opentelemetry.io/otel v1.0.0-RC3 h1:kvwiyEkiUT/JaadXzVLI/R1wDO934A7r3Bs2wEe6wqA=
+go.opentelemetry.io/otel v1.0.0-RC3/go.mod h1:Ka5j3ua8tZs4Rkq4Ex3hwgBgOchyPVq5S6P2lz//nKQ=
 go.opentelemetry.io/otel/sdk v1.0.0-RC2.0.20210812161231-a8bb0bf89f3b h1:3L//VzNirHuL0jZSmHFeQOIdGvNmSsfnl4g9UV6ZRcI=
 go.opentelemetry.io/otel/sdk v1.0.0-RC2.0.20210812161231-a8bb0bf89f3b/go.mod h1:RiCEArosW4fWBJshjrl1H4IAzoRwI0sIqfqac5ramT8=
-go.opentelemetry.io/otel/trace v1.0.0-RC2 h1:dunAP0qDULMIT82atj34m5RgvsIK6LcsXf1c/MsYg1w=
 go.opentelemetry.io/otel/trace v1.0.0-RC2/go.mod h1:JPQ+z6nNw9mqEGT8o3eoPTdnNI+Aj5JcxEsVGREIAy4=
+go.opentelemetry.io/otel/trace v1.0.0-RC3 h1:9F0ayEvlxv8BmNmPbU005WK7hC+7KbOazCPZjNa1yME=
+go.opentelemetry.io/otel/trace v1.0.0-RC3/go.mod h1:VUt2TUYd8S2/ZRX09ZDFZQwn2RqfMB5MzO17jBojGxo=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=


### PR DESCRIPTION
Impletment the traceresponse in [W3C Trace-Context HTTP Propagator](https://w3c.github.io/trace-context/#traceresponse-header) and [b3 response header](https://github.com/openzipkin/b3-propagation/blob/master/RATIONALE.md)
* Add Inject Response Header in gin middleware
* Bump gin test's otel trace version to v1.0.0-RC3