### PR TITLE
Rename tracer name to echo-server

### DIFF
--- a/instrumentation/github.com/labstack/echo/otelecho/example/server.go
+++ b/instrumentation/github.com/labstack/echo/otelecho/example/server.go
@@ -30,7 +30,7 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
-var tracer = otel.Tracer("gin-server")
+var tracer = otel.Tracer("echo-server")
 
 func main() {
 	tp, err := initTracer()


### PR DESCRIPTION
This example is about echo, so makes sense to use echo-server, not gin-server.