### PR TITLE
Include dependabot PR number in the dependabot pr merger workflow

### DIFF
--- a/.github/workflows/scripts/dependabot-pr.sh
+++ b/.github/workflows/scripts/dependabot-pr.sh
@@ -21,7 +21,7 @@ PR_NAME=dependabot-prs/`date +'%Y-%m-%dT%H%M%S'`
 git checkout -b $PR_NAME
 
 IFS=$'\n'
-requests=($( gh pr list --search "author:app/dependabot" --json title --jq '.[].title' ))
+requests=($( gh pr list --search "author:app/dependabot" --json number,title --jq '.[] | "\(.title) #\(.number)"' ))
 message=""
 dirs=(`find . -type f -name "go.mod" -exec dirname {} \; | sort | egrep  '^./'`)
 


### PR DESCRIPTION
Include dependabot PR number in the dependabot pr merger workflow https://github.com/open-telemetry/opentelemetry-go-contrib/actions/workflows/create-dependabot-pr.yml

This will include the PR number in the description of the pr that merge multiple dependabot PRs. E.g.:

The fist line of [this pr](https://github.com/open-telemetry/opentelemetry-go-contrib/pull/3422) description would look like:
 build(deps): bump golang.org/x/net from 0.6.0 to 0.7.0 in /tools #3405 

This is very minor, but it will allow to track back to the original dependabot prs very easily.