### PR TITLE
Add missing dependabot entry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -614,6 +614,15 @@ updates:
       interval: weekly
       day: sunday
   - package-ecosystem: gomod
+    directory: /samplers/probability/consistent
+    labels:
+      - dependencies
+      - go
+      - Skip Changelog
+    schedule:
+      interval: weekly
+      day: sunday
+  - package-ecosystem: gomod
     directory: /tools
     labels:
       - dependencies


### PR DESCRIPTION
Module introduce in https://github.com/open-telemetry/opentelemetry-go-contrib/pull/1379