### PR TITLE
otelmux: fix: Do not require calling Write nor WriteHeader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - The `"go.opentelemetry.io/contrib/detector/aws/ecs".Detector` no longer errors if not running in ECS. (#1426, #1428)
-- `go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux` does not
-  require instrumented HTTP handlers to call `Write` nor `WriteHeader` anymore. (#1443)
+- `go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux`
+  does not require from instrumented HTTP handlers to call `Write` nor
+  `WriteHeader` anymore. (#1443)
 
 ## [1.2.0/0.27.0] - 2021-11-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - The `"go.opentelemetry.io/contrib/detector/aws/ecs".Detector` no longer errors if not running in ECS. (#1426, #1428)
+- `go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux` does not
+  require instrumented HTTP handlers to call `Write` nor `WriteHeader` anymore. (#1443)
 
 ## [1.2.0/0.27.0] - 2021-11-15
 
@@ -46,7 +48,7 @@ Update dependency on the `go.opentelemetry.io/otel` project to `v1.1.0`.
 - Add instrumentation for the `github.com/aws/aws-lambda-go` package. (#983)
 - Add resource detector for AWS Lambda. (#983)
 - Add `WithTracerProvider` option for `otelhttptrace.NewClientTrace`. (#1128)
-- Add optional AWS X-Ray configuration module for AWS Lambda Instrumentation (#984)
+- Add optional AWS X-Ray configuration module for AWS Lambda Instrumentation. (#984)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - The `"go.opentelemetry.io/contrib/detector/aws/ecs".Detector` no longer errors if not running in ECS. (#1426, #1428)
 - `go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux`
-  does not require from instrumented HTTP handlers to call `Write` nor
+  does not require instrumented HTTP handlers to call `Write` nor
   `WriteHeader` anymore. (#1443)
 
 ## [1.2.0/0.27.0] - 2021-11-15

--- a/instrumentation/github.com/gorilla/mux/otelmux/mux.go
+++ b/instrumentation/github.com/gorilla/mux/otelmux/mux.go
@@ -83,13 +83,12 @@ var rrwPool = &sync.Pool{
 func getRRW(writer http.ResponseWriter) *recordingResponseWriter {
 	rrw := rrwPool.Get().(*recordingResponseWriter)
 	rrw.written = false
-	rrw.status = 0
+	rrw.status = http.StatusOK
 	rrw.writer = httpsnoop.Wrap(writer, httpsnoop.Hooks{
 		Write: func(next httpsnoop.WriteFunc) httpsnoop.WriteFunc {
 			return func(b []byte) (int, error) {
 				if !rrw.written {
 					rrw.written = true
-					rrw.status = http.StatusOK
 				}
 				return next(b)
 			}

--- a/instrumentation/github.com/gorilla/mux/otelmux/test/mux_test.go
+++ b/instrumentation/github.com/gorilla/mux/otelmux/test/mux_test.go
@@ -31,7 +31,6 @@ import (
 )
 
 func ok(w http.ResponseWriter, _ *http.Request) {
-	w.WriteHeader(http.StatusOK)
 }
 
 func TestSDKIntegration(t *testing.T) {

--- a/instrumentation/github.com/gorilla/mux/otelmux/test/mux_test.go
+++ b/instrumentation/github.com/gorilla/mux/otelmux/test/mux_test.go
@@ -30,8 +30,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-func ok(w http.ResponseWriter, _ *http.Request) {
-}
+func ok(w http.ResponseWriter, _ *http.Request) {}
 
 func TestSDKIntegration(t *testing.T) {
 	sr := tracetest.NewSpanRecorder()


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go-contrib/issues/1387

`go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux` does not require the instrumented HTTP handlers to call `Write` nor `WriteHeader` anymore