### PR TITLE
fix comments for HealthCheck filter

### DIFF
--- a/instrumentation/google.golang.org/grpc/otelgrpc/filters/filters.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/filters/filters.go
@@ -151,7 +151,7 @@ func ServicePrefix(pre string) otelgrpc.Filter {
 }
 
 // HealthCheck returns a Filter that returns true if the request's
-// is not health check defined by gRPC Health Checking Protocol.
+// service name is health check defined by gRPC Health Checking Protocol.
 // https://github.com/grpc/grpc/blob/master/doc/health-checking.md
 func HealthCheck() otelgrpc.Filter {
 	return ServicePrefix("grpc.health.v1.Health")


### PR DESCRIPTION
This is a follow up PR for #2572. As commented in https://github.com/open-telemetry/opentelemetry-go-contrib/pull/2672#pullrequestreview-1074799969, the comments on HealthCheck filter is incorrect and this issue fixes that. Fixes #2674.
