### PR TITLE
otelhttp: nil check wrappedBody.Close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Upgraded all dependencies on stable modules from `go.opentelemetry.io/otel` from v1.5.0 to v1.6.1. (#2134)
 - Upgraded all dependencies on metric modules from `go.opentelemetry.io/otel` from v0.27.0 to v0.28.0. (#1977)
 
+### Fixed
+
+- otelhttp: Avoid panic by adding nil check to `wrappedBody.Close` (#2164)
+
 ## [1.5.0/0.30.0/0.1.0] - 2022-03-16
 
 ### Added

--- a/instrumentation/net/http/otelhttp/transport.go
+++ b/instrumentation/net/http/otelhttp/transport.go
@@ -186,5 +186,8 @@ func (wb *wrappedBody) Read(b []byte) (int, error) {
 
 func (wb *wrappedBody) Close() error {
 	wb.span.End()
-	return wb.body.Close()
+	if wb.body != nil {
+		return wb.body.Close()
+	}
+	return nil
 }

--- a/instrumentation/net/http/otelhttp/transport_test.go
+++ b/instrumentation/net/http/otelhttp/transport_test.go
@@ -285,7 +285,7 @@ func TestWrappedBodyClosePanic(t *testing.T) {
 	s := new(span)
 	var body io.ReadCloser
 	wb := newWrappedBody(s, body)
-	assert.NoError(t, wb.Close())
+	assert.NotPanics(t, func() { wb.Close() }, "nil body should not panic on close")
 }
 
 func TestWrappedBodyCloseError(t *testing.T) {

--- a/instrumentation/net/http/otelhttp/transport_test.go
+++ b/instrumentation/net/http/otelhttp/transport_test.go
@@ -281,6 +281,13 @@ func TestWrappedBodyClose(t *testing.T) {
 	s.assert(t, true, nil, codes.Unset, "")
 }
 
+func TestWrappedBodyClosePanic(t *testing.T) {
+	s := new(span)
+	var body io.ReadCloser
+	wb := newWrappedBody(s, body)
+	assert.NoError(t, wb.Close())
+}
+
 func TestWrappedBodyCloseError(t *testing.T) {
 	s := new(span)
 	expectedErr := errors.New("test")


### PR DESCRIPTION
We're experimenting with open-telemetry and ran into a panic where `*wrappedBody.Close()` can panic. This seems to be code from 2+ years ago, so I'm surprised we ran into it. 

I'm happy to sign the CLA if this change will be accepted. 