### PR TITLE
Add instrgen directory for source level instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- Add the new `go.opentelemetry.io/contrib/instrgen` package to provide auto-generated source code  instrumentation. (#3068)
+- Add the new `go.opentelemetry.io/contrib/instrgen` package to provide auto-generated source code instrumentation. (#3068)
 
 ## [1.12.0/0.37.0/0.6.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- Add the new `go.opentelemetry.io/contrib/instrgen` package to provide auto-generated source code  instrumentation. (#3068)
+
 ## [1.12.0/0.37.0/0.6.0]
 
 ### Added

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,3 +15,5 @@
 * @jmacd @MrAlias @Aneurysm9 @evantorrie @XSAM @dashpole @MadVikingGod @pellared @hanyuancheung @dmathieu
 
 CODEOWNERS @MrAlias @Aneurysm9 @MadVikingGod
+
+instrgen/                                  @open-telemetry/go-approvers @MrAlias @pdelewski

--- a/instrgen/README.md
+++ b/instrgen/README.md
@@ -1,0 +1,13 @@
+# OpenTelemetry Go Source Automatic Instrumentation
+
+This package provides a code generation utility that instruments existing source code with [OpenTelemetry].
+
+## Project Status
+
+:construction: This package is currently work in progress.
+
+### Compatibility
+
+The `instrgen` utility is based on the Go standard library and is platform agnostic.
+
+[OpenTelemetry]: https://opentelemetry.io/

--- a/instrgen/doc.go
+++ b/instrgen/doc.go
@@ -1,0 +1,19 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package instrgen provides a code generation utility that instruments existing
+source code with OpenTelemetry.
+*/
+package instrgen // import "go.opentelemetry.io/contrib/instrgen"

--- a/instrgen/go.mod
+++ b/instrgen/go.mod
@@ -1,0 +1,3 @@
+module go.opentelemetry.io/contrib/instrgen
+
+go 1.18


### PR DESCRIPTION
This PR adds new directory for source instrumentation according to discussions

https://github.com/open-telemetry/opentelemetry-go-instrumentation/issues/3
https://github.com/open-telemetry/opentelemetry-go-contrib/issues/2834