### PR TITLE
feat: Acquire configuration from remote, when sampler is started 

### DIFF
--- a/samplers/jaegerremote/sampler_remote.go
+++ b/samplers/jaegerremote/sampler_remote.go
@@ -124,6 +124,8 @@ func (s *Sampler) pollController() {
 }
 
 func (s *Sampler) pollControllerWithTicker(ticker *time.Ticker) {
+	s.UpdateSampler()
+
 	for {
 		select {
 		case <-ticker.C:


### PR DESCRIPTION
load the configuration from the remote as soon as the sampler is started and the type is remote, instead of waiting for the timer notification