### PR TITLE
fix: do not swallow error in otel echo middleware and return it to other middlewares as expected. #2209

### DIFF
--- a/instrumentation/github.com/labstack/echo/otelecho/echo.go
+++ b/instrumentation/github.com/labstack/echo/otelecho/echo.go
@@ -89,8 +89,6 @@ func Middleware(service string, opts ...Option) echo.MiddlewareFunc {
 			err := next(c)
 			if err != nil {
 				span.SetAttributes(attribute.String("echo.error", err.Error()))
-				// invokes the registered HTTP error handler
-				c.Error(err)
 			}
 
 			attrs := semconv.HTTPAttributesFromHTTPStatusCode(c.Response().Status)
@@ -98,7 +96,7 @@ func Middleware(service string, opts ...Option) echo.MiddlewareFunc {
 			span.SetAttributes(attrs...)
 			span.SetStatus(spanStatus, spanMessage)
 
-			return nil
+			return err
 		}
 	}
 }


### PR DESCRIPTION
fix: do not swallow error in otel echo middleware and return it to other middlewares as expected.

Middleware was swallowing the error and it was not passing it to previous middlewares as expected.
Also, when we return the error from the middleware, HTTP error handler is called automatically.

Co-authored-by: Erkan Zileli<erkan.zileli@trendyol.com>
Signed-off-by: Celal Öner <celal.oner@trendyol.com>

Fixes #2209