### PR TITLE
Optimize otelgrpc, avoid unnecessary allocations and copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-
 ### Changed
 
 - google.golang.org/grpc/otelgrpc: Avoid getting a new Tracer for every RPC.
+- google.golang.org/grpc/otelgrpc: Deprecate Inject and Extract public funcs.
 
 ## [0.36.1]
 


### PR DESCRIPTION
Depends on https://github.com/open-telemetry/opentelemetry-go-contrib/pull/2835