### PR TITLE
[otelsarama] Add producer/consumer metrics instrumentation

### DIFF
--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -51,7 +51,7 @@ The following instrumentation packages are provided for popular Go packages and 
 | [github.com/gocql/gocql](./github.com/gocql/gocql/otelgocql) | ✓ | ✓ |
 | [github.com/gorilla/mux](./github.com/gorilla/mux/otelmux) |  | ✓ |
 | [github.com/labstack/echo](./github.com/labstack/echo/otelecho) |  | ✓ |
-| [github.com/Shopify/sarama](./github.com/Shopify/sarama/otelsarama) |  | ✓ |
+| [github.com/Shopify/sarama](./github.com/Shopify/sarama/otelsarama) | ✓ | ✓ |
 | [go.mongodb.org/mongo-driver](./go.mongodb.org/mongo-driver/mongo/otelmongo) |  | ✓ |
 | [google.golang.org/grpc](./google.golang.org/grpc/otelgrpc) | ✓ | ✓ |
 | [gopkg.in/macaron.v1](./gopkg.in/macaron.v1/otelmacaron) |  | ✓ |

--- a/instrumentation/github.com/Shopify/sarama/otelsarama/consumer.go
+++ b/instrumentation/github.com/Shopify/sarama/otelsarama/consumer.go
@@ -67,3 +67,9 @@ func WrapConsumer(c sarama.Consumer, opts ...Option) sarama.Consumer {
 		opts:     opts,
 	}
 }
+
+func StartConsumerMetrics(saramaConfig *sarama.Config, opts ...Option) error {
+	cfg := newConfig(opts...)
+
+	return startConsumerMetric(cfg.Meter, saramaConfig.MetricRegistry)
+}

--- a/instrumentation/github.com/Shopify/sarama/otelsarama/example/go.mod
+++ b/instrumentation/github.com/Shopify/sarama/otelsarama/example/go.mod
@@ -32,6 +32,9 @@ require (
 	github.com/klauspost/compress v1.15.11 // indirect
 	github.com/pierrec/lz4/v4 v4.1.17 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
+	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v0.33.0 // indirect
+	go.opentelemetry.io/otel/metric v0.33.0 // indirect
+	go.opentelemetry.io/otel/sdk/metric v0.33.0 // indirect
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa // indirect
 	golang.org/x/net v0.0.0-20220927171203-f486391704dc // indirect
 	golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 // indirect

--- a/instrumentation/github.com/Shopify/sarama/otelsarama/example/go.sum
+++ b/instrumentation/github.com/Shopify/sarama/otelsarama/example/go.sum
@@ -56,10 +56,16 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 go.opentelemetry.io/otel v1.11.1 h1:4WLLAmcfkmDk2ukNXJyq3/kiz/3UzCaYq6PskJsaou4=
 go.opentelemetry.io/otel v1.11.1/go.mod h1:1nNhXBbWSD0nsL38H6btgnFN2k4i0sNLHNNMZMSbUGE=
+go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v0.33.0 h1:hlnyYcK61UzruaUssIZvCHl72qSxGB1R55RexLKjFs8=
+go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v0.33.0/go.mod h1:GD6hP1UBb3pVN4IIFH1iMuRiWEVDy1E/7/g1rYQiJyc=
 go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.11.1 h1:3Yvzs7lgOw8MmbxmLRsQGwYdCubFmUHSooKaEhQunFQ=
 go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.11.1/go.mod h1:pyHDt0YlyuENkD2VwHsiRDf+5DfI3EH7pfhUYW6sQUE=
+go.opentelemetry.io/otel/metric v0.33.0 h1:xQAyl7uGEYvrLAiV/09iTJlp1pZnQ9Wl793qbVvED1E=
+go.opentelemetry.io/otel/metric v0.33.0/go.mod h1:QlTYc+EnYNq/M2mNk1qDDMRLpqCOj2f/r5c7Fd5FYaI=
 go.opentelemetry.io/otel/sdk v1.11.1 h1:F7KmQgoHljhUuJyA+9BiU+EkJfyX5nVVF4wyzWZpKxs=
 go.opentelemetry.io/otel/sdk v1.11.1/go.mod h1:/l3FE4SupHJ12TduVjUkZtlfFqDCQJlOlithYrdktys=
+go.opentelemetry.io/otel/sdk/metric v0.33.0 h1:oTqyWfksgKoJmbrs2q7O7ahkJzt+Ipekihf8vhpa9qo=
+go.opentelemetry.io/otel/sdk/metric v0.33.0/go.mod h1:xdypMeA21JBOvjjzDUtD0kzIcHO/SPez+a8HOzJPGp0=
 go.opentelemetry.io/otel/trace v1.11.1 h1:ofxdnzsNrGBYXbP7t7zpUK281+go5rF7dvdIZXF8gdQ=
 go.opentelemetry.io/otel/trace v1.11.1/go.mod h1:f/Q9G7vzk5u91PhbmKbg1Qn0rzH1LJ4vbPHFGkTPtOk=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/instrumentation/github.com/Shopify/sarama/otelsarama/go.mod
+++ b/instrumentation/github.com/Shopify/sarama/otelsarama/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
+	go.opentelemetry.io/otel/metric v0.33.0
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa // indirect
 	golang.org/x/net v0.0.0-20220927171203-f486391704dc // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/instrumentation/github.com/Shopify/sarama/otelsarama/go.sum
+++ b/instrumentation/github.com/Shopify/sarama/otelsarama/go.sum
@@ -64,6 +64,8 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 go.opentelemetry.io/otel v1.11.1 h1:4WLLAmcfkmDk2ukNXJyq3/kiz/3UzCaYq6PskJsaou4=
 go.opentelemetry.io/otel v1.11.1/go.mod h1:1nNhXBbWSD0nsL38H6btgnFN2k4i0sNLHNNMZMSbUGE=
+go.opentelemetry.io/otel/metric v0.33.0 h1:xQAyl7uGEYvrLAiV/09iTJlp1pZnQ9Wl793qbVvED1E=
+go.opentelemetry.io/otel/metric v0.33.0/go.mod h1:QlTYc+EnYNq/M2mNk1qDDMRLpqCOj2f/r5c7Fd5FYaI=
 go.opentelemetry.io/otel/trace v1.11.1 h1:ofxdnzsNrGBYXbP7t7zpUK281+go5rF7dvdIZXF8gdQ=
 go.opentelemetry.io/otel/trace v1.11.1/go.mod h1:f/Q9G7vzk5u91PhbmKbg1Qn0rzH1LJ4vbPHFGkTPtOk=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/instrumentation/github.com/Shopify/sarama/otelsarama/metric.go
+++ b/instrumentation/github.com/Shopify/sarama/otelsarama/metric.go
@@ -1,0 +1,358 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otelsarama // import "go.opentelemetry.io/contrib/instrumentation/github.com/Shopify/sarama/otelsarama"
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	saramaMetrics "github.com/rcrowley/go-metrics"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/instrument"
+	"go.opentelemetry.io/otel/metric/instrument/asyncfloat64"
+	"go.opentelemetry.io/otel/metric/instrument/asyncint64"
+	"go.opentelemetry.io/otel/metric/unit"
+)
+
+type metricsType string
+
+const (
+	HISTOGRAM metricsType = "histogram"
+	GAUGE     metricsType = "gauge"
+	COUNTER   metricsType = "counter"
+)
+
+type variableType string
+
+const (
+	INT64   variableType = "int64"
+	FLOAT64 variableType = "float64"
+)
+
+type metricsProps struct {
+	Name              string
+	MetricType        metricsType
+	MetricUnit        unit.Unit
+	Description       string
+	VariableType      variableType
+	RetrievalFunction func(r saramaMetrics.Registry) interface{} //TODO: refinement
+}
+
+const (
+	metricsReservoirSize = 1028
+	metricsAlphaFactor   = 0.015
+)
+
+type observable[T int64 | float64] interface {
+	instrument.Asynchronous
+	Observe(ctx context.Context, x T, attrs ...attribute.KeyValue)
+}
+
+func producerMetrics( /*topics []string*/ ) []metricsProps {
+	return []metricsProps{
+		{
+			Name:       "batch-size",
+			MetricType: GAUGE,
+			MetricUnit: unit.Bytes,
+			// derived from sarama doc
+			Description:  "Distribution of the number of bytes sent per partition per request for all topics",
+			VariableType: FLOAT64,
+			RetrievalFunction: func(r saramaMetrics.Registry) interface{} {
+				var val int64
+				hist, ok := r.Get("batch-size").(saramaMetrics.Histogram)
+				if !ok {
+					return val
+				}
+				return hist.Mean()
+			}, // TODO:
+		}, // -for-topic-<topic>
+		{
+			Name:       "record-send-rate",
+			MetricType: GAUGE,
+			MetricUnit: unit.Dimensionless,
+			// derived from sarama doc
+			Description:  "Records/second sent to all topics",
+			VariableType: INT64,
+			RetrievalFunction: func(r saramaMetrics.Registry) interface{} {
+				var val int64
+				gaug, ok := r.Get("record-send-rate").(saramaMetrics.Gauge)
+				if !ok {
+					return val
+				}
+				return gaug.Value()
+			},
+		}, // -for-topic-<topic>
+		{
+			Name:       "records-per-request",
+			MetricType: GAUGE,
+			MetricUnit: unit.Dimensionless,
+			// derived from sarama doc
+			Description:  "Distribution of the number of records sent per request for all topics",
+			VariableType: FLOAT64,
+			RetrievalFunction: func(r saramaMetrics.Registry) interface{} {
+				var val float64
+				hist, ok := r.Get("records-per-request").(saramaMetrics.Histogram)
+				if !ok {
+					return val
+				}
+				return hist.Mean()
+			},
+		}, // -for-topic-<topic>
+		{
+			Name:       "compression-ratio",
+			MetricType: GAUGE,
+			MetricUnit: unit.Dimensionless,
+			// derived from sarama doc
+			Description:  "Distribution of the compression ratio times 100 of record batches for all topics",
+			VariableType: FLOAT64,
+			RetrievalFunction: func(r saramaMetrics.Registry) interface{} {
+				var val float64
+				hist, ok := r.Get("compression-ratio").(saramaMetrics.Histogram)
+				if !ok {
+					return val
+				}
+				return hist.Mean()
+			},
+		}, // -for-topic-<topic>
+	}
+}
+
+/*
+consumer-batch-size				histogram
+consumer-fetch-rate				meter
+consumer-fetch-response-size	histogram
+*/
+func consumerMetrics( /*topics []string*/ ) []metricsProps {
+	return []metricsProps{
+		{
+			Name:       "consumer-batch-size",
+			MetricType: GAUGE,
+			MetricUnit: unit.Bytes,
+			// derived from sarama doc
+			Description:  "Distribution of the number of messages in a batch",
+			VariableType: FLOAT64,
+			RetrievalFunction: func(r saramaMetrics.Registry) interface{} {
+				var val int64
+				hist, ok := r.Get("consumer-batch-size").(saramaMetrics.Histogram)
+				if !ok {
+					return val
+				}
+				return hist.Mean()
+			},
+		}, // -for-topic-<topic>
+		{
+			Name:       "consumer-fetch-rate",
+			MetricType: GAUGE,
+			MetricUnit: unit.Dimensionless,
+			// derived from sarama doc
+			Description:  "Fetch requests/second sent to all brokers",
+			VariableType: INT64,
+			RetrievalFunction: func(r saramaMetrics.Registry) interface{} {
+				var val int64
+				gaug, ok := r.Get("consumer-fetch-rate").(saramaMetrics.Gauge)
+				if !ok {
+					return val
+				}
+				return gaug.Value()
+			},
+		}, // -for-topic-<topic>
+		{
+			Name:       "consumer-fetch-response-size",
+			MetricType: GAUGE,
+			MetricUnit: unit.Bytes,
+			// derived from sarama doc
+			Description:  "Distribution of the fetch response size in bytes",
+			VariableType: FLOAT64,
+			RetrievalFunction: func(r saramaMetrics.Registry) interface{} {
+				var val float64
+				hist, ok := r.Get("consumer-fetch-response-size").(saramaMetrics.Histogram)
+				if !ok {
+					return val
+				}
+				return hist.Mean()
+			},
+		},
+	}
+}
+
+func startProducerMetric(meter metric.Meter, registry saramaMetrics.Registry) error {
+	var lock sync.Mutex
+	lock.Lock()
+	defer lock.Unlock()
+
+	if registry == nil {
+		return nil
+	}
+
+	producerMetrics := producerMetrics()
+
+	return startMetrics(meter, registry, producerMetrics)
+}
+
+func startConsumerMetric(meter metric.Meter, registry saramaMetrics.Registry) error {
+	var lock sync.Mutex
+	lock.Lock()
+	defer lock.Unlock()
+
+	if registry == nil {
+		return nil
+	}
+
+	consumerMetrics := consumerMetrics()
+
+	return startMetrics(meter, registry, consumerMetrics)
+}
+
+func startMetrics(meter metric.Meter, registry saramaMetrics.Registry, mets []metricsProps) error {
+	var (
+		asyncInsts []instrument.Asynchronous         = make([]instrument.Asynchronous, len(mets))
+		callbacks  []func(ctx context.Context) error = make([]func(ctx context.Context) error, len(mets))
+	)
+
+	for _, met := range mets {
+		switch met.VariableType {
+		case INT64:
+			//Idea: Refinement based on generic intrumentprovider (opentelemetry-go)
+			prov := meter.AsyncInt64()
+			obs, callback, err := convertToInt64MetricType(prov, registry, met)
+			if err != nil {
+				return err
+			}
+			asyncInsts = append(asyncInsts, obs)
+			callbacks = append(callbacks, callback)
+		case FLOAT64:
+			//Idea: Refinement based on generic intrumentprovider (opentelemetry-go)
+			prov := meter.AsyncFloat64()
+			obs, callback, err := convertToFloat64MetricType(prov, registry, met)
+			if err != nil {
+				return err
+			}
+			asyncInsts = append(asyncInsts, obs)
+			callbacks = append(callbacks, callback)
+		}
+	}
+
+	err := meter.RegisterCallback(asyncInsts, func(ctx context.Context) {
+		for _, callback := range callbacks {
+			if callback != nil { // in initial startup, nil is being returned
+				err := callback(ctx)
+				if err != nil {
+					otel.Handle(err)
+				}
+			}
+		}
+	})
+
+	return err
+}
+
+func convertToInt64MetricType(prov asyncint64.InstrumentProvider, r saramaMetrics.Registry, prop metricsProps) (instrument.Asynchronous, func(ctx context.Context) error, error) {
+	var (
+		err     error
+		metType observable[int64]
+	)
+
+	switch prop.MetricType {
+	case HISTOGRAM:
+		return nil, nil, errors.New("Histogram on Async instrument provier is not supported") // TODO: aggregate error functions for sake of errors.as / is
+	case GAUGE:
+		metType, err = prov.Gauge(
+			prop.Name,
+			instrument.WithUnit(prop.MetricUnit),
+			instrument.WithDescription(prop.Description),
+		)
+		if err != nil {
+			return metType, nil, err
+		}
+		break
+	case COUNTER:
+		metType, err = prov.Counter(
+			prop.Name,
+			instrument.WithUnit(prop.MetricUnit),
+			instrument.WithDescription(prop.Description),
+		)
+		if err != nil {
+			return metType, nil, err
+		}
+		break
+	}
+
+	if metType == nil {
+		return metType, nil, errors.New("no metric type found")
+	}
+
+	callback := func(ctx context.Context) error {
+		val, ok := prop.RetrievalFunction(r).(int64)
+
+		if !ok {
+			return fmt.Errorf("RetrievalFunction of %s does not return correct variable type", prop.Name)
+		}
+		metType.Observe(ctx, val)
+		return nil
+	}
+
+	return metType, callback, err
+}
+
+func convertToFloat64MetricType(prov asyncfloat64.InstrumentProvider, r saramaMetrics.Registry, prop metricsProps) (instrument.Asynchronous, func(ctx context.Context) error, error) {
+	var (
+		err     error
+		metType observable[float64]
+	)
+
+	switch prop.MetricType {
+	case HISTOGRAM:
+		return nil, nil, errors.New("Histogram on Async instrument provier is not supported") // TODO: aggregate error functions for sake of errors.as / is
+	case GAUGE:
+		metType, err = prov.Gauge(
+			prop.Name,
+			instrument.WithUnit(prop.MetricUnit),
+			instrument.WithDescription(prop.Description),
+		)
+		if err != nil {
+			return metType, nil, err
+		}
+		break
+	case COUNTER:
+		metType, err = prov.Counter(
+			prop.Name,
+			instrument.WithUnit(prop.MetricUnit),
+			instrument.WithDescription(prop.Description),
+		)
+		if err != nil {
+			return metType, nil, err
+		}
+		break
+	}
+
+	if metType == nil {
+		return metType, nil, errors.New("no metric type found")
+	}
+
+	callback := func(ctx context.Context) error {
+		val, ok := prop.RetrievalFunction(r).(float64)
+
+		if !ok {
+			return fmt.Errorf("RetrievalFunction of %s does not return correct variable type", prop.Name)
+		}
+		metType.Observe(ctx, val)
+		return nil
+	}
+
+	return metType, callback, err
+}

--- a/instrumentation/github.com/Shopify/sarama/otelsarama/metric_test.go
+++ b/instrumentation/github.com/Shopify/sarama/otelsarama/metric_test.go
@@ -1,0 +1,22 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otelsarama
+
+// TODO(#2755): Add integration tests for the host instrumentation. These tests
+// depend on https://github.com/open-telemetry/opentelemetry-go/issues/3031
+// being resolved.
+//
+// The added tests will depend on the metric SDK. Therefore, they should be
+// added to a sub-directory called "test" instead of this file.

--- a/instrumentation/github.com/Shopify/sarama/otelsarama/producer.go
+++ b/instrumentation/github.com/Shopify/sarama/otelsarama/producer.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/Shopify/sarama"
 
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -65,6 +66,11 @@ func WrapSyncProducer(saramaConfig *sarama.Config, producer sarama.SyncProducer,
 	cfg := newConfig(opts...)
 	if saramaConfig == nil {
 		saramaConfig = sarama.NewConfig()
+	}
+
+	err := startProducerMetric(cfg.Meter, saramaConfig.MetricRegistry)
+	if err != nil {
+		otel.Handle(err)
 	}
 
 	return &syncProducer{
@@ -131,6 +137,11 @@ func WrapAsyncProducer(saramaConfig *sarama.Config, p sarama.AsyncProducer, opts
 	cfg := newConfig(opts...)
 	if saramaConfig == nil {
 		saramaConfig = sarama.NewConfig()
+	}
+
+	err := startProducerMetric(cfg.Meter, saramaConfig.MetricRegistry)
+	if err != nil {
+		otel.Handle(err)
 	}
 
 	wrapped := &asyncProducer{


### PR DESCRIPTION
it is related to feature enhancement of otelsarama instrumentation in order to export the both producer & consumer metrics that are propagated by sarama library.

Issue: https://github.com/open-telemetry/opentelemetry-go-contrib/issues/2966

***Producer Metrics***
- batch-size
- record-send-rate
- records-per-request
- compression-ratio

***Consumer Metrics***
- consumer-batch-size
- consumer-fetch-rate
- consumer-fetch-response-size

The metrics might need to be renamed.

There are still two future works to do:

- unit tests for metrics part as soon as sdk test suite is mature
- topic specific producer&consumer metrics are out of scope in this PR