### PR TITLE
[net/http] add http.server.active_requests metric

### DIFF
--- a/instrumentation/net/http/otelhttp/common.go
+++ b/instrumentation/net/http/otelhttp/common.go
@@ -35,6 +35,7 @@ const (
 	RequestContentLength  = "http.server.request_content_length"  // Incoming request bytes total
 	ResponseContentLength = "http.server.response_content_length" // Incoming response bytes total
 	ServerLatency         = "http.server.duration"                // Incoming end to end duration, microseconds
+	ActiveRequest         = "http.server.active_requests"         // Active request count
 )
 
 // Filter is a predicate used to determine whether a given http.request should


### PR DESCRIPTION
Signed-off-by: Ziqi Zhao <zhaoziqi9146@gmail.com>

Enhance instrumentation library [otelhttp](https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/instrumentation/net/http/otelhttp) for `net/http` to satisfy opentelemetry [http server metric semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/http-metrics.md#http-server).

This PR added missed metric `http.server.active_requests` for server 