### PR TITLE
[runtime] Change `runtime.uptime` instrument from `Int64ObservableUpDownCounter` to `Int64ObservableCounter`

### DIFF
--- a/instrumentation/runtime/runtime.go
+++ b/instrumentation/runtime/runtime.go
@@ -118,7 +118,7 @@ func Start(opts ...Option) error {
 
 func (r *runtime) register() error {
 	startTime := time.Now()
-	uptime, err := r.meter.Int64ObservableUpDownCounter(
+	uptime, err := r.meter.Int64ObservableCounter(
 		"runtime.uptime",
 		instrument.WithUnit(unit.Milliseconds),
 		instrument.WithDescription("Milliseconds since application was initialized"),


### PR DESCRIPTION
Signed-off-by: Matej Gera <matej.gera@coralogix.com>

`runtime.uptime` captures the uptime of the process, meaning it is monotonic - there doesn't seem to be reason for this to be up down counter instead of just a counter.