### PR TITLE
[otelhttp] Remove propagation header injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix the `otelmux` middleware by using `SpanKindServer` when deciding the `SpanStatus`.
   This makes `4xx` response codes to not be an error anymore. (#1973)
 - Fixed jaegerremote sampler not behaving properly with per operation strategy set. (#2137)
-- otelhttp: Stopped injecting propagation context into response headers (#2180)
+- Stopped injecting propagation context into response headers in otelhttp. (#2180)
 
 ## [1.6.0/0.31.0] - 2022-03-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix the `otelmux` middleware by using `SpanKindServer` when deciding the `SpanStatus`.
   This makes `4xx` response codes to not be an error anymore. (#1973)
 - Fixed jaegerremote sampler not behaving properly with per operation strategy set. (#2137)
+- otelhttp: Stopped injecting propagation context into response headers (#2180)
 
 ## [1.6.0/0.31.0] - 2022-03-28
 

--- a/instrumentation/net/http/otelhttp/test/handler_test.go
+++ b/instrumentation/net/http/otelhttp/test/handler_test.go
@@ -91,9 +91,6 @@ func TestHandlerBasics(t *testing.T) {
 	if got, expected := rr.Result().StatusCode, http.StatusOK; got != expected {
 		t.Fatalf("got %d, expected %d", got, expected)
 	}
-	if got := rr.Header().Get("Traceparent"); got == "" {
-		t.Fatal("expected non empty trace header")
-	}
 
 	spans := spanRecorder.Ended()
 	if got, expected := len(spans), 1; got != expected {

--- a/instrumentation/net/http/otelhttp/wrap.go
+++ b/instrumentation/net/http/otelhttp/wrap.go
@@ -91,6 +91,5 @@ func (w *respWriterWrapper) WriteHeader(statusCode int) {
 	}
 	w.wroteHeader = true
 	w.statusCode = statusCode
-	w.props.Inject(w.ctx, propagation.HeaderCarrier(w.Header()))
 	w.ResponseWriter.WriteHeader(statusCode)
 }


### PR DESCRIPTION
Current otelhttp instrumentation leaks propagation headers in the response headers.  This behavior is not defined so it should be removed.  Fixes #2163 