### PR TITLE
Fix changelog release link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -546,8 +546,8 @@ First official tagged release of `contrib` repository.
 - Prefix support for dogstatsd (#34)
 - Update Go Runtime package to use batch observer (#44)
 
-[Unreleased]: https://github.com/open-telemetry/opentelemetry-go-contrib/compare/v0.36.0...HEAD
-[0.36.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v0.36.0
+[Unreleased]: https://github.com/open-telemetry/opentelemetry-go-contrib/compare/zpages/v0.36.0...HEAD
+[0.36.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/zpages/v0.36.0
 [1.10.0/0.35.0/0.5.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v1.10.0
 [1.9.0/0.34.0/0.4.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v1.9.0
 [1.8.0/0.33.0]: https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v1.8.0


### PR DESCRIPTION
Erroneous link introduced in https://github.com/open-telemetry/opentelemetry-go-contrib/pull/2781