### PR TITLE
use true/false for ot-tracer-sampled header

### DIFF
--- a/propagators/ot/ot_data_test.go
+++ b/propagators/ot/ot_data_test.go
@@ -198,7 +198,7 @@ var injectHeaders = []injectTest{
 		wantHeaders: map[string]string{
 			traceIDHeader: traceID16Str,
 			spanIDHeader:  spanIDStr,
-			sampledHeader: "1",
+			sampledHeader: "true",
 		},
 	},
 	{
@@ -214,7 +214,7 @@ var injectHeaders = []injectTest{
 		wantHeaders: map[string]string{
 			traceIDHeader:  traceID16Str,
 			spanIDHeader:   spanIDStr,
-			sampledHeader:  "0",
+			sampledHeader:  "false",
 			baggageHeader:  baggageValue,
 			baggageHeader2: baggageValue2,
 		},

--- a/propagators/ot/ot_propagator.go
+++ b/propagators/ot/ot_propagator.go
@@ -66,9 +66,9 @@ func (o OT) Inject(ctx context.Context, carrier propagation.TextMapCarrier) {
 	carrier.Set(spanIDHeader, sc.SpanID().String())
 
 	if sc.IsSampled() {
-		carrier.Set(sampledHeader, "1")
+		carrier.Set(sampledHeader, "true")
 	} else {
-		carrier.Set(sampledHeader, "0")
+		carrier.Set(sampledHeader, "false")
 	}
 
 	for _, m := range baggage.FromContext(ctx).Members() {


### PR DESCRIPTION
Other implementations of the ot trace propagator are setting the values to `true`/`false`, this change is making the go implementation consistent.

See other implementations:
- [Java](https://github.com/open-telemetry/opentelemetry-java/blob/9cea4ef1f92d3186b1bd8296e9daac4281c0f759/extensions/trace-propagators/src/main/java/io/opentelemetry/extension/trace/propagation/OtTracePropagator.java#L73)
- [Python](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/c24c77dd3adcbfe9406b139acaa08d68155d6edb/propagator/opentelemetry-propagator-ot-trace/src/opentelemetry/propagators/ot_trace/__init__.py#L130-L133)
- [Javascript](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/f5851e72512117dbce571a42930a90c560dbf63d/propagators/opentelemetry-propagator-ot-trace/src/OTTracePropagator.ts#L75)