### PR TITLE
Update gcp detector library to v0.32.0

### DIFF
--- a/detectors/gcp/go.mod
+++ b/detectors/gcp/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	cloud.google.com/go/compute v1.6.1
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v0.31.0
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v0.32.0
 	github.com/google/go-cmp v0.5.8
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/otel v1.7.0

--- a/detectors/gcp/go.sum
+++ b/detectors/gcp/go.sum
@@ -54,8 +54,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v0.31.0 h1:EnFLvwFv8onlnjYFSrQ4EMSm6uWRBZHOItR/Tz0Jnqk=
-github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v0.31.0/go.mod h1:s7Gpwj0tk7XnVCm4BQEmx/mbS36SuTCY/vMB2SNxe8o=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v0.32.0 h1:pbODK/s33oiMCVzAGwl0cuB91a+vWNgL6s5eyWOHUtg=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v0.32.0/go.mod h1:s7Gpwj0tk7XnVCm4BQEmx/mbS36SuTCY/vMB2SNxe8o=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/detectors/gcp/types.go
+++ b/detectors/gcp/types.go
@@ -23,7 +23,6 @@ type gcpDetector interface {
 	GKEAvailabilityZoneOrRegion() (string, gcp.LocationType, error)
 	GKEClusterName() (string, error)
 	GKEHostID() (string, error)
-	GKEHostName() (string, error)
 	FaaSName() (string, error)
 	FaaSVersion() (string, error)
 	FaaSID() (string, error)


### PR DESCRIPTION
Supersedes https://github.com/open-telemetry/opentelemetry-go-contrib/pull/2337.

The `GKEHostName()` function was removed because of https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/10486, but I forgot to remove it from the test interface.  I had removed its usage from the detector already, but didn't remove it from the interface, so this isn't a functional change.