### PR TITLE
Add `WithTracerProvider()` func to `httptrace` package

### DIFF
--- a/instrumentation/net/http/httptrace/otelhttptrace/clienttrace.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/clienttrace.go
@@ -147,6 +147,7 @@ type clientTracer struct {
 func NewClientTrace(ctx context.Context, opts ...ClientTraceOption) *httptrace.ClientTrace {
 	ct := &clientTracer{
 		Context:     ctx,
+		tracerProvider: otel.GetTracerProvider(),
 		activeHooks: make(map[string]context.Context),
 		redactedHeaders: map[string]struct{}{
 			"authorization":       {},
@@ -163,7 +164,6 @@ func NewClientTrace(ctx context.Context, opts ...ClientTraceOption) *httptrace.C
 		opt.apply(ct)
 	}
 
-	ct.tracerProvider = otel.GetTracerProvider()
 	ct.tr = ct.tracerProvider.Tracer(
 		"go.opentelemetry.io/otel/instrumentation/httptrace",
 		trace.WithInstrumentationVersion(SemVersion()),

--- a/instrumentation/net/http/httptrace/otelhttptrace/clienttrace.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/clienttrace.go
@@ -112,8 +112,20 @@ func WithInsecureHeaders() ClientTraceOption {
 	})
 }
 
+// WithTracerProvider specifies a tracer provider for creating a tracer.
+// The global provider is used if none is specified.
+func WithTracerProvider(provider trace.TracerProvider) ClientTraceOption {
+	return clientTraceOptionFunc(func(ct *clientTracer) {
+		if provider != nil {
+			ct.tracerProvider = provider
+		}
+	})
+}
+
 type clientTracer struct {
 	context.Context
+
+	tracerProvider 	trace.TracerProvider
 
 	tr trace.Tracer
 
@@ -151,7 +163,8 @@ func NewClientTrace(ctx context.Context, opts ...ClientTraceOption) *httptrace.C
 		opt.apply(ct)
 	}
 
-	ct.tr = otel.GetTracerProvider().Tracer(
+	ct.tracerProvider = otel.GetTracerProvider()
+	ct.tr = ct.tracerProvider.Tracer(
 		"go.opentelemetry.io/otel/instrumentation/httptrace",
 		trace.WithInstrumentationVersion(SemVersion()),
 	)

--- a/instrumentation/net/http/httptrace/otelhttptrace/httptrace.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/httptrace.go
@@ -39,7 +39,7 @@ func (o optionFunc) apply(c *config) {
 }
 
 type config struct {
-	propagators 	propagation.TextMapPropagator
+	propagators propagation.TextMapPropagator
 }
 
 func newConfig(opts []Option) *config {

--- a/instrumentation/net/http/httptrace/otelhttptrace/httptrace.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/httptrace.go
@@ -39,7 +39,6 @@ func (o optionFunc) apply(c *config) {
 }
 
 type config struct {
-	tracerProvider 	trace.TracerProvider
 	propagators 	propagation.TextMapPropagator
 }
 
@@ -49,16 +48,6 @@ func newConfig(opts []Option) *config {
 		o.apply(c)
 	}
 	return c
-}
-
-// WithTracerProvider specifies a tracer provider for creating a tracer.
-// The global provider is used if none is specified.
-func WithTracerProvider(provider trace.TracerProvider) Option {
-	return optionFunc(func(cfg *config) {
-		if provider != nil {
-			cfg.tracerProvider = provider
-		}
-	})
 }
 
 // WithPropagators sets the propagators to use for Extraction and Injection

--- a/instrumentation/net/http/httptrace/otelhttptrace/httptrace.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/httptrace.go
@@ -39,7 +39,8 @@ func (o optionFunc) apply(c *config) {
 }
 
 type config struct {
-	propagators propagation.TextMapPropagator
+	tracerProvider 	trace.TracerProvider
+	propagators 	propagation.TextMapPropagator
 }
 
 func newConfig(opts []Option) *config {
@@ -48,6 +49,16 @@ func newConfig(opts []Option) *config {
 		o.apply(c)
 	}
 	return c
+}
+
+// WithTracerProvider specifies a tracer provider for creating a tracer.
+// The global provider is used if none is specified.
+func WithTracerProvider(provider trace.TracerProvider) Option {
+	return optionFunc(func(cfg *config) {
+		if provider != nil {
+			cfg.tracerProvider = provider
+		}
+	})
 }
 
 // WithPropagators sets the propagators to use for Extraction and Injection


### PR DESCRIPTION
**Description:**
This PR adds the `WithTracerProvider()` function to the `httptrace` package. This is done in `clienttrace.go`.

**Link to tracking Issue:**
#1105 