### PR TITLE
Drop support for Go 1.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
   compatibility-test:
     strategy:
       matrix:
-        go-version: [1.19, 1.18, 1.17]
+        go-version: [1.19, 1.18]
         os: [ubuntu-latest, macos-latest, windows-latest]
         # GitHub Actions does not support arm* architectures on default
         # runners. It is possible to acomplish this with a self-hosted runner

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Removed
+
+- Drop support for Go 1.17.
+  The project currently only supports Go 1.18 and above. (#2785)
+
 ## [0.36.0]
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ go-mod-tidy/%: DIR=$*
 go-mod-tidy/%:
 	@echo "$(GO) mod tidy in $(DIR)" \
 		&& cd $(DIR) \
-		&& $(GO) mod tidy -compat=1.17
+		&& $(GO) mod tidy -compat=1.18
 
 .PHONY: misspell
 misspell: | $(MISSPELL)

--- a/README.md
+++ b/README.md
@@ -46,19 +46,14 @@ This project is tested on the following systems.
 | ------- | ---------- | ------------ |
 | Ubuntu  | 1.19       | amd64        |
 | Ubuntu  | 1.18       | amd64        |
-| Ubuntu  | 1.17       | amd64        |
 | Ubuntu  | 1.19       | 386          |
 | Ubuntu  | 1.18       | 386          |
-| Ubuntu  | 1.17       | 386          |
 | MacOS   | 1.19       | amd64        |
 | MacOS   | 1.18       | amd64        |
-| MacOS   | 1.17       | amd64        |
 | Windows | 1.19       | amd64        |
 | Windows | 1.18       | amd64        |
-| Windows | 1.17       | amd64        |
 | Windows | 1.19       | 386          |
 | Windows | 1.18       | 386          |
-| Windows | 1.17       | 386          |
 
 While this project should work for other systems, no compatibility guarantees
 are made for those systems currently.

--- a/detectors/aws/ec2/go.mod
+++ b/detectors/aws/ec2/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/detectors/aws/ec2
 
-go 1.17
+go 1.18
 
 require (
 	github.com/aws/aws-sdk-go v1.44.96

--- a/detectors/aws/ecs/go.mod
+++ b/detectors/aws/ecs/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/detectors/aws/ecs
 
-go 1.17
+go 1.18
 
 require (
 	github.com/stretchr/testify v1.8.0

--- a/detectors/aws/eks/go.mod
+++ b/detectors/aws/eks/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/detectors/aws/eks
 
-go 1.17
+go 1.18
 
 require (
 	github.com/stretchr/testify v1.8.0

--- a/detectors/aws/lambda/go.mod
+++ b/detectors/aws/lambda/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/detectors/aws/lambda
 
-go 1.17
+go 1.18
 
 require (
 	github.com/stretchr/testify v1.8.0

--- a/detectors/gcp/go.mod
+++ b/detectors/gcp/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/detectors/gcp
 
-go 1.17
+go 1.18
 
 require (
 	cloud.google.com/go/compute v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module go.opentelemetry.io/contrib
 
-go 1.17
+go 1.18

--- a/instrumentation/github.com/Shopify/sarama/otelsarama/example/go.mod
+++ b/instrumentation/github.com/Shopify/sarama/otelsarama/example/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/Shopify/sarama/otelsarama/example
 
-go 1.17
+go 1.18
 
 replace go.opentelemetry.io/contrib/instrumentation/github.com/Shopify/sarama/otelsarama => ../
 

--- a/instrumentation/github.com/Shopify/sarama/otelsarama/go.mod
+++ b/instrumentation/github.com/Shopify/sarama/otelsarama/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/Shopify/sarama/otelsarama
 
-go 1.17
+go 1.18
 
 require (
 	github.com/Shopify/sarama v1.36.0

--- a/instrumentation/github.com/Shopify/sarama/otelsarama/test/go.mod
+++ b/instrumentation/github.com/Shopify/sarama/otelsarama/test/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/Shopify/sarama/otelsarama/test
 
-go 1.17
+go 1.18
 
 require (
 	github.com/Shopify/sarama v1.36.0

--- a/instrumentation/github.com/astaxie/beego/otelbeego/example/Dockerfile
+++ b/instrumentation/github.com/astaxie/beego/otelbeego/example/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.17-alpine AS base
+FROM golang:1.18-alpine AS base
 COPY . /src/
 WORKDIR /src/instrumentation/github.com/astaxie/beego/otelbeego/example
 

--- a/instrumentation/github.com/astaxie/beego/otelbeego/example/go.mod
+++ b/instrumentation/github.com/astaxie/beego/otelbeego/example/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/astaxie/beego/otelbeego/example
 
-go 1.17
+go 1.18
 
 replace (
 	go.opentelemetry.io/contrib/instrumentation/github.com/astaxie/beego/otelbeego => ../

--- a/instrumentation/github.com/astaxie/beego/otelbeego/go.mod
+++ b/instrumentation/github.com/astaxie/beego/otelbeego/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/astaxie/beego/otelbeego
 
-go 1.17
+go 1.18
 
 replace go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp => ../../../../net/http/otelhttp
 

--- a/instrumentation/github.com/astaxie/beego/otelbeego/test/go.mod
+++ b/instrumentation/github.com/astaxie/beego/otelbeego/test/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/astaxie/beego/otelbeego/test
 
-go 1.17
+go 1.18
 
 require (
 	github.com/astaxie/beego v1.12.3

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/example/Dockerfile
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/example/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.17 AS base
+FROM golang:1.18 AS base
 COPY . /src/
 WORKDIR /src/instrumentation/github.com/aws/aws-lambda-go/otellambda/example
 RUN apt-get update

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/example/go.mod
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/example/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda/example
 
-go 1.17
+go 1.18
 
 replace (
 	go.opentelemetry.io/contrib/detectors/aws/lambda => ../../../../../../detectors/aws/lambda

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/go.mod
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda
 
-go 1.17
+go 1.18
 
 require (
 	github.com/aws/aws-lambda-go v1.34.1

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/test/go.mod
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/test/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda/test
 
-go 1.17
+go 1.18
 
 replace (
 	go.opentelemetry.io/contrib/detectors/aws/lambda => ../../../../../../detectors/aws/lambda

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/xrayconfig/go.mod
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/xrayconfig/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda/xrayconfig
 
-go 1.17
+go 1.18
 
 replace (
 	go.opentelemetry.io/contrib/detectors/aws/lambda => ../../../../../../detectors/aws/lambda

--- a/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/example/Dockerfile
+++ b/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/example/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.17-alpine AS base
+FROM golang:1.18-alpine AS base
 COPY . /src/
 WORKDIR /src/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/example
 

--- a/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/example/go.mod
+++ b/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/example/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/example
 
-go 1.17
+go 1.18
 
 replace go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws => ../
 

--- a/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/go.mod
+++ b/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws
 
-go 1.17
+go 1.18
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.16.14

--- a/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/test/go.mod
+++ b/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/test/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/test
 
-go 1.17
+go 1.18
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.16.14

--- a/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache/example/Dockerfile
+++ b/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache/example/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.17-alpine AS base
+FROM golang:1.18-alpine AS base
 COPY . /src/
 WORKDIR /src/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache/example
 

--- a/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache/example/go.mod
+++ b/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache/example/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache/example
 
-go 1.17
+go 1.18
 
 replace go.opentelemetry.io/contrib/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache => ../
 

--- a/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache/go.mod
+++ b/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache
 
-go 1.17
+go 1.18
 
 require (
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b

--- a/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache/test/go.mod
+++ b/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache/test/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/bradfitz/gomemcache/memcache/otelmemcache/test
 
-go 1.17
+go 1.18
 
 require (
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b

--- a/instrumentation/github.com/emicklei/go-restful/otelrestful/example/Dockerfile
+++ b/instrumentation/github.com/emicklei/go-restful/otelrestful/example/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.17-alpine AS base
+FROM golang:1.18-alpine AS base
 COPY . /src/
 WORKDIR /src/instrumentation/github.com/emicklei/go-restful/otelrestful/example
 

--- a/instrumentation/github.com/emicklei/go-restful/otelrestful/example/docker-compose.yml
+++ b/instrumentation/github.com/emicklei/go-restful/otelrestful/example/docker-compose.yml
@@ -14,7 +14,7 @@
 version: "3.7"
 services:
   go-restful-client:
-    image: golang:1.17-alpine
+    image: golang:1.18-alpine
     networks:
       - example
     command:

--- a/instrumentation/github.com/emicklei/go-restful/otelrestful/example/go.mod
+++ b/instrumentation/github.com/emicklei/go-restful/otelrestful/example/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful/example
 
-go 1.17
+go 1.18
 
 replace (
 	go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful => ../

--- a/instrumentation/github.com/emicklei/go-restful/otelrestful/go.mod
+++ b/instrumentation/github.com/emicklei/go-restful/otelrestful/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful
 
-go 1.17
+go 1.18
 
 replace go.opentelemetry.io/contrib/propagators/b3 => ../../../../../propagators/b3
 

--- a/instrumentation/github.com/emicklei/go-restful/otelrestful/test/go.mod
+++ b/instrumentation/github.com/emicklei/go-restful/otelrestful/test/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful/test
 
-go 1.17
+go 1.18
 
 require (
 	github.com/emicklei/go-restful/v3 v3.9.0

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/example/go.mod
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/example/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin/example
 
-go 1.17
+go 1.18
 
 replace (
 	go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin => ../

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/go.mod
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin
 
-go 1.17
+go 1.18
 
 replace go.opentelemetry.io/contrib/propagators/b3 => ../../../../../propagators/b3
 

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/test/go.mod
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/test/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin/test
 
-go 1.17
+go 1.18
 
 require (
 	github.com/gin-gonic/gin v1.8.1

--- a/instrumentation/github.com/go-kit/kit/otelkit/example/go.mod
+++ b/instrumentation/github.com/go-kit/kit/otelkit/example/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/go-kit/kit/otelkit/example
 
-go 1.17
+go 1.18
 
 require (
 	github.com/gorilla/mux v1.8.0

--- a/instrumentation/github.com/go-kit/kit/otelkit/go.mod
+++ b/instrumentation/github.com/go-kit/kit/otelkit/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/go-kit/kit/otelkit
 
-go 1.17
+go 1.18
 
 require (
 	github.com/go-kit/kit v0.12.0

--- a/instrumentation/github.com/go-kit/kit/otelkit/test/go.mod
+++ b/instrumentation/github.com/go-kit/kit/otelkit/test/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/go-kit/kit/otelkit/test
 
-go 1.17
+go 1.18
 
 require (
 	github.com/go-kit/kit v0.12.0

--- a/instrumentation/github.com/gocql/gocql/otelgocql/go.mod
+++ b/instrumentation/github.com/gocql/gocql/otelgocql/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/gocql/gocql/otelgocql
 
-go 1.17
+go 1.18
 
 require (
 	github.com/gocql/gocql v0.0.0-20200624222514-34081eda590e

--- a/instrumentation/github.com/gocql/gocql/otelgocql/test/go.mod
+++ b/instrumentation/github.com/gocql/gocql/otelgocql/test/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/gocql/gocql/otelgocql/test
 
-go 1.17
+go 1.18
 
 require (
 	github.com/gocql/gocql v0.0.0-20210707082121-9a3953d1826d

--- a/instrumentation/github.com/gorilla/mux/otelmux/example/go.mod
+++ b/instrumentation/github.com/gorilla/mux/otelmux/example/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux/example
 
-go 1.17
+go 1.18
 
 replace go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux => ../
 

--- a/instrumentation/github.com/gorilla/mux/otelmux/go.mod
+++ b/instrumentation/github.com/gorilla/mux/otelmux/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux
 
-go 1.17
+go 1.18
 
 require (
 	github.com/felixge/httpsnoop v1.0.3

--- a/instrumentation/github.com/gorilla/mux/otelmux/test/go.mod
+++ b/instrumentation/github.com/gorilla/mux/otelmux/test/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux/test
 
-go 1.17
+go 1.18
 
 require (
 	github.com/gorilla/mux v1.8.0

--- a/instrumentation/github.com/labstack/echo/otelecho/example/go.mod
+++ b/instrumentation/github.com/labstack/echo/otelecho/example/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho/example
 
-go 1.17
+go 1.18
 
 replace (
 	go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho => ../

--- a/instrumentation/github.com/labstack/echo/otelecho/go.mod
+++ b/instrumentation/github.com/labstack/echo/otelecho/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho
 
-go 1.17
+go 1.18
 
 replace go.opentelemetry.io/contrib/propagators/b3 => ../../../../../propagators/b3
 

--- a/instrumentation/github.com/labstack/echo/otelecho/test/go.mod
+++ b/instrumentation/github.com/labstack/echo/otelecho/test/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho/test
 
-go 1.17
+go 1.18
 
 require (
 	github.com/labstack/echo/v4 v4.9.0

--- a/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/go.mod
+++ b/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo
 
-go 1.17
+go 1.18
 
 require (
 	go.mongodb.org/mongo-driver v1.10.2

--- a/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/test/go.mod
+++ b/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/test/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/test
 
-go 1.17
+go 1.18
 
 require (
 	github.com/stretchr/testify v1.8.0

--- a/instrumentation/google.golang.org/grpc/otelgrpc/example/go.mod
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/example/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc/example
 
-go 1.17
+go 1.18
 
 replace go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc => ../
 

--- a/instrumentation/google.golang.org/grpc/otelgrpc/go.mod
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc
 
-go 1.17
+go 1.18
 
 require (
 	github.com/golang/protobuf v1.5.2

--- a/instrumentation/google.golang.org/grpc/otelgrpc/test/go.mod
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/test/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc/test
 
-go 1.17
+go 1.18
 
 require (
 	github.com/golang/protobuf v1.5.2

--- a/instrumentation/gopkg.in/macaron.v1/otelmacaron/example/go.mod
+++ b/instrumentation/gopkg.in/macaron.v1/otelmacaron/example/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/gopkg.in/macaron.v1/otelmacaron/example
 
-go 1.17
+go 1.18
 
 replace (
 	go.opentelemetry.io/contrib/instrumentation/gopkg.in/macaron.v1/otelmacaron => ../

--- a/instrumentation/gopkg.in/macaron.v1/otelmacaron/go.mod
+++ b/instrumentation/gopkg.in/macaron.v1/otelmacaron/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/gopkg.in/macaron.v1/otelmacaron
 
-go 1.17
+go 1.18
 
 replace go.opentelemetry.io/contrib/propagators/b3 => ../../../../propagators/b3
 

--- a/instrumentation/gopkg.in/macaron.v1/otelmacaron/test/go.mod
+++ b/instrumentation/gopkg.in/macaron.v1/otelmacaron/test/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/gopkg.in/macaron.v1/otelmacaron/test
 
-go 1.17
+go 1.18
 
 require (
 	github.com/stretchr/testify v1.8.0

--- a/instrumentation/host/go.mod
+++ b/instrumentation/host/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/host
 
-go 1.17
+go 1.18
 
 require (
 	github.com/shirou/gopsutil/v3 v3.22.8

--- a/instrumentation/net/http/httptrace/otelhttptrace/example/Dockerfile
+++ b/instrumentation/net/http/httptrace/otelhttptrace/example/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.17-alpine AS base
+FROM golang:1.18-alpine AS base
 COPY . /src/
 WORKDIR /src/instrumentation/net/http/httptrace/otelhttptrace/example
 

--- a/instrumentation/net/http/httptrace/otelhttptrace/example/go.mod
+++ b/instrumentation/net/http/httptrace/otelhttptrace/example/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace/example
 
-go 1.17
+go 1.18
 
 replace (
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace => ../

--- a/instrumentation/net/http/httptrace/otelhttptrace/go.mod
+++ b/instrumentation/net/http/httptrace/otelhttptrace/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace
 
-go 1.17
+go 1.18
 
 require (
 	github.com/google/go-cmp v0.5.9

--- a/instrumentation/net/http/httptrace/otelhttptrace/test/go.mod
+++ b/instrumentation/net/http/httptrace/otelhttptrace/test/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace/test
 
-go 1.17
+go 1.18
 
 require (
 	github.com/stretchr/testify v1.8.0

--- a/instrumentation/net/http/otelhttp/example/Dockerfile
+++ b/instrumentation/net/http/otelhttp/example/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.17-alpine AS base
+FROM golang:1.18-alpine AS base
 COPY . /src/
 WORKDIR /src/instrumentation/net/http/otelhttp/example
 

--- a/instrumentation/net/http/otelhttp/example/go.mod
+++ b/instrumentation/net/http/otelhttp/example/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/example
 
-go 1.17
+go 1.18
 
 replace go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp => ../
 

--- a/instrumentation/net/http/otelhttp/go.mod
+++ b/instrumentation/net/http/otelhttp/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
 
-go 1.17
+go 1.18
 
 require (
 	github.com/felixge/httpsnoop v1.0.3

--- a/instrumentation/net/http/otelhttp/test/go.mod
+++ b/instrumentation/net/http/otelhttp/test/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/test
 
-go 1.17
+go 1.18
 
 require (
 	github.com/stretchr/testify v1.8.0

--- a/instrumentation/runtime/go.mod
+++ b/instrumentation/runtime/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/runtime
 
-go 1.17
+go 1.18
 
 require go.opentelemetry.io/otel/metric v0.32.0
 

--- a/propagators/autoprop/go.mod
+++ b/propagators/autoprop/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/propagators/autoprop
 
-go 1.17
+go 1.18
 
 require (
 	github.com/stretchr/testify v1.8.0

--- a/propagators/aws/go.mod
+++ b/propagators/aws/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/propagators/aws
 
-go 1.17
+go 1.18
 
 require (
 	github.com/stretchr/testify v1.8.0

--- a/propagators/b3/go.mod
+++ b/propagators/b3/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/propagators/b3
 
-go 1.17
+go 1.18
 
 require (
 	github.com/google/go-cmp v0.5.9

--- a/propagators/jaeger/go.mod
+++ b/propagators/jaeger/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/propagators/jaeger
 
-go 1.17
+go 1.18
 
 require (
 	github.com/google/go-cmp v0.5.9

--- a/propagators/opencensus/examples/go.mod
+++ b/propagators/opencensus/examples/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/propagators/opencensus/examples
 
-go 1.17
+go 1.18
 
 require (
 	go.opencensus.io v0.22.6-0.20201102222123-380f4078db9f

--- a/propagators/opencensus/go.mod
+++ b/propagators/opencensus/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/propagators/opencensus
 
-go 1.17
+go 1.18
 
 require (
 	github.com/google/go-cmp v0.5.9

--- a/propagators/ot/go.mod
+++ b/propagators/ot/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/propagators/ot
 
-go 1.17
+go 1.18
 
 require (
 	github.com/google/go-cmp v0.5.9

--- a/samplers/aws/xray/go.mod
+++ b/samplers/aws/xray/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/samplers/aws/xray
 
-go 1.17
+go 1.18
 
 require (
 	github.com/go-logr/logr v1.2.3

--- a/samplers/jaegerremote/example/go.mod
+++ b/samplers/jaegerremote/example/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/samplers/jaegerremote/example
 
-go 1.17
+go 1.18
 
 require (
 	github.com/davecgh/go-spew v1.1.1

--- a/samplers/jaegerremote/go.mod
+++ b/samplers/jaegerremote/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/samplers/jaegerremote
 
-go 1.17
+go 1.18
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/samplers/probability/consistent/go.mod
+++ b/samplers/probability/consistent/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/samplers/probability/consistent
 
-go 1.17
+go 1.18
 
 require (
 	github.com/stretchr/testify v1.8.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/tools
 
-go 1.17
+go 1.18
 
 exclude github.com/blizzy78/varnamelen v0.6.1
 

--- a/zpages/go.mod
+++ b/zpages/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/zpages
 
-go 1.17
+go 1.18
 
 require (
 	github.com/stretchr/testify v1.8.0


### PR DESCRIPTION
Follow up to https://github.com/open-telemetry/opentelemetry-go/pull/3179