### PR TITLE
Remove the SDK dependency from `otelmux`

### DIFF
--- a/instrumentation/github.com/gorilla/mux/otelmux/go.mod
+++ b/instrumentation/github.com/gorilla/mux/otelmux/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/stretchr/testify v1.8.1
 	go.opentelemetry.io/otel v1.12.0
-	go.opentelemetry.io/otel/sdk v1.12.0
 	go.opentelemetry.io/otel/trace v1.12.0
 )
 
@@ -16,6 +15,5 @@ require (
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/instrumentation/github.com/gorilla/mux/otelmux/go.sum
+++ b/instrumentation/github.com/gorilla/mux/otelmux/go.sum
@@ -22,12 +22,8 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 go.opentelemetry.io/otel v1.12.0 h1:IgfC7kqQrRccIKuB7Cl+SRUmsKbEwSGPr0Eu+/ht1SQ=
 go.opentelemetry.io/otel v1.12.0/go.mod h1:geaoz0L0r1BEOR81k7/n9W4TCXYCJ7bPO7K374jQHG0=
-go.opentelemetry.io/otel/sdk v1.12.0 h1:8npliVYV7qc0t1FKdpU08eMnOjgPFMnriPhn0HH4q3o=
-go.opentelemetry.io/otel/sdk v1.12.0/go.mod h1:WYcvtgquYvgODEvxOry5owO2y9MyciW7JqMz6cpXShE=
 go.opentelemetry.io/otel/trace v1.12.0 h1:p28in++7Kd0r2d8gSt931O57fdjUyWxkVbESuILAeUc=
 go.opentelemetry.io/otel/trace v1.12.0/go.mod h1:pHlgBynn6s25qJ2szD+Bv+iwKJttjHSI3lUAyf0GNuQ=
-golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 h1:h+EGohizhe9XlX18rfpa8k8RAc5XyaeamM+0VHRd4lc=
-golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/instrumentation/github.com/gorilla/mux/otelmux/mux_test.go
+++ b/instrumentation/github.com/gorilla/mux/otelmux/mux_test.go
@@ -17,7 +17,6 @@ package otelmux
 import (
 	"bufio"
 	"context"
-	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -26,12 +25,9 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -165,48 +161,4 @@ func TestResponseWriterInterfaces(t *testing.T) {
 	}
 
 	router.ServeHTTP(w, r)
-}
-
-func TestCustomSpanNameFormatter(t *testing.T) {
-	exporter := tracetest.NewInMemoryExporter()
-
-	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
-
-	routeTpl := "/user/{id}"
-
-	testdata := []struct {
-		spanNameFormatter func(string, *http.Request) string
-		expected          string
-	}{
-		{nil, routeTpl},
-		{
-			func(string, *http.Request) string { return "custom" },
-			"custom",
-		},
-		{
-			func(name string, r *http.Request) string {
-				return fmt.Sprintf("%s %s", r.Method, name)
-			},
-			"GET " + routeTpl,
-		},
-	}
-
-	for i, d := range testdata {
-		t.Run(fmt.Sprintf("%d_%s", i, d.expected), func(t *testing.T) {
-			router := mux.NewRouter()
-			router.Use(Middleware("foobar", WithTracerProvider(tp), WithSpanNameFormatter(d.spanNameFormatter)))
-			router.HandleFunc(routeTpl, func(w http.ResponseWriter, r *http.Request) {})
-
-			r := httptest.NewRequest("GET", "/user/123", nil)
-			w := httptest.NewRecorder()
-
-			router.ServeHTTP(w, r)
-
-			spans := exporter.GetSpans()
-			require.Len(t, spans, 1)
-			assert.Equal(t, d.expected, spans[0].Name)
-
-			exporter.Reset()
-		})
-	}
 }

--- a/instrumentation/github.com/gorilla/mux/otelmux/test/mux_test.go
+++ b/instrumentation/github.com/gorilla/mux/otelmux/test/mux_test.go
@@ -15,6 +15,7 @@
 package test
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -30,6 +31,54 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
 )
+
+func TestCustomSpanNameFormatter(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+
+	routeTpl := "/user/{id}"
+
+	testdata := []struct {
+		spanNameFormatter func(string, *http.Request) string
+		expected          string
+	}{
+		{nil, routeTpl},
+		{
+			func(string, *http.Request) string { return "custom" },
+			"custom",
+		},
+		{
+			func(name string, r *http.Request) string {
+				return fmt.Sprintf("%s %s", r.Method, name)
+			},
+			"GET " + routeTpl,
+		},
+	}
+
+	for i, d := range testdata {
+		t.Run(fmt.Sprintf("%d_%s", i, d.expected), func(t *testing.T) {
+			router := mux.NewRouter()
+			router.Use(otelmux.Middleware(
+				"foobar",
+				otelmux.WithTracerProvider(tp),
+				otelmux.WithSpanNameFormatter(d.spanNameFormatter),
+			))
+			router.HandleFunc(routeTpl, func(w http.ResponseWriter, r *http.Request) {})
+
+			r := httptest.NewRequest("GET", "/user/123", nil)
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, r)
+
+			spans := exporter.GetSpans()
+			require.Len(t, spans, 1)
+			assert.Equal(t, d.expected, spans[0].Name)
+
+			exporter.Reset()
+		})
+	}
+}
 
 func ok(w http.ResponseWriter, _ *http.Request) {}
 func notfound(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-go-contrib/pull/3041 added a test to `otelmux` that belongs in `otelmux/test`, it depends on the SDK to perform testing.