### PR TITLE
gRPC: evaluate config only once

### DIFF
--- a/instrumentation/google.golang.org/grpc/otelgrpc/grpctrace.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/grpctrace.go
@@ -137,7 +137,11 @@ func (s *metadataSupplier) Keys() []string {
 // requests.
 func Inject(ctx context.Context, md *metadata.MD, opts ...Option) {
 	c := newConfig(opts)
-	c.Propagators.Inject(ctx, &metadataSupplier{
+	inject(ctx, md, c.Propagators)
+}
+
+func inject(ctx context.Context, md *metadata.MD, propagators propagation.TextMapPropagator) {
+	propagators.Inject(ctx, &metadataSupplier{
 		metadata: md,
 	})
 }
@@ -147,7 +151,11 @@ func Inject(ctx context.Context, md *metadata.MD, opts ...Option) {
 // This function is meant to be used on incoming requests.
 func Extract(ctx context.Context, md *metadata.MD, opts ...Option) (baggage.Baggage, trace.SpanContext) {
 	c := newConfig(opts)
-	ctx = c.Propagators.Extract(ctx, &metadataSupplier{
+	return extract(ctx, md, c.Propagators)
+}
+
+func extract(ctx context.Context, md *metadata.MD, propagators propagation.TextMapPropagator) (baggage.Baggage, trace.SpanContext) {
+	ctx = propagators.Extract(ctx, &metadataSupplier{
 		metadata: md,
 	})
 

--- a/instrumentation/google.golang.org/grpc/otelgrpc/interceptor.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/interceptor.go
@@ -100,7 +100,7 @@ func UnaryClientInterceptor(opts ...Option) grpc.UnaryClientInterceptor {
 		)
 		defer span.End()
 
-		Inject(ctx, &metadataCopy, opts...)
+		inject(ctx, &metadataCopy, cfg.Propagators)
 		ctx = metadata.NewOutgoingContext(ctx, metadataCopy)
 
 		messageSent.Event(ctx, 1, req)
@@ -278,7 +278,7 @@ func StreamClientInterceptor(opts ...Option) grpc.StreamClientInterceptor {
 			trace.WithAttributes(attr...),
 		)
 
-		Inject(ctx, &metadataCopy, opts...)
+		inject(ctx, &metadataCopy, cfg.Propagators)
 		ctx = metadata.NewOutgoingContext(ctx, metadataCopy)
 
 		s, err := streamer(ctx, desc, cc, method, callOpts...)

--- a/instrumentation/google.golang.org/grpc/otelgrpc/interceptor.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/interceptor.go
@@ -65,6 +65,7 @@ var (
 // UnaryClientInterceptor returns a grpc.UnaryClientInterceptor suitable
 // for use in a grpc.Dial call.
 func UnaryClientInterceptor(opts ...Option) grpc.UnaryClientInterceptor {
+	cfg := newConfig(opts)
 	return func(
 		ctx context.Context,
 		method string,
@@ -73,7 +74,6 @@ func UnaryClientInterceptor(opts ...Option) grpc.UnaryClientInterceptor {
 		invoker grpc.UnaryInvoker,
 		callOpts ...grpc.CallOption,
 	) error {
-		cfg := newConfig(opts)
 		i := &InterceptorInfo{
 			Method: method,
 			Typ:    UnaryClient,
@@ -244,6 +244,7 @@ func (w *clientStream) sendStreamEvent(eventType streamEventType, err error) {
 // StreamClientInterceptor returns a grpc.StreamClientInterceptor suitable
 // for use in a grpc.Dial call.
 func StreamClientInterceptor(opts ...Option) grpc.StreamClientInterceptor {
+	cfg := newConfig(opts)
 	return func(
 		ctx context.Context,
 		desc *grpc.StreamDesc,
@@ -252,7 +253,6 @@ func StreamClientInterceptor(opts ...Option) grpc.StreamClientInterceptor {
 		streamer grpc.Streamer,
 		callOpts ...grpc.CallOption,
 	) (grpc.ClientStream, error) {
-		cfg := newConfig(opts)
 		i := &InterceptorInfo{
 			Method: method,
 			Typ:    StreamClient,
@@ -312,13 +312,13 @@ func StreamClientInterceptor(opts ...Option) grpc.StreamClientInterceptor {
 // UnaryServerInterceptor returns a grpc.UnaryServerInterceptor suitable
 // for use in a grpc.NewServer call.
 func UnaryServerInterceptor(opts ...Option) grpc.UnaryServerInterceptor {
+	cfg := newConfig(opts)
 	return func(
 		ctx context.Context,
 		req interface{},
 		info *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
 	) (interface{}, error) {
-		cfg := newConfig(opts)
 		i := &InterceptorInfo{
 			UnaryServerInfo: info,
 			Typ:             UnaryServer,
@@ -408,6 +408,7 @@ func wrapServerStream(ctx context.Context, ss grpc.ServerStream) *serverStream {
 // StreamServerInterceptor returns a grpc.StreamServerInterceptor suitable
 // for use in a grpc.NewServer call.
 func StreamServerInterceptor(opts ...Option) grpc.StreamServerInterceptor {
+	cfg := newConfig(opts)
 	return func(
 		srv interface{},
 		ss grpc.ServerStream,
@@ -415,7 +416,6 @@ func StreamServerInterceptor(opts ...Option) grpc.StreamServerInterceptor {
 		handler grpc.StreamHandler,
 	) error {
 		ctx := ss.Context()
-		cfg := newConfig(opts)
 		i := &InterceptorInfo{
 			StreamServerInfo: info,
 			Typ:              StreamServer,


### PR DESCRIPTION
Currently options are evaluated twice on each request. Change code to evaluate options only a single time when an interceptor is created.