### PR TITLE
inject context before handling downstream for grpc/http server

### DIFF
--- a/instrumentation/google.golang.org/grpc/otelgrpc/interceptor.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/interceptor.go
@@ -346,6 +346,7 @@ func UnaryServerInterceptor(opts ...Option) grpc.UnaryServerInterceptor {
 			cfg.rpcServerDuration.Record(ctx, int64(elapsedTime), attr...)
 		}(time.Now())
 
+		ctx = inject(ctx, cfg.Propagators)
 		resp, err := handler(ctx, req)
 		if err != nil {
 			s, _ := status.FromError(err)

--- a/instrumentation/net/http/otelhttp/handler.go
+++ b/instrumentation/net/http/otelhttp/handler.go
@@ -200,6 +200,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	labeler := &Labeler{}
 	ctx = injectLabeler(ctx, labeler)
+	h.propagators.Inject(ctx, propagation.HeaderCarrier(r.Header))
 
 	h.handler.ServeHTTP(w, r.WithContext(ctx))
 


### PR DESCRIPTION
With current implementation, http/grpc server does not propagate context to downstream anymore. It does not function well in distributed tracing scenario. For example, in our case, http endpoint forward request to grpc service, and grpc service query an external grpc service etc. With current implementation, these traces will be separate traces instead of one. I fixed the issue by injecting context before handling downstream in grpc/http server in this PR. 