### PR TITLE
Extract region name from Cloud Run metadata server response

### DIFF
--- a/detectors/gcp/cloud-run_test.go
+++ b/detectors/gcp/cloud-run_test.go
@@ -85,7 +85,7 @@ func TestCloudRunDetectorExpectSuccess(t *testing.T) {
 	metadata := map[string]string{
 		"project/project-id": "foo",
 		"instance/id":        "bar",
-		"instance/region":    "utopia",
+		"instance/region":    "/projects/123/regions/utopia",
 	}
 	envvars := map[string]string{
 		"K_SERVICE": "x-service",


### PR DESCRIPTION
Previously this was returning a full string like /projects/123/regions/r, which does not match up with what the semvconv.CloudRegionKey value is supposed to be.

Originally filed as GoogleCloudPlatform/opentelemetry-operations-go#227