### PR TITLE
Release prep v1.1.1/v0.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [1.1.1/0.26.1] - 2021-11-04
+
 ### Changed
 
 - The `Transport`, `Handler`, and HTTP client convenience wrappers in the `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp` package now use the `TracerProvider` from the parent context if one exists and none was explicitly set when configuring the instrumentation. (#873)
@@ -379,7 +381,8 @@ First official tagged release of `contrib` repository.
 - Prefix support for dogstatsd (#34)
 - Update Go Runtime package to use batch observer (#44)
 
-[Unreleased]: https://github.com/open-telemetry/opentelemetry-go-contrib/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/open-telemetry/opentelemetry-go-contrib/compare/v1.1.1...HEAD
+[1.1.1/0.26.1]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v1.1.1
 [1.1.0/0.26.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v1.1.0
 [1.0.0/0.25.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v1.0.0
 [0.24.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v0.24.0

--- a/detectors/aws/ec2/version.go
+++ b/detectors/aws/ec2/version.go
@@ -16,7 +16,7 @@ package ec2
 
 // Version is the current release version of the EC2 resource detector.
 func Version() string {
-	return "1.1.0"
+	return "1.1.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/detectors/aws/ecs/version.go
+++ b/detectors/aws/ecs/version.go
@@ -16,7 +16,7 @@ package ecs
 
 // Version is the current release version of the ECS resource detector.
 func Version() string {
-	return "1.1.0"
+	return "1.1.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/detectors/aws/eks/version.go
+++ b/detectors/aws/eks/version.go
@@ -16,7 +16,7 @@ package eks
 
 // Version is the current release version of the EKS resource detector.
 func Version() string {
-	return "1.1.0"
+	return "1.1.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/detectors/gcp/version.go
+++ b/detectors/gcp/version.go
@@ -16,7 +16,7 @@ package gcp
 
 // Version is the current release version of the GCP resource detector.
 func Version() string {
-	return "1.1.0"
+	return "1.1.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/exporters/metric/cortex/example/go.mod
+++ b/exporters/metric/cortex/example/go.mod
@@ -8,8 +8,8 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/contrib/exporters/metric/cortex v0.26.0
-	go.opentelemetry.io/contrib/exporters/metric/cortex/utils v0.26.0
+	go.opentelemetry.io/contrib/exporters/metric/cortex v0.26.1
+	go.opentelemetry.io/contrib/exporters/metric/cortex/utils v0.26.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/metric v0.24.0
 	go.opentelemetry.io/otel/sdk v1.1.0

--- a/exporters/metric/cortex/utils/go.mod
+++ b/exporters/metric/cortex/utils/go.mod
@@ -8,5 +8,5 @@ require (
 	github.com/spf13/afero v1.6.0
 	github.com/spf13/viper v1.9.0
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/contrib/exporters/metric/cortex v0.26.0
+	go.opentelemetry.io/contrib/exporters/metric/cortex v0.26.1
 )

--- a/exporters/metric/cortex/utils/version.go
+++ b/exporters/metric/cortex/utils/version.go
@@ -16,7 +16,7 @@ package utils
 
 // Version is the current release version of the Cortex utils module.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/exporters/metric/cortex/version.go
+++ b/exporters/metric/cortex/version.go
@@ -16,7 +16,7 @@ package cortex
 
 // Version is the current release version of the Cortex exporter.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/exporters/metric/datadog/version.go
+++ b/exporters/metric/datadog/version.go
@@ -16,7 +16,7 @@ package datadog
 
 // Version is the current release version of the DataDog exporter.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/exporters/metric/dogstatsd/version.go
+++ b/exporters/metric/dogstatsd/version.go
@@ -16,7 +16,7 @@ package dogstatsd
 
 // Version is the current release version of the dogstatsd exporter.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/instrumentation/github.com/Shopify/sarama/otelsarama/example/go.mod
+++ b/instrumentation/github.com/Shopify/sarama/otelsarama/example/go.mod
@@ -9,7 +9,7 @@ replace (
 
 require (
 	github.com/Shopify/sarama v1.29.1
-	go.opentelemetry.io/contrib/instrumentation/github.com/Shopify/sarama/otelsarama v0.26.0
+	go.opentelemetry.io/contrib/instrumentation/github.com/Shopify/sarama/otelsarama v0.26.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.1.0
 	go.opentelemetry.io/otel/sdk v1.1.0

--- a/instrumentation/github.com/Shopify/sarama/otelsarama/test/go.mod
+++ b/instrumentation/github.com/Shopify/sarama/otelsarama/test/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/Shopify/sarama v1.29.1
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/contrib/instrumentation/github.com/Shopify/sarama/otelsarama v0.26.0
+	go.opentelemetry.io/contrib/instrumentation/github.com/Shopify/sarama/otelsarama v0.26.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/sdk v1.1.0
 	go.opentelemetry.io/otel/trace v1.1.0

--- a/instrumentation/github.com/Shopify/sarama/otelsarama/test/version.go
+++ b/instrumentation/github.com/Shopify/sarama/otelsarama/test/version.go
@@ -16,7 +16,7 @@ package test
 
 // Version is the current release version of the sarama instrumentation test module.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/instrumentation/github.com/Shopify/sarama/otelsarama/version.go
+++ b/instrumentation/github.com/Shopify/sarama/otelsarama/version.go
@@ -16,7 +16,7 @@ package otelsarama
 
 // Version is the current release version of the sarama instrumentation.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/instrumentation/github.com/astaxie/beego/otelbeego/example/go.mod
+++ b/instrumentation/github.com/astaxie/beego/otelbeego/example/go.mod
@@ -11,7 +11,7 @@ replace (
 
 require (
 	github.com/astaxie/beego v1.12.3
-	go.opentelemetry.io/contrib/instrumentation/github.com/astaxie/beego/otelbeego v0.26.0
+	go.opentelemetry.io/contrib/instrumentation/github.com/astaxie/beego/otelbeego v0.26.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.1.0
 	go.opentelemetry.io/otel/sdk v1.1.0

--- a/instrumentation/github.com/astaxie/beego/otelbeego/go.mod
+++ b/instrumentation/github.com/astaxie/beego/otelbeego/go.mod
@@ -11,7 +11,7 @@ replace (
 require (
 	github.com/astaxie/beego v1.12.3
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.26.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.26.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/metric v0.24.0
 	go.opentelemetry.io/otel/trace v1.1.0

--- a/instrumentation/github.com/astaxie/beego/otelbeego/test/go.mod
+++ b/instrumentation/github.com/astaxie/beego/otelbeego/test/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/astaxie/beego v1.12.3
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/contrib/instrumentation/github.com/astaxie/beego/otelbeego v0.26.0
+	go.opentelemetry.io/contrib/instrumentation/github.com/astaxie/beego/otelbeego v0.26.1
 	go.opentelemetry.io/contrib/propagators/b3 v1.1.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/metric v0.24.0

--- a/instrumentation/github.com/astaxie/beego/otelbeego/test/go.mod
+++ b/instrumentation/github.com/astaxie/beego/otelbeego/test/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/astaxie/beego v1.12.3
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/contrib/instrumentation/github.com/astaxie/beego/otelbeego v0.26.0
-	go.opentelemetry.io/contrib/propagators/b3 v1.1.0
+	go.opentelemetry.io/contrib/propagators/b3 v1.1.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/metric v0.24.0
 	go.opentelemetry.io/otel/sdk v1.1.0

--- a/instrumentation/github.com/astaxie/beego/otelbeego/test/version.go
+++ b/instrumentation/github.com/astaxie/beego/otelbeego/test/version.go
@@ -16,7 +16,7 @@ package test
 
 // Version is the current release version of the Beego instrumentation test module.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/instrumentation/github.com/astaxie/beego/otelbeego/version.go
+++ b/instrumentation/github.com/astaxie/beego/otelbeego/version.go
@@ -16,7 +16,7 @@ package otelbeego
 
 // Version is the current release version of the Beego instrumentation.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/example/go.mod
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/example/go.mod
@@ -13,10 +13,10 @@ require (
 	github.com/aws/aws-lambda-go v1.27.0
 	github.com/aws/aws-sdk-go-v2/config v1.9.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.17.0
-	go.opentelemetry.io/contrib/detectors/aws/lambda v0.26.0
-	go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda v0.26.0
-	go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws v0.26.0
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.26.0
+	go.opentelemetry.io/contrib/detectors/aws/lambda v0.26.1
+	go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda v0.26.1
+	go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws v0.26.1
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.26.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.1.0
 	go.opentelemetry.io/otel/sdk v1.1.0

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/test/go.mod
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/test/go.mod
@@ -12,8 +12,8 @@ replace (
 require (
 	github.com/aws/aws-lambda-go v1.27.0
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/contrib/detectors/aws/lambda v0.26.0
-	go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda v0.26.0
+	go.opentelemetry.io/contrib/detectors/aws/lambda v0.26.1
+	go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda v0.26.1
 	go.opentelemetry.io/contrib/propagators/aws v1.1.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/sdk v1.1.0

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/test/go.mod
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/test/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/contrib/detectors/aws/lambda v0.26.0
 	go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda v0.26.0
-	go.opentelemetry.io/contrib/propagators/aws v1.1.0
+	go.opentelemetry.io/contrib/propagators/aws v1.1.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/sdk v1.1.0
 	go.opentelemetry.io/otel/trace v1.1.0

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/version.go
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/version.go
@@ -16,7 +16,7 @@ package otellambda
 
 // Version is the current release version of the AWS Lambda instrumentation.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/xrayconfig/go.mod
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/xrayconfig/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/contrib/detectors/aws/lambda v0.26.0
 	go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda v0.26.0
-	go.opentelemetry.io/contrib/propagators/aws v1.1.0
+	go.opentelemetry.io/contrib/propagators/aws v1.1.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.1.0
 	go.opentelemetry.io/otel/sdk v1.1.0

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/xrayconfig/go.mod
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/xrayconfig/go.mod
@@ -11,8 +11,8 @@ replace (
 require (
 	github.com/aws/aws-lambda-go v1.27.0
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/contrib/detectors/aws/lambda v0.26.0
-	go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda v0.26.0
+	go.opentelemetry.io/contrib/detectors/aws/lambda v0.26.1
+	go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda v0.26.1
 	go.opentelemetry.io/contrib/propagators/aws v1.1.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.1.0

--- a/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/example/go.mod
+++ b/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/example/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.9.0
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.6.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.17.0
-	go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws v0.26.0
+	go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws v0.26.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.1.0
 	go.opentelemetry.io/otel/sdk v1.1.0

--- a/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/test/go.mod
+++ b/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/test/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.10.0
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.12.0
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws v0.26.0
+	go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws v0.26.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/sdk v1.1.0
 	go.opentelemetry.io/otel/trace v1.1.0

--- a/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/test/version.go
+++ b/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/test/version.go
@@ -16,7 +16,7 @@ package test
 
 // Version is the current release version of the AWS intstrumentation test module.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/version.go
+++ b/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/version.go
@@ -16,7 +16,7 @@ package otelaws
 
 // Version is the current release version of the AWS SDKv2 instrumentation.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache/example/go.mod
+++ b/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache/example/go.mod
@@ -9,7 +9,7 @@ replace (
 
 require (
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b
-	go.opentelemetry.io/contrib/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache v0.26.0
+	go.opentelemetry.io/contrib/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache v0.26.1
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.1.0
 	go.opentelemetry.io/otel/sdk v1.1.0
 )

--- a/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache/test/go.mod
+++ b/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache/test/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/contrib v1.1.1
-	go.opentelemetry.io/contrib/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache v0.26.0
+	go.opentelemetry.io/contrib/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache v0.26.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/sdk v1.1.0
 	go.opentelemetry.io/otel/trace v1.1.0

--- a/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache/test/go.mod
+++ b/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache/test/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/contrib v1.1.0
+	go.opentelemetry.io/contrib v1.1.1
 	go.opentelemetry.io/contrib/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache v0.26.0
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/sdk v1.1.0

--- a/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache/test/version.go
+++ b/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache/test/version.go
@@ -16,7 +16,7 @@ package test
 
 // Version is the current release version of the memcached instrumentation test module.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache/version.go
+++ b/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache/version.go
@@ -16,7 +16,7 @@ package otelmemcache
 
 // Version is the current release version of the memcached instrumentation.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/instrumentation/github.com/emicklei/go-restful/otelrestful/example/go.mod
+++ b/instrumentation/github.com/emicklei/go-restful/otelrestful/example/go.mod
@@ -10,7 +10,7 @@ replace (
 
 require (
 	github.com/emicklei/go-restful/v3 v3.7.1
-	go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful v0.26.0
+	go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful v0.26.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.1.0
 	go.opentelemetry.io/otel/sdk v1.1.0

--- a/instrumentation/github.com/emicklei/go-restful/otelrestful/go.mod
+++ b/instrumentation/github.com/emicklei/go-restful/otelrestful/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/emicklei/go-restful/v3 v3.7.1
 	github.com/json-iterator/go v1.1.10 // indirect
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/contrib/propagators/b3 v1.1.0
+	go.opentelemetry.io/contrib/propagators/b3 v1.1.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/trace v1.1.0
 )

--- a/instrumentation/github.com/emicklei/go-restful/otelrestful/test/go.mod
+++ b/instrumentation/github.com/emicklei/go-restful/otelrestful/test/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/emicklei/go-restful/v3 v3.7.1
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful v0.26.0
+	go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful v0.26.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/sdk v1.1.0
 	go.opentelemetry.io/otel/trace v1.1.0

--- a/instrumentation/github.com/emicklei/go-restful/otelrestful/test/version.go
+++ b/instrumentation/github.com/emicklei/go-restful/otelrestful/test/version.go
@@ -16,7 +16,7 @@ package test
 
 // Version is the current release version of the go-restful instrumentation test module.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/instrumentation/github.com/emicklei/go-restful/otelrestful/version.go
+++ b/instrumentation/github.com/emicklei/go-restful/otelrestful/version.go
@@ -16,7 +16,7 @@ package otelrestful
 
 // Version is the current release version of the go-restful instrumentation.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/example/go.mod
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/example/go.mod
@@ -10,7 +10,7 @@ replace (
 
 require (
 	github.com/gin-gonic/gin v1.7.4
-	go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.26.0
+	go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.26.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.1.0
 	go.opentelemetry.io/otel/sdk v1.1.0

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/go.mod
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/go.mod
@@ -10,7 +10,7 @@ replace (
 require (
 	github.com/gin-gonic/gin v1.7.4
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/contrib/propagators/b3 v1.1.0
+	go.opentelemetry.io/contrib/propagators/b3 v1.1.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/trace v1.1.0
 )

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/test/go.mod
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/test/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/gin-gonic/gin v1.7.4
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.26.0
+	go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.26.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/sdk v1.1.0
 	go.opentelemetry.io/otel/trace v1.1.0

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/test/version.go
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/test/version.go
@@ -16,7 +16,7 @@ package test
 
 // Version is the current release version of the gin instrumentation test module.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/version.go
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/version.go
@@ -16,7 +16,7 @@ package otelgin
 
 // Version is the current release version of the gin instrumentation.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/instrumentation/github.com/go-kit/kit/otelkit/example/go.mod
+++ b/instrumentation/github.com/go-kit/kit/otelkit/example/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/gorilla/mux v1.8.0
-	go.opentelemetry.io/contrib/instrumentation/github.com/go-kit/kit/otelkit v0.26.0
+	go.opentelemetry.io/contrib/instrumentation/github.com/go-kit/kit/otelkit v0.26.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.1.0
 	go.opentelemetry.io/otel/sdk v1.1.0

--- a/instrumentation/github.com/go-kit/kit/otelkit/test/go.mod
+++ b/instrumentation/github.com/go-kit/kit/otelkit/test/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/go-kit/kit v0.12.0
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/contrib/instrumentation/github.com/go-kit/kit/otelkit v0.26.0
+	go.opentelemetry.io/contrib/instrumentation/github.com/go-kit/kit/otelkit v0.26.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/sdk v1.1.0
 	go.opentelemetry.io/otel/trace v1.1.0

--- a/instrumentation/github.com/go-kit/kit/otelkit/test/version.go
+++ b/instrumentation/github.com/go-kit/kit/otelkit/test/version.go
@@ -16,7 +16,7 @@ package test
 
 // Version is the current release version of the go-kit instrumentation test module.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/instrumentation/github.com/go-kit/kit/otelkit/version.go
+++ b/instrumentation/github.com/go-kit/kit/otelkit/version.go
@@ -16,7 +16,7 @@ package otelkit
 
 // Version is the current release version of the go-kit instrumentation.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/instrumentation/github.com/gocql/gocql/otelgocql/example/go.mod
+++ b/instrumentation/github.com/gocql/gocql/otelgocql/example/go.mod
@@ -9,7 +9,7 @@ replace (
 
 require (
 	github.com/gocql/gocql v0.0.0-20200624222514-34081eda590e
-	go.opentelemetry.io/contrib/instrumentation/github.com/gocql/gocql/otelgocql v0.26.0
+	go.opentelemetry.io/contrib/instrumentation/github.com/gocql/gocql/otelgocql v0.26.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.24.0
 	go.opentelemetry.io/otel/exporters/zipkin v1.1.0

--- a/instrumentation/github.com/gocql/gocql/otelgocql/test/go.mod
+++ b/instrumentation/github.com/gocql/gocql/otelgocql/test/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/gocql/gocql v0.0.0-20210707082121-9a3953d1826d
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/contrib v1.1.0
+	go.opentelemetry.io/contrib v1.1.1
 	go.opentelemetry.io/contrib/instrumentation/github.com/gocql/gocql/otelgocql v0.26.0
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/metric v0.24.0

--- a/instrumentation/github.com/gocql/gocql/otelgocql/test/go.mod
+++ b/instrumentation/github.com/gocql/gocql/otelgocql/test/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/gocql/gocql v0.0.0-20210707082121-9a3953d1826d
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/contrib v1.1.1
-	go.opentelemetry.io/contrib/instrumentation/github.com/gocql/gocql/otelgocql v0.26.0
+	go.opentelemetry.io/contrib/instrumentation/github.com/gocql/gocql/otelgocql v0.26.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/metric v0.24.0
 	go.opentelemetry.io/otel/sdk v1.1.0

--- a/instrumentation/github.com/gocql/gocql/otelgocql/test/version.go
+++ b/instrumentation/github.com/gocql/gocql/otelgocql/test/version.go
@@ -16,7 +16,7 @@ package test
 
 // Version is the current release version of the gocql instrumentation test module.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/instrumentation/github.com/gocql/gocql/otelgocql/version.go
+++ b/instrumentation/github.com/gocql/gocql/otelgocql/version.go
@@ -16,7 +16,7 @@ package otelgocql
 
 // Version is the current release version of the gocql instrumentation.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/instrumentation/github.com/gorilla/mux/otelmux/example/go.mod
+++ b/instrumentation/github.com/gorilla/mux/otelmux/example/go.mod
@@ -9,7 +9,7 @@ replace (
 
 require (
 	github.com/gorilla/mux v1.8.0
-	go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.26.0
+	go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.26.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.1.0
 	go.opentelemetry.io/otel/sdk v1.1.0

--- a/instrumentation/github.com/gorilla/mux/otelmux/test/go.mod
+++ b/instrumentation/github.com/gorilla/mux/otelmux/test/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/gorilla/mux v1.8.0
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.26.0
+	go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.26.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/sdk v1.1.0
 	go.opentelemetry.io/otel/trace v1.1.0

--- a/instrumentation/github.com/gorilla/mux/otelmux/test/version.go
+++ b/instrumentation/github.com/gorilla/mux/otelmux/test/version.go
@@ -16,7 +16,7 @@ package test
 
 // Version is the current release version of the gorilla/mux instrumentation test module.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/instrumentation/github.com/gorilla/mux/otelmux/version.go
+++ b/instrumentation/github.com/gorilla/mux/otelmux/version.go
@@ -16,7 +16,7 @@ package otelmux
 
 // Version is the current release version of the gorilla/mux instrumentation.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/instrumentation/github.com/labstack/echo/otelecho/example/go.mod
+++ b/instrumentation/github.com/labstack/echo/otelecho/example/go.mod
@@ -10,7 +10,7 @@ replace (
 
 require (
 	github.com/labstack/echo/v4 v4.6.1
-	go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho v0.26.0
+	go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho v0.26.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.1.0
 	go.opentelemetry.io/otel/sdk v1.1.0

--- a/instrumentation/github.com/labstack/echo/otelecho/go.mod
+++ b/instrumentation/github.com/labstack/echo/otelecho/go.mod
@@ -10,7 +10,7 @@ replace (
 require (
 	github.com/labstack/echo/v4 v4.6.1
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/contrib/propagators/b3 v1.1.0
+	go.opentelemetry.io/contrib/propagators/b3 v1.1.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/trace v1.1.0
 )

--- a/instrumentation/github.com/labstack/echo/otelecho/test/go.mod
+++ b/instrumentation/github.com/labstack/echo/otelecho/test/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/labstack/echo/v4 v4.6.1
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho v0.26.0
+	go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho v0.26.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/sdk v1.1.0
 	go.opentelemetry.io/otel/trace v1.1.0

--- a/instrumentation/github.com/labstack/echo/otelecho/test/version.go
+++ b/instrumentation/github.com/labstack/echo/otelecho/test/version.go
@@ -16,7 +16,7 @@ package test
 
 // Version is the current release version of the echo instrumentation test module.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/instrumentation/github.com/labstack/echo/otelecho/version.go
+++ b/instrumentation/github.com/labstack/echo/otelecho/version.go
@@ -16,7 +16,7 @@ package otelecho
 
 // Version is the current release version of the echo instrumentation.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/test/go.mod
+++ b/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/test/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/stretchr/testify v1.7.0
 	go.mongodb.org/mongo-driver v1.7.3
-	go.opentelemetry.io/contrib v1.1.0
+	go.opentelemetry.io/contrib v1.1.1
 	go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo v0.26.0
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/sdk v1.1.0

--- a/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/test/go.mod
+++ b/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/test/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	go.mongodb.org/mongo-driver v1.7.3
 	go.opentelemetry.io/contrib v1.1.1
-	go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo v0.26.0
+	go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo v0.26.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/sdk v1.1.0
 	go.opentelemetry.io/otel/trace v1.1.0

--- a/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/test/version.go
+++ b/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/test/version.go
@@ -16,7 +16,7 @@ package test
 
 // Version is the current release version of the mongo-driver instrumentation test module.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/version.go
+++ b/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/version.go
@@ -16,7 +16,7 @@ package otelmongo
 
 // Version is the current release version of the mongo-driver instrumentation.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/instrumentation/google.golang.org/grpc/otelgrpc/example/go.mod
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/example/go.mod
@@ -9,7 +9,7 @@ replace (
 
 require (
 	github.com/golang/protobuf v1.5.2
-	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.26.0
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.26.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.1.0
 	go.opentelemetry.io/otel/sdk v1.1.0

--- a/instrumentation/google.golang.org/grpc/otelgrpc/test/go.mod
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/test/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/golang/protobuf v1.5.2
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.26.0
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.26.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/sdk v1.1.0
 	go.uber.org/goleak v1.1.12

--- a/instrumentation/google.golang.org/grpc/otelgrpc/test/version.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/test/version.go
@@ -16,7 +16,7 @@ package test
 
 // Version is the current release version of the gRPC instrumentation test module.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/instrumentation/google.golang.org/grpc/otelgrpc/version.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/version.go
@@ -16,7 +16,7 @@ package otelgrpc
 
 // Version is the current release version of the gRPC instrumentation.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/instrumentation/gopkg.in/macaron.v1/otelmacaron/example/go.mod
+++ b/instrumentation/gopkg.in/macaron.v1/otelmacaron/example/go.mod
@@ -9,7 +9,7 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/contrib/instrumentation/gopkg.in/macaron.v1/otelmacaron v0.26.0
+	go.opentelemetry.io/contrib/instrumentation/gopkg.in/macaron.v1/otelmacaron v0.26.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.1.0
 	go.opentelemetry.io/otel/sdk v1.1.0

--- a/instrumentation/gopkg.in/macaron.v1/otelmacaron/go.mod
+++ b/instrumentation/gopkg.in/macaron.v1/otelmacaron/go.mod
@@ -9,7 +9,7 @@ replace (
 
 require (
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/contrib/propagators/b3 v1.1.0
+	go.opentelemetry.io/contrib/propagators/b3 v1.1.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/trace v1.1.0
 	gopkg.in/macaron.v1 v1.4.0

--- a/instrumentation/gopkg.in/macaron.v1/otelmacaron/test/go.mod
+++ b/instrumentation/gopkg.in/macaron.v1/otelmacaron/test/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/contrib/instrumentation/gopkg.in/macaron.v1/otelmacaron v0.26.0
+	go.opentelemetry.io/contrib/instrumentation/gopkg.in/macaron.v1/otelmacaron v0.26.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/sdk v1.1.0
 	go.opentelemetry.io/otel/trace v1.1.0

--- a/instrumentation/gopkg.in/macaron.v1/otelmacaron/test/version.go
+++ b/instrumentation/gopkg.in/macaron.v1/otelmacaron/test/version.go
@@ -16,7 +16,7 @@ package test
 
 // Version is the current release version of the macron instrumentation test module.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/instrumentation/gopkg.in/macaron.v1/otelmacaron/version.go
+++ b/instrumentation/gopkg.in/macaron.v1/otelmacaron/version.go
@@ -16,7 +16,7 @@ package otelmacaron
 
 // Version is the current release version of the macron instrumentation.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/instrumentation/host/example/go.mod
+++ b/instrumentation/host/example/go.mod
@@ -8,7 +8,7 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/contrib/instrumentation/host v0.26.0
+	go.opentelemetry.io/contrib/instrumentation/host v0.26.1
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v0.24.0
 	go.opentelemetry.io/otel/metric v0.24.0
 	go.opentelemetry.io/otel/sdk/metric v0.24.0

--- a/instrumentation/host/version.go
+++ b/instrumentation/host/version.go
@@ -16,7 +16,7 @@ package host
 
 // Version is the current release version of the host instrumentation.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/instrumentation/net/http/httptrace/otelhttptrace/example/go.mod
+++ b/instrumentation/net/http/httptrace/otelhttptrace/example/go.mod
@@ -9,8 +9,8 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.26.0
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.26.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.26.1
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.26.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.1.0
 	go.opentelemetry.io/otel/sdk v1.1.0

--- a/instrumentation/net/http/httptrace/otelhttptrace/test/go.mod
+++ b/instrumentation/net/http/httptrace/otelhttptrace/test/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.26.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.26.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/sdk v1.1.0
 )

--- a/instrumentation/net/http/httptrace/otelhttptrace/test/version.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/test/version.go
@@ -16,7 +16,7 @@ package test
 
 // Version is the current release version of the httptrace instrumentation test module.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/instrumentation/net/http/httptrace/otelhttptrace/version.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/version.go
@@ -16,7 +16,7 @@ package otelhttptrace
 
 // Version is the current release version of the httptrace instrumentation.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/instrumentation/net/http/otelhttp/example/go.mod
+++ b/instrumentation/net/http/otelhttp/example/go.mod
@@ -8,7 +8,7 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.26.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.26.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.1.0
 	go.opentelemetry.io/otel/sdk v1.1.0

--- a/instrumentation/net/http/otelhttp/test/go.mod
+++ b/instrumentation/net/http/otelhttp/test/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.26.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.26.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/metric v0.24.0
 	go.opentelemetry.io/otel/sdk v1.1.0

--- a/instrumentation/net/http/otelhttp/test/version.go
+++ b/instrumentation/net/http/otelhttp/test/version.go
@@ -16,7 +16,7 @@ package test
 
 // Version is the current release version of the otelhttp instrumentation test module.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/instrumentation/net/http/otelhttp/version.go
+++ b/instrumentation/net/http/otelhttp/version.go
@@ -16,7 +16,7 @@ package otelhttp
 
 // Version is the current release version of the otelhttp instrumentation.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/instrumentation/runtime/example/go.mod
+++ b/instrumentation/runtime/example/go.mod
@@ -8,7 +8,7 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/contrib/instrumentation/runtime v0.26.0
+	go.opentelemetry.io/contrib/instrumentation/runtime v0.26.1
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v0.24.0
 	go.opentelemetry.io/otel/metric v0.24.0
 	go.opentelemetry.io/otel/sdk/metric v0.24.0

--- a/instrumentation/runtime/version.go
+++ b/instrumentation/runtime/version.go
@@ -16,7 +16,7 @@ package runtime
 
 // Version is the current release version of the runtime instrumentation.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/propagators/aws/version.go
+++ b/propagators/aws/version.go
@@ -16,7 +16,7 @@ package aws
 
 // Version is the current release version of the AWS XRay propagator.
 func Version() string {
-	return "1.1.0"
+	return "1.1.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/propagators/b3/version.go
+++ b/propagators/b3/version.go
@@ -16,7 +16,7 @@ package b3
 
 // Version is the current release version of the B3 propagator.
 func Version() string {
-	return "1.1.0"
+	return "1.1.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/propagators/jaeger/version.go
+++ b/propagators/jaeger/version.go
@@ -16,7 +16,7 @@ package jaeger
 
 // Version is the current release version of the Jaeger propagator.
 func Version() string {
-	return "1.1.0"
+	return "1.1.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/propagators/opencensus/examples/go.mod
+++ b/propagators/opencensus/examples/go.mod
@@ -4,8 +4,8 @@ go 1.15
 
 require (
 	go.opencensus.io v0.22.6-0.20201102222123-380f4078db9f
-	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.26.0
-	go.opentelemetry.io/contrib/propagators/opencensus v0.26.0
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.26.1
+	go.opentelemetry.io/contrib/propagators/opencensus v0.26.1
 	go.opentelemetry.io/otel v1.1.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.1.0
 	go.opentelemetry.io/otel/sdk v1.1.0

--- a/propagators/opencensus/version.go
+++ b/propagators/opencensus/version.go
@@ -16,7 +16,7 @@ package opencensus
 
 // Version is the current release version of the OpenCensus propagator.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/propagators/ot/version.go
+++ b/propagators/ot/version.go
@@ -16,7 +16,7 @@ package ot
 
 // Version is the current release version of the ot propagator.
 func Version() string {
-	return "1.1.0"
+	return "1.1.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/tools/version.go
+++ b/tools/version.go
@@ -16,7 +16,7 @@ package tools
 
 // Version is the current release version of the OpenTelemetry Contrib tools.
 func Version() string {
-	return "1.1.0"
+	return "1.1.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/version.go
+++ b/version.go
@@ -18,7 +18,7 @@ package contrib // import "go.opentelemetry.io/contrib"
 
 // Version is the current release version of OpenTelemetry Contrib in use.
 func Version() string {
-	return "1.1.0"
+	return "1.1.1"
 	// This string is updated by the pre_release.sh script during release
 }
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -14,7 +14,7 @@
 
 module-sets:
   stable-v1:
-    version: v1.1.0
+    version: v1.1.1
     modules:
       - go.opentelemetry.io/contrib
       - go.opentelemetry.io/contrib/tools
@@ -27,7 +27,7 @@ module-sets:
       - go.opentelemetry.io/contrib/detectors/aws/ecs
       - go.opentelemetry.io/contrib/detectors/aws/eks
   experimental-instrumentation:
-    version: v0.26.0
+    version: v0.26.1
     modules:
       - go.opentelemetry.io/contrib/detectors/aws/lambda
       - go.opentelemetry.io/contrib/propagators/opencensus
@@ -82,7 +82,7 @@ module-sets:
       - go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful/test
       - go.opentelemetry.io/contrib/zpages
   experimental-metrics:
-    version: v0.26.0
+    version: v0.26.1
     modules:
       - go.opentelemetry.io/contrib/exporters/metric/dogstatsd
       - go.opentelemetry.io/contrib/exporters/metric/cortex

--- a/zpages/version.go
+++ b/zpages/version.go
@@ -16,7 +16,7 @@ package zpages
 
 // Version is the current release version of the zpages span processor.
 func Version() string {
-	return "0.26.0"
+	return "0.26.1"
 	// This string is updated by the pre_release.sh script during release
 }
 


### PR DESCRIPTION
### Changed

- The `Transport`, `Handler`, and HTTP client convenience wrappers in the `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp` package now use the `TracerProvider` from the parent context if one exists and none was explicitly set when configuring the instrumentation. (#873)
- Semantic conventions now use `go.opentelemetry.io/otel/semconv/v1.7.0"`. (#1385)