### PR TITLE
Add Go install step to create-dependabot-pr action

### DIFF
--- a/.github/workflows/create-dependabot-pr.yml
+++ b/.github/workflows/create-dependabot-pr.yml
@@ -7,6 +7,11 @@ jobs:
   create-pr:
     runs-on: ubuntu-latest
     steps:
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+
       - uses: actions/checkout@v3
 
       - name: Install zsh


### PR DESCRIPTION
The default Go version on the Ubuntu image the job runs on is 1.17. This fails to run the project that requires Go >= 1.18. Resolve this by explicitly installing Go 1.19.