### PR TITLE
Add aws instrumentation package to instrumentation README

### DIFF
--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -9,6 +9,7 @@ The following instrumentation packages are provided for popular Go packages and 
 | Instrumentation Package | Metrics | Traces |
 | :---------------------: | :-----: | :----: |
 | [github.com/astaxie/beego](./github.com/astaxie/beego/otelbeego) | ✓ | ✓ |
+| [github.com/aws/aws-sdk-go-v2](./github.com/aws/aws-sdk-go-v2/otelaws)|  | ✓ |
 | [github.com/bradfitz/gomemcache](./github.com/bradfitz/gomemcache/memcache/otelmemcache) |  | ✓ |
 | [github.com/emicklei/go-restful](./github.com/emicklei/go-restful/otelrestful) |  | ✓ |
 | [github.com/gin-gonic/gin](./github.com/gin-gonic/gin/otelgin) |  | ✓ |


### PR DESCRIPTION
**Description:**
This PR adds the aws instrumentation package to the list of packages found in `./instrumentation/README.md`.