### PR TITLE
Avoid getting a new Tracer for every RPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+
+### Changed
+
+- google.golang.org/grpc/otelgrpc: Avoid getting a new Tracer for every RPC.
+
 ## [0.36.1]
 
 ### Changed

--- a/instrumentation/google.golang.org/grpc/otelgrpc/interceptor.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/interceptor.go
@@ -66,6 +66,11 @@ var (
 // for use in a grpc.Dial call.
 func UnaryClientInterceptor(opts ...Option) grpc.UnaryClientInterceptor {
 	cfg := newConfig(opts)
+	tracer := cfg.TracerProvider.Tracer(
+		instrumentationName,
+		trace.WithInstrumentationVersion(SemVersion()),
+	)
+
 	return func(
 		ctx context.Context,
 		method string,
@@ -84,11 +89,6 @@ func UnaryClientInterceptor(opts ...Option) grpc.UnaryClientInterceptor {
 
 		requestMetadata, _ := metadata.FromOutgoingContext(ctx)
 		metadataCopy := requestMetadata.Copy()
-
-		tracer := cfg.TracerProvider.Tracer(
-			instrumentationName,
-			trace.WithInstrumentationVersion(SemVersion()),
-		)
 
 		name, attr := spanInfo(method, cc.Target())
 		var span trace.Span
@@ -245,6 +245,11 @@ func (w *clientStream) sendStreamEvent(eventType streamEventType, err error) {
 // for use in a grpc.Dial call.
 func StreamClientInterceptor(opts ...Option) grpc.StreamClientInterceptor {
 	cfg := newConfig(opts)
+	tracer := cfg.TracerProvider.Tracer(
+		instrumentationName,
+		trace.WithInstrumentationVersion(SemVersion()),
+	)
+
 	return func(
 		ctx context.Context,
 		desc *grpc.StreamDesc,
@@ -263,11 +268,6 @@ func StreamClientInterceptor(opts ...Option) grpc.StreamClientInterceptor {
 
 		requestMetadata, _ := metadata.FromOutgoingContext(ctx)
 		metadataCopy := requestMetadata.Copy()
-
-		tracer := cfg.TracerProvider.Tracer(
-			instrumentationName,
-			trace.WithInstrumentationVersion(SemVersion()),
-		)
 
 		name, attr := spanInfo(method, cc.Target())
 		var span trace.Span
@@ -313,6 +313,11 @@ func StreamClientInterceptor(opts ...Option) grpc.StreamClientInterceptor {
 // for use in a grpc.NewServer call.
 func UnaryServerInterceptor(opts ...Option) grpc.UnaryServerInterceptor {
 	cfg := newConfig(opts)
+	tracer := cfg.TracerProvider.Tracer(
+		instrumentationName,
+		trace.WithInstrumentationVersion(SemVersion()),
+	)
+
 	return func(
 		ctx context.Context,
 		req interface{},
@@ -332,11 +337,6 @@ func UnaryServerInterceptor(opts ...Option) grpc.UnaryServerInterceptor {
 
 		bags, spanCtx := Extract(ctx, &metadataCopy, opts...)
 		ctx = baggage.ContextWithBaggage(ctx, bags)
-
-		tracer := cfg.TracerProvider.Tracer(
-			instrumentationName,
-			trace.WithInstrumentationVersion(SemVersion()),
-		)
 
 		name, attr := spanInfo(info.FullMethod, peerFromCtx(ctx))
 		ctx, span := tracer.Start(
@@ -409,6 +409,11 @@ func wrapServerStream(ctx context.Context, ss grpc.ServerStream) *serverStream {
 // for use in a grpc.NewServer call.
 func StreamServerInterceptor(opts ...Option) grpc.StreamServerInterceptor {
 	cfg := newConfig(opts)
+	tracer := cfg.TracerProvider.Tracer(
+		instrumentationName,
+		trace.WithInstrumentationVersion(SemVersion()),
+	)
+
 	return func(
 		srv interface{},
 		ss grpc.ServerStream,
@@ -429,11 +434,6 @@ func StreamServerInterceptor(opts ...Option) grpc.StreamServerInterceptor {
 
 		bags, spanCtx := Extract(ctx, &metadataCopy, opts...)
 		ctx = baggage.ContextWithBaggage(ctx, bags)
-
-		tracer := cfg.TracerProvider.Tracer(
-			instrumentationName,
-			trace.WithInstrumentationVersion(SemVersion()),
-		)
 
 		name, attr := spanInfo(info.FullMethod, peerFromCtx(ctx))
 		ctx, span := tracer.Start(


### PR DESCRIPTION
@open-telemetry/go-approvers I believe you should do this optimization for all your instrumentations, since it does not make any sense to retrieve a new Tracer (with same arguments) every request.