### PR TITLE
Support proto v2 message format, drop v1 format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - google.golang.org/grpc/otelgrpc: Avoid getting a new Tracer for every RPC.
 - google.golang.org/grpc/otelgrpc: Deprecate Inject and Extract public funcs.
+- google.golang.org/grpc/otelgrpc: Conditionally compute message size for tracing events using proto v2 API rather than legacy v1 API.
 
 ## [0.36.1]
 

--- a/instrumentation/google.golang.org/grpc/otelgrpc/example/go.mod
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/example/go.mod
@@ -21,5 +21,5 @@ require (
 	golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7 // indirect
 	golang.org/x/text v0.3.3 // indirect
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
-	google.golang.org/protobuf v1.27.1 // indirect
+	google.golang.org/protobuf v1.28.1 // indirect
 )

--- a/instrumentation/google.golang.org/grpc/otelgrpc/example/go.sum
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/example/go.sum
@@ -95,8 +95,8 @@ google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
-google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
+google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/instrumentation/google.golang.org/grpc/otelgrpc/go.mod
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/go.mod
@@ -3,21 +3,21 @@ module go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgr
 go 1.18
 
 require (
-	github.com/golang/protobuf v1.5.2
 	go.opentelemetry.io/otel v1.10.0
 	go.opentelemetry.io/otel/trace v1.10.0
 	google.golang.org/grpc v1.49.0
+	google.golang.org/protobuf v1.28.1
 )
 
 require (
 	cloud.google.com/go v0.34.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
 	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
 	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 // indirect
 	golang.org/x/text v0.3.3 // indirect
 	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
-	google.golang.org/protobuf v1.27.1 // indirect
 )

--- a/instrumentation/google.golang.org/grpc/otelgrpc/go.sum
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/go.sum
@@ -95,8 +95,8 @@ google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
-google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
+google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/instrumentation/google.golang.org/grpc/otelgrpc/interceptor.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/interceptor.go
@@ -21,13 +21,12 @@ import (
 	"io"
 	"net"
 
-	"github.com/golang/protobuf/proto" // nolint:staticcheck
-
 	"google.golang.org/grpc"
 	grpc_codes "google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc/internal"
 	"go.opentelemetry.io/otel/attribute"
@@ -42,6 +41,9 @@ type messageType attribute.KeyValue
 // passed context with id and size (if message is a proto message).
 func (m messageType) Event(ctx context.Context, id int, message interface{}) {
 	span := trace.SpanFromContext(ctx)
+	if !span.IsRecording() {
+		return
+	}
 	if p, ok := message.(proto.Message); ok {
 		span.AddEvent("message", trace.WithAttributes(
 			attribute.KeyValue(m),

--- a/instrumentation/google.golang.org/grpc/otelgrpc/test/go.mod
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/test/go.mod
@@ -3,13 +3,13 @@ module go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgr
 go 1.18
 
 require (
-	github.com/golang/protobuf v1.5.2
 	github.com/stretchr/testify v1.8.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.36.1
 	go.opentelemetry.io/otel v1.10.0
 	go.opentelemetry.io/otel/sdk v1.10.0
 	go.uber.org/goleak v1.2.0
 	google.golang.org/grpc v1.49.0
+	google.golang.org/protobuf v1.28.1
 )
 
 require (
@@ -17,6 +17,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/otel/trace v1.10.0 // indirect
@@ -26,7 +27,6 @@ require (
 	golang.org/x/text v0.3.3 // indirect
 	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
-	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/instrumentation/google.golang.org/grpc/otelgrpc/test/go.sum
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/test/go.sum
@@ -111,8 +111,8 @@ google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
-google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
+google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/instrumentation/google.golang.org/grpc/otelgrpc/test/interceptor_test.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/test/interceptor_test.go
@@ -30,15 +30,16 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
 
-	"github.com/golang/protobuf/proto" //nolint:staticcheck
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 	"google.golang.org/grpc"
 	grpc_codes "google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/interop/grpc_testing"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 func getSpanFromRecorder(sr *tracetest.SpanRecorder, name string) (trace.ReadOnlySpan, bool) {
@@ -65,18 +66,6 @@ func (mcuici *mockUICInvoker) invoker(ctx context.Context, method string, req, r
 	return nil
 }
 
-type mockProtoMessage struct{}
-
-func (mm *mockProtoMessage) Reset() {
-}
-
-func (mm *mockProtoMessage) String() string {
-	return "mock"
-}
-
-func (mm *mockProtoMessage) ProtoMessage() {
-}
-
 func TestUnaryClientInterceptor(t *testing.T) {
 	clientConn, err := grpc.Dial("fake:connection", grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
@@ -88,8 +77,8 @@ func TestUnaryClientInterceptor(t *testing.T) {
 	tp := trace.NewTracerProvider(trace.WithSpanProcessor(sr))
 	unaryInterceptor := otelgrpc.UnaryClientInterceptor(otelgrpc.WithTracerProvider(tp))
 
-	req := &mockProtoMessage{}
-	reply := &mockProtoMessage{}
+	req := &grpc_testing.SimpleRequest{}
+	reply := &grpc_testing.SimpleResponse{}
 	uniInterceptorInvoker := &mockUICInvoker{}
 
 	checks := []struct {
@@ -115,12 +104,12 @@ func TestUnaryClientInterceptor(t *testing.T) {
 				{
 					otelgrpc.RPCMessageTypeKey:             attribute.StringValue("SENT"),
 					otelgrpc.RPCMessageIDKey:               attribute.IntValue(1),
-					otelgrpc.RPCMessageUncompressedSizeKey: attribute.IntValue(proto.Size(proto.Message(req))),
+					otelgrpc.RPCMessageUncompressedSizeKey: attribute.IntValue(proto.Size(req)),
 				},
 				{
 					otelgrpc.RPCMessageTypeKey:             attribute.StringValue("RECEIVED"),
 					otelgrpc.RPCMessageIDKey:               attribute.IntValue(1),
-					otelgrpc.RPCMessageUncompressedSizeKey: attribute.IntValue(proto.Size(proto.Message(reply))),
+					otelgrpc.RPCMessageUncompressedSizeKey: attribute.IntValue(proto.Size(reply)),
 				},
 			},
 		},
@@ -139,12 +128,12 @@ func TestUnaryClientInterceptor(t *testing.T) {
 				{
 					otelgrpc.RPCMessageTypeKey:             attribute.StringValue("SENT"),
 					otelgrpc.RPCMessageIDKey:               attribute.IntValue(1),
-					otelgrpc.RPCMessageUncompressedSizeKey: attribute.IntValue(proto.Size(proto.Message(req))),
+					otelgrpc.RPCMessageUncompressedSizeKey: attribute.IntValue(proto.Size(req)),
 				},
 				{
 					otelgrpc.RPCMessageTypeKey:             attribute.StringValue("RECEIVED"),
 					otelgrpc.RPCMessageIDKey:               attribute.IntValue(1),
-					otelgrpc.RPCMessageUncompressedSizeKey: attribute.IntValue(proto.Size(proto.Message(reply))),
+					otelgrpc.RPCMessageUncompressedSizeKey: attribute.IntValue(proto.Size(reply)),
 				},
 			},
 		},
@@ -163,12 +152,12 @@ func TestUnaryClientInterceptor(t *testing.T) {
 				{
 					otelgrpc.RPCMessageTypeKey:             attribute.StringValue("SENT"),
 					otelgrpc.RPCMessageIDKey:               attribute.IntValue(1),
-					otelgrpc.RPCMessageUncompressedSizeKey: attribute.IntValue(proto.Size(proto.Message(req))),
+					otelgrpc.RPCMessageUncompressedSizeKey: attribute.IntValue(proto.Size(req)),
 				},
 				{
 					otelgrpc.RPCMessageTypeKey:             attribute.StringValue("RECEIVED"),
 					otelgrpc.RPCMessageIDKey:               attribute.IntValue(1),
-					otelgrpc.RPCMessageUncompressedSizeKey: attribute.IntValue(proto.Size(proto.Message(reply))),
+					otelgrpc.RPCMessageUncompressedSizeKey: attribute.IntValue(proto.Size(reply)),
 				},
 			},
 		},
@@ -188,12 +177,12 @@ func TestUnaryClientInterceptor(t *testing.T) {
 				{
 					otelgrpc.RPCMessageTypeKey:             attribute.StringValue("SENT"),
 					otelgrpc.RPCMessageIDKey:               attribute.IntValue(1),
-					otelgrpc.RPCMessageUncompressedSizeKey: attribute.IntValue(proto.Size(proto.Message(req))),
+					otelgrpc.RPCMessageUncompressedSizeKey: attribute.IntValue(proto.Size(req)),
 				},
 				{
 					otelgrpc.RPCMessageTypeKey:             attribute.StringValue("RECEIVED"),
 					otelgrpc.RPCMessageIDKey:               attribute.IntValue(1),
-					otelgrpc.RPCMessageUncompressedSizeKey: attribute.IntValue(proto.Size(proto.Message(reply))),
+					otelgrpc.RPCMessageUncompressedSizeKey: attribute.IntValue(proto.Size(reply)),
 				},
 			},
 			expectErr: true,
@@ -211,12 +200,12 @@ func TestUnaryClientInterceptor(t *testing.T) {
 				{
 					otelgrpc.RPCMessageTypeKey:             attribute.StringValue("SENT"),
 					otelgrpc.RPCMessageIDKey:               attribute.IntValue(1),
-					otelgrpc.RPCMessageUncompressedSizeKey: attribute.IntValue(proto.Size(proto.Message(req))),
+					otelgrpc.RPCMessageUncompressedSizeKey: attribute.IntValue(proto.Size(req)),
 				},
 				{
 					otelgrpc.RPCMessageTypeKey:             attribute.StringValue("RECEIVED"),
 					otelgrpc.RPCMessageIDKey:               attribute.IntValue(1),
-					otelgrpc.RPCMessageUncompressedSizeKey: attribute.IntValue(proto.Size(proto.Message(reply))),
+					otelgrpc.RPCMessageUncompressedSizeKey: attribute.IntValue(proto.Size(reply)),
 				},
 			},
 		},
@@ -235,12 +224,12 @@ func TestUnaryClientInterceptor(t *testing.T) {
 				{
 					otelgrpc.RPCMessageTypeKey:             attribute.StringValue("SENT"),
 					otelgrpc.RPCMessageIDKey:               attribute.IntValue(1),
-					otelgrpc.RPCMessageUncompressedSizeKey: attribute.IntValue(proto.Size(proto.Message(req))),
+					otelgrpc.RPCMessageUncompressedSizeKey: attribute.IntValue(proto.Size(req)),
 				},
 				{
 					otelgrpc.RPCMessageTypeKey:             attribute.StringValue("RECEIVED"),
 					otelgrpc.RPCMessageIDKey:               attribute.IntValue(1),
-					otelgrpc.RPCMessageUncompressedSizeKey: attribute.IntValue(proto.Size(proto.Message(reply))),
+					otelgrpc.RPCMessageUncompressedSizeKey: attribute.IntValue(proto.Size(reply)),
 				},
 			},
 		},
@@ -277,7 +266,7 @@ func eventAttrMap(events []trace.Event) []map[attribute.Key]attribute.Value {
 type mockClientStream struct {
 	Desc *grpc.StreamDesc
 	Ctx  context.Context
-	msgs []mockProtoMessage
+	msgs []grpc_testing.SimpleResponse
 }
 
 func (mockClientStream) SendMsg(m interface{}) error { return nil }
@@ -299,9 +288,9 @@ type clientStreamOpts struct {
 }
 
 func newMockClientStream(opts clientStreamOpts) *mockClientStream {
-	var msgs []mockProtoMessage
+	var msgs []grpc_testing.SimpleResponse
 	for i := 0; i < opts.NumRecvMsgs; i++ {
-		msgs = append(msgs, mockProtoMessage{})
+		msgs = append(msgs, grpc_testing.SimpleResponse{})
 	}
 	return &mockClientStream{msgs: msgs}
 }
@@ -347,8 +336,8 @@ func TestStreamClientInterceptorOnBIDIStream(t *testing.T) {
 	_, ok := getSpanFromRecorder(sr, name)
 	require.False(t, ok, "span should not end while stream is open")
 
-	req := &mockProtoMessage{}
-	reply := &mockProtoMessage{}
+	req := &grpc_testing.SimpleRequest{}
+	reply := &grpc_testing.SimpleResponse{}
 
 	// send and receive fake data
 	for i := 0; i < 10; i++ {
@@ -414,8 +403,8 @@ func TestStreamClientInterceptorOnUnidirectionalClientServerStream(t *testing.T)
 	_, ok := getSpanFromRecorder(sr, name)
 	require.False(t, ok, "span should not end while stream is open")
 
-	req := &mockProtoMessage{}
-	reply := &mockProtoMessage{}
+	req := &grpc_testing.SimpleRequest{}
+	reply := &grpc_testing.SimpleResponse{}
 
 	// send fake data
 	for i := 0; i < 10; i++ {
@@ -509,8 +498,8 @@ func TestStreamClientInterceptorCancelContext(t *testing.T) {
 	_, ok := getSpanFromRecorder(sr, name)
 	require.False(t, ok, "span should not ended while stream is open")
 
-	req := &mockProtoMessage{}
-	reply := &mockProtoMessage{}
+	req := &grpc_testing.SimpleRequest{}
+	reply := &grpc_testing.SimpleResponse{}
 
 	// send and receive fake data
 	for i := 0; i < 10; i++ {
@@ -581,7 +570,7 @@ func TestServerInterceptorError(t *testing.T) {
 	handler := func(_ context.Context, _ interface{}) (interface{}, error) {
 		return nil, deniedErr
 	}
-	_, err := usi(context.Background(), &mockProtoMessage{}, &grpc.UnaryServerInfo{}, handler)
+	_, err := usi(context.Background(), &grpc_testing.SimpleRequest{}, &grpc.UnaryServerInfo{}, handler)
 	require.Error(t, err)
 	assert.Equal(t, err, deniedErr)
 

--- a/propagators/opencensus/examples/go.mod
+++ b/propagators/opencensus/examples/go.mod
@@ -25,7 +25,7 @@ require (
 	golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7 // indirect
 	golang.org/x/text v0.3.3 // indirect
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
-	google.golang.org/protobuf v1.27.1 // indirect
+	google.golang.org/protobuf v1.28.1 // indirect
 )
 
 replace (

--- a/propagators/opencensus/examples/go.sum
+++ b/propagators/opencensus/examples/go.sum
@@ -120,8 +120,8 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
-google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
+google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go-contrib/issues/1028.

Currently, the size is only calculated for v1 messages and not for v2. This is because type assertion checks for the v1 interface.

We have two options:

- Add type check for v2 interface and support both v1 and v2 messages.
- Drop support for v1 and support v2 only.

This PR proposes to drop v1 support as the API has been deprecated for quite a while and most users should have migrated to v2 already. This should fix the performance problem by never calculating the size for v1 messages. Instead, the size will be efficiently calculated for v2 messages.