### PR TITLE
Add aws-sdk-go-v2 to instrumentation readme

### DIFF
--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -8,6 +8,7 @@ The following instrumentation packages are provided for popular Go packages and 
 
 | Instrumentation Package | Metrics | Traces |
 | :---------------------: | :-----: | :----: |
+| [github.com/aws/aws-sdk-go-v2](./github.com/aws/aws-sdk-go-v2/otelaws) |  | ✓ |
 | [github.com/astaxie/beego](./github.com/astaxie/beego/otelbeego) | ✓ | ✓ |
 | [github.com/bradfitz/gomemcache](./github.com/bradfitz/gomemcache/memcache/otelmemcache) |  | ✓ |
 | [github.com/emicklei/go-restful](./github.com/emicklei/go-restful/otelrestful) |  | ✓ |


### PR DESCRIPTION
Explicitly mention support for  aws-sdk-go-v2. It was added
in #621 but not documented.