### PR TITLE
Implementing xrayTraceIDRatioBasedsampler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Add the new `go.opentelemetry.io/contrib/instrgen` package to provide auto-generated source code instrumentation. (#3068)
 - `otelmux`: Add new `WithSpanNameFormatter` option to `go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux` to allow customizing span names. (#3041)
+- Add `TraceIDRatioBasedSampler` for AWS X-Ray (#3090)
 
 ## [1.12.0/0.37.0/0.6.0]
 

--- a/samplers/aws/xray/go.mod
+++ b/samplers/aws/xray/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-logr/logr v1.2.3
 	github.com/go-logr/stdr v1.2.2
 	github.com/stretchr/testify v1.8.1
+	go.opentelemetry.io/contrib/propagators/aws v1.12.0
 	go.opentelemetry.io/otel v1.11.2
 	go.opentelemetry.io/otel/sdk v1.11.2
 	go.opentelemetry.io/otel/trace v1.11.2

--- a/samplers/aws/xray/go.mod
+++ b/samplers/aws/xray/go.mod
@@ -18,3 +18,5 @@ require (
 	golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace go.opentelemetry.io/contrib/propagators/aws => ../../../propagators/aws

--- a/samplers/aws/xray/go.sum
+++ b/samplers/aws/xray/go.sum
@@ -16,6 +16,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+go.opentelemetry.io/contrib/propagators/aws v1.12.0 h1:n3lNyZs2ytVEfFhcn2QO5Z80lgrMXyP1Ncx0C7rUU8A=
+go.opentelemetry.io/contrib/propagators/aws v1.12.0/go.mod h1:xZSOQIixr40Cq3NHn/YsvkDOzpVaR0j19WJRZnOKwbk=
 go.opentelemetry.io/otel v1.11.2 h1:YBZcQlsVekzFsFbjygXMOXSs6pialIZxcjfO/mBDmR0=
 go.opentelemetry.io/otel v1.11.2/go.mod h1:7p4EUV+AqgdlNV9gL97IgUZiVR3yrFXYo53f9BM3tRI=
 go.opentelemetry.io/otel/sdk v1.11.2 h1:GF4JoaEx7iihdMFu30sOyRx52HDHOkl9xQ8SMqNXUiU=

--- a/samplers/aws/xray/traceid_ratio_sampler.go
+++ b/samplers/aws/xray/traceid_ratio_sampler.go
@@ -1,3 +1,17 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package xray
 
 import (
@@ -9,30 +23,30 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-type xrayTraceIDRatioBasedSampler struct {
+type traceIDRatioBasedSampler struct {
 	sdktrace.Sampler
 	max  uint64
 	desc string
 }
 
-// NewXrayTraceIDRatioBased creates a sampler based on random number.
+// NewTraceIDRatioBased creates a sampler based on random number.
 // fraction parameter should be between 0 and 1 where:
 // fraction >= 1 it will always sample
 // fraction <= 0 it will never sample
-func NewXrayTraceIDRatioBased(fraction float64) sdktrace.Sampler {
+func NewTraceIDRatioBased(fraction float64) sdktrace.Sampler {
 	if fraction >= 1 {
 		return sdktrace.AlwaysSample()
 	} else if fraction <= 0 {
 		return sdktrace.NeverSample()
 	}
 
-	return &xrayTraceIDRatioBasedSampler{
+	return &traceIDRatioBasedSampler{
 		desc: fmt.Sprintf("xrayTraceIDRatioBasedSampler{%v}", fraction),
 		max:  uint64(fraction * math.MaxUint64),
 	}
 }
 
-func (s *xrayTraceIDRatioBasedSampler) ShouldSample(p sdktrace.SamplingParameters) sdktrace.SamplingResult {
+func (s *traceIDRatioBasedSampler) ShouldSample(p sdktrace.SamplingParameters) sdktrace.SamplingResult {
 	// The default otel sampler pick the first 8 bytes to make the sampling decision and this is a problem to
 	// xray case as the first 4 bytes on the xray traceId is the time of the original request and the random part are
 	// the 12 last bytes, and so, this sampler pick the last 8 bytes to make the sampling decision.
@@ -54,6 +68,6 @@ func (s *xrayTraceIDRatioBasedSampler) ShouldSample(p sdktrace.SamplingParameter
 	}
 }
 
-func (s *xrayTraceIDRatioBasedSampler) Description() string {
+func (s *traceIDRatioBasedSampler) Description() string {
 	return s.desc
 }

--- a/samplers/aws/xray/traceid_ratio_sampler.go
+++ b/samplers/aws/xray/traceid_ratio_sampler.go
@@ -29,7 +29,7 @@ type traceIDRatioBasedSampler struct {
 	desc string
 }
 
-// NewTraceIDRatioBased creates a sampler based on random number.
+// NewTraceIDRatioBased creates a sampler based on (presumably) random parts of the TraceID.
 // fraction parameter should be between 0 and 1 where:
 // fraction >= 1 it will always sample
 // fraction <= 0 it will never sample

--- a/samplers/aws/xray/traceid_ratio_sampler.go
+++ b/samplers/aws/xray/traceid_ratio_sampler.go
@@ -32,7 +32,7 @@ type traceIDRatioBasedSampler struct {
 // NewTraceIDRatioBased creates a sampler based on (presumably) random parts of the TraceID.
 // fraction parameter should be between 0 and 1 where:
 // fraction >= 1 it will always sample
-// fraction <= 0 it will never sample
+// fraction <= 0 it will never sample.
 func NewTraceIDRatioBased(fraction float64) sdktrace.Sampler {
 	if fraction >= 1 {
 		return sdktrace.AlwaysSample()

--- a/samplers/aws/xray/traceid_ratio_sampler.go
+++ b/samplers/aws/xray/traceid_ratio_sampler.go
@@ -1,0 +1,59 @@
+package xray
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type xrayTraceIDRatioBasedSampler struct {
+	sdktrace.Sampler
+	max  uint64
+	desc string
+}
+
+// NewXrayTraceIDRatioBased creates a sampler based on random number.
+// fraction parameter should be between 0 and 1 where:
+// fraction >= 1 it will always sample
+// fraction <= 0 it will never sample
+func NewXrayTraceIDRatioBased(fraction float64) sdktrace.Sampler {
+	if fraction >= 1 {
+		return sdktrace.AlwaysSample()
+	} else if fraction <= 0 {
+		return sdktrace.NeverSample()
+	}
+
+	return &xrayTraceIDRatioBasedSampler{
+		desc: fmt.Sprintf("xrayTraceIDRatioBasedSampler{%v}", fraction),
+		max:  uint64(fraction * math.MaxUint64),
+	}
+}
+
+func (s *xrayTraceIDRatioBasedSampler) ShouldSample(p sdktrace.SamplingParameters) sdktrace.SamplingResult {
+	// The default otel sampler pick the first 8 bytes to make the sampling decision and this is a problem to
+	// xray case as the first 4 bytes on the xray traceId is the time of the original request and the random part are
+	// the 12 last bytes, and so, this sampler pick the last 8 bytes to make the sampling decision.
+	// Xray Trace format: https://docs.aws.amazon.com/xray/latest/devguide/xray-api-sendingdata.html
+	// Xray Id Generator: https://github.com/open-telemetry/opentelemetry-go-contrib/blob/54f0bc5c0fd347cd6db9b7bc14c9f0c00dfcb36b/propagators/aws/xray/idgenerator.go#L58-L63
+	// Ref: https://github.com/open-telemetry/opentelemetry-go/blob/7a60bc785d669fa6ad26ba70e88151d4df631d90/sdk/trace/sampling.go#L82-L95
+	val := binary.BigEndian.Uint64(p.TraceID[8:16])
+	psc := trace.SpanContextFromContext(p.ParentContext)
+	shouldSample := val < s.max
+	if shouldSample {
+		return sdktrace.SamplingResult{
+			Decision:   sdktrace.RecordAndSample,
+			Tracestate: psc.TraceState(),
+		}
+	}
+	return sdktrace.SamplingResult{
+		Decision:   sdktrace.Drop,
+		Tracestate: psc.TraceState(),
+	}
+}
+
+func (s *xrayTraceIDRatioBasedSampler) Description() string {
+	return s.desc
+}

--- a/samplers/aws/xray/traceid_ratio_sampler_test.go
+++ b/samplers/aws/xray/traceid_ratio_sampler_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	xraypropagator "go.opentelemetry.io/contrib/propagators/aws/xray"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"

--- a/samplers/aws/xray/traceid_ratio_sampler_test.go
+++ b/samplers/aws/xray/traceid_ratio_sampler_test.go
@@ -1,0 +1,73 @@
+package xray
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	xraypropagator "go.opentelemetry.io/contrib/propagators/aws/xray"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func Test_ShouldSample(t *testing.T) {
+	parentCtx := trace.ContextWithSpanContext(
+		context.Background(),
+		trace.NewSpanContext(trace.SpanContextConfig{
+			TraceState: trace.TraceState{},
+		}),
+	)
+
+	generator := xraypropagator.NewIDGenerator()
+
+	tests := []struct {
+		name     string
+		fraction float64
+	}{
+		{
+			name:     "should always sample",
+			fraction: 1,
+		},
+		{
+			name:     "should nerver sample",
+			fraction: 0,
+		},
+		{
+			name:     "should sample 50%",
+			fraction: 0.5,
+		},
+		{
+			name:     "should sample 10%",
+			fraction: 0.1,
+		},
+		{
+			name:     "should sample 1%",
+			fraction: 0.01,
+		},
+	}
+
+	totalIterations := 100000
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			totalSampled := 0
+			s := NewXrayTraceIDRatioBased(tt.fraction)
+			for i := 0; i < totalIterations; i++ {
+				traceID, _ := generator.NewIDs(context.Background())
+				r := s.ShouldSample(
+					sdktrace.SamplingParameters{
+						ParentContext: parentCtx,
+						TraceID:       traceID,
+						Name:          "test",
+						Kind:          trace.SpanKindServer,
+					})
+				if r.Decision == sdktrace.RecordAndSample {
+					totalSampled++
+				}
+			}
+
+			tolerance := 0.1
+			expected := tt.fraction * float64(totalIterations)
+			require.InDelta(t, expected, totalSampled, expected*tolerance)
+		})
+	}
+}

--- a/samplers/aws/xray/traceid_ratio_sampler_test.go
+++ b/samplers/aws/xray/traceid_ratio_sampler_test.go
@@ -1,3 +1,17 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package xray
 
 import (
@@ -50,7 +64,7 @@ func Test_ShouldSample(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			totalSampled := 0
-			s := NewXrayTraceIDRatioBased(tt.fraction)
+			s := NewTraceIDRatioBased(tt.fraction)
 			for i := 0; i < totalIterations; i++ {
 				traceID, _ := generator.NewIDs(context.Background())
 				r := s.ShouldSample(


### PR DESCRIPTION
Signed-off-by: Alan Protasio <approtas@amazon.com>

Hi..

The default Otel TraceIDRatioBased does not work with XRay as it make the decision based on the first 8 bytes of the traceId  -> which are not random on traces generated with the `xray.NewIDGenerator()`.

This PR creates a similar sampler that works on XRAY as it makes the decision based on the last 8 bytes of the trace id.