### PR TITLE
Update use of metric `Reader.Collect()`

### DIFF
--- a/instrumentation/github.com/gocql/gocql/otelgocql/example/go.mod
+++ b/instrumentation/github.com/gocql/gocql/otelgocql/example/go.mod
@@ -11,7 +11,7 @@ require (
 	go.opentelemetry.io/otel v1.13.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.36.0
 	go.opentelemetry.io/otel/exporters/zipkin v1.13.0
-	go.opentelemetry.io/otel/metric v0.36.0
+	go.opentelemetry.io/otel/metric v0.36.1-0.20230221193137-99ec432679fb
 	go.opentelemetry.io/otel/sdk v1.13.0
 	go.opentelemetry.io/otel/sdk/metric v0.36.0
 )

--- a/instrumentation/github.com/gocql/gocql/otelgocql/example/go.sum
+++ b/instrumentation/github.com/gocql/gocql/otelgocql/example/go.sum
@@ -227,8 +227,8 @@ go.opentelemetry.io/otel/exporters/prometheus v0.36.0 h1:EbfJRxojnpb+ux8IO79oKHX
 go.opentelemetry.io/otel/exporters/prometheus v0.36.0/go.mod h1:gYHAjuEuMrtPXccEHyvYcQVC//c4QwgQcUq1/3mx7Ys=
 go.opentelemetry.io/otel/exporters/zipkin v1.13.0 h1:RqPV1VhJjrx28qOKYFPj3Mso56uaBovur3GZehF9y9s=
 go.opentelemetry.io/otel/exporters/zipkin v1.13.0/go.mod h1:x6S2VkXmdpoYUqQx9FKiMEsndal6xkcwDdV0Oi1RlLM=
-go.opentelemetry.io/otel/metric v0.36.0 h1:t0lgGI+L68QWt3QtOIlqM9gXoxqxWLhZ3R/e5oOAY0Q=
-go.opentelemetry.io/otel/metric v0.36.0/go.mod h1:wKVw57sd2HdSZAzyfOM9gTqqE8v7CbqWsYL6AyrH9qk=
+go.opentelemetry.io/otel/metric v0.36.1-0.20230221193137-99ec432679fb h1:ERlouo+/B1ERdSHUNYj1s4zT+zp2gg2J4/f69tbdio0=
+go.opentelemetry.io/otel/metric v0.36.1-0.20230221193137-99ec432679fb/go.mod h1:wKVw57sd2HdSZAzyfOM9gTqqE8v7CbqWsYL6AyrH9qk=
 go.opentelemetry.io/otel/sdk v1.13.0 h1:BHib5g8MvdqS65yo2vV1s6Le42Hm6rrw08qU6yz5JaM=
 go.opentelemetry.io/otel/sdk v1.13.0/go.mod h1:YLKPx5+6Vx/o1TCUYYs+bpymtkmazOMT6zoRrC7AQ7I=
 go.opentelemetry.io/otel/sdk/metric v0.36.0 h1:dEXpkkOAEcHiRiaZdvd63MouV+3bCtAB/bF3jlNKnr8=

--- a/instrumentation/github.com/gocql/gocql/otelgocql/test/go.mod
+++ b/instrumentation/github.com/gocql/gocql/otelgocql/test/go.mod
@@ -8,9 +8,9 @@ require (
 	go.opentelemetry.io/contrib v1.14.0
 	go.opentelemetry.io/contrib/instrumentation/github.com/gocql/gocql/otelgocql v0.39.0
 	go.opentelemetry.io/otel v1.13.0
-	go.opentelemetry.io/otel/metric v0.36.0
+	go.opentelemetry.io/otel/metric v0.36.1-0.20230221193137-99ec432679fb
 	go.opentelemetry.io/otel/sdk v1.13.0
-	go.opentelemetry.io/otel/sdk/metric v0.36.0
+	go.opentelemetry.io/otel/sdk/metric v0.36.1-0.20230221193137-99ec432679fb
 	go.opentelemetry.io/otel/trace v1.13.0
 )
 

--- a/instrumentation/github.com/gocql/gocql/otelgocql/test/go.sum
+++ b/instrumentation/github.com/gocql/gocql/otelgocql/test/go.sum
@@ -34,12 +34,12 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 go.opentelemetry.io/otel v1.13.0 h1:1ZAKnNQKwBBxFtww/GwxNUyTf0AxkZzrukO8MeXqe4Y=
 go.opentelemetry.io/otel v1.13.0/go.mod h1:FH3RtdZCzRkJYFTCsAKDy9l/XYjMdNv6QrkFFB8DvVg=
-go.opentelemetry.io/otel/metric v0.36.0 h1:t0lgGI+L68QWt3QtOIlqM9gXoxqxWLhZ3R/e5oOAY0Q=
-go.opentelemetry.io/otel/metric v0.36.0/go.mod h1:wKVw57sd2HdSZAzyfOM9gTqqE8v7CbqWsYL6AyrH9qk=
+go.opentelemetry.io/otel/metric v0.36.1-0.20230221193137-99ec432679fb h1:ERlouo+/B1ERdSHUNYj1s4zT+zp2gg2J4/f69tbdio0=
+go.opentelemetry.io/otel/metric v0.36.1-0.20230221193137-99ec432679fb/go.mod h1:wKVw57sd2HdSZAzyfOM9gTqqE8v7CbqWsYL6AyrH9qk=
 go.opentelemetry.io/otel/sdk v1.13.0 h1:BHib5g8MvdqS65yo2vV1s6Le42Hm6rrw08qU6yz5JaM=
 go.opentelemetry.io/otel/sdk v1.13.0/go.mod h1:YLKPx5+6Vx/o1TCUYYs+bpymtkmazOMT6zoRrC7AQ7I=
-go.opentelemetry.io/otel/sdk/metric v0.36.0 h1:dEXpkkOAEcHiRiaZdvd63MouV+3bCtAB/bF3jlNKnr8=
-go.opentelemetry.io/otel/sdk/metric v0.36.0/go.mod h1:Lv4HQQPSCSkhyBKzLNtE8YhTSdK4HCwNh3lh7CiR20s=
+go.opentelemetry.io/otel/sdk/metric v0.36.1-0.20230221193137-99ec432679fb h1:/BUwS+4dNdmMI/ucDWKfR8GYnv+Wfh7po5v0kNI+jdI=
+go.opentelemetry.io/otel/sdk/metric v0.36.1-0.20230221193137-99ec432679fb/go.mod h1:Lv4HQQPSCSkhyBKzLNtE8YhTSdK4HCwNh3lh7CiR20s=
 go.opentelemetry.io/otel/trace v1.13.0 h1:CBgRZ6ntv+Amuj1jDsMhZtlAPT6gbyIRdaIzFhfBSdY=
 go.opentelemetry.io/otel/trace v1.13.0/go.mod h1:muCvmmO9KKpvuXSf3KKAXXB2ygNYHQ+ZfI5X08d3tds=
 golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 h1:h+EGohizhe9XlX18rfpa8k8RAc5XyaeamM+0VHRd4lc=

--- a/instrumentation/github.com/gocql/gocql/otelgocql/test/gocql_test.go
+++ b/instrumentation/github.com/gocql/gocql/otelgocql/test/gocql_test.go
@@ -104,7 +104,8 @@ func TestQuery(t *testing.T) {
 		assertConnectionLevelAttributes(t, span)
 	}
 
-	rm, err := reader.Collect(context.Background())
+	rm := metricdata.ResourceMetrics{}
+	err = reader.Collect(context.Background(), &rm)
 	require.NoError(t, err)
 	require.Len(t, rm.ScopeMetrics, 1)
 	sm := rm.ScopeMetrics[0]
@@ -159,7 +160,8 @@ func TestBatch(t *testing.T) {
 		assertConnectionLevelAttributes(t, span)
 	}
 
-	rm, err := reader.Collect(context.Background())
+	rm := metricdata.ResourceMetrics{}
+	err = reader.Collect(context.Background(), &rm)
 	require.NoError(t, err)
 	require.Len(t, rm.ScopeMetrics, 1)
 	sm := rm.ScopeMetrics[0]
@@ -200,7 +202,8 @@ func TestConnection(t *testing.T) {
 		assertConnectionLevelAttributes(t, span)
 	}
 
-	rm, err := reader.Collect(context.Background())
+	rm := metricdata.ResourceMetrics{}
+	err = reader.Collect(context.Background(), &rm)
 	require.NoError(t, err)
 	require.Len(t, rm.ScopeMetrics, 1)
 	sm := rm.ScopeMetrics[0]

--- a/instrumentation/google.golang.org/grpc/otelgrpc/test/go.mod
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/test/go.mod
@@ -7,7 +7,7 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.39.0
 	go.opentelemetry.io/otel v1.13.0
 	go.opentelemetry.io/otel/sdk v1.13.0
-	go.opentelemetry.io/otel/sdk/metric v0.36.0
+	go.opentelemetry.io/otel/sdk/metric v0.36.1-0.20230221193137-99ec432679fb
 	go.uber.org/goleak v1.2.1
 	google.golang.org/grpc v1.53.0
 )
@@ -21,7 +21,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/metric v0.36.0 // indirect
+	go.opentelemetry.io/otel/metric v0.36.1-0.20230221193137-99ec432679fb // indirect
 	go.opentelemetry.io/otel/trace v1.13.0 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/oauth2 v0.4.0 // indirect

--- a/instrumentation/google.golang.org/grpc/otelgrpc/test/go.sum
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/test/go.sum
@@ -31,12 +31,12 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 go.opentelemetry.io/otel v1.13.0 h1:1ZAKnNQKwBBxFtww/GwxNUyTf0AxkZzrukO8MeXqe4Y=
 go.opentelemetry.io/otel v1.13.0/go.mod h1:FH3RtdZCzRkJYFTCsAKDy9l/XYjMdNv6QrkFFB8DvVg=
-go.opentelemetry.io/otel/metric v0.36.0 h1:t0lgGI+L68QWt3QtOIlqM9gXoxqxWLhZ3R/e5oOAY0Q=
-go.opentelemetry.io/otel/metric v0.36.0/go.mod h1:wKVw57sd2HdSZAzyfOM9gTqqE8v7CbqWsYL6AyrH9qk=
+go.opentelemetry.io/otel/metric v0.36.1-0.20230221193137-99ec432679fb h1:ERlouo+/B1ERdSHUNYj1s4zT+zp2gg2J4/f69tbdio0=
+go.opentelemetry.io/otel/metric v0.36.1-0.20230221193137-99ec432679fb/go.mod h1:wKVw57sd2HdSZAzyfOM9gTqqE8v7CbqWsYL6AyrH9qk=
 go.opentelemetry.io/otel/sdk v1.13.0 h1:BHib5g8MvdqS65yo2vV1s6Le42Hm6rrw08qU6yz5JaM=
 go.opentelemetry.io/otel/sdk v1.13.0/go.mod h1:YLKPx5+6Vx/o1TCUYYs+bpymtkmazOMT6zoRrC7AQ7I=
-go.opentelemetry.io/otel/sdk/metric v0.36.0 h1:dEXpkkOAEcHiRiaZdvd63MouV+3bCtAB/bF3jlNKnr8=
-go.opentelemetry.io/otel/sdk/metric v0.36.0/go.mod h1:Lv4HQQPSCSkhyBKzLNtE8YhTSdK4HCwNh3lh7CiR20s=
+go.opentelemetry.io/otel/sdk/metric v0.36.1-0.20230221193137-99ec432679fb h1:/BUwS+4dNdmMI/ucDWKfR8GYnv+Wfh7po5v0kNI+jdI=
+go.opentelemetry.io/otel/sdk/metric v0.36.1-0.20230221193137-99ec432679fb/go.mod h1:Lv4HQQPSCSkhyBKzLNtE8YhTSdK4HCwNh3lh7CiR20s=
 go.opentelemetry.io/otel/trace v1.13.0 h1:CBgRZ6ntv+Amuj1jDsMhZtlAPT6gbyIRdaIzFhfBSdY=
 go.opentelemetry.io/otel/trace v1.13.0/go.mod h1:muCvmmO9KKpvuXSf3KKAXXB2ygNYHQ+ZfI5X08d3tds=
 go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=

--- a/instrumentation/google.golang.org/grpc/otelgrpc/test/grpc_test.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/test/grpc_test.go
@@ -586,7 +586,8 @@ func assertEvents(t *testing.T, expected, actual []trace.Event) bool {
 }
 
 func checkUnaryServerRecords(t *testing.T, reader metric.Reader) {
-	rm, err := reader.Collect(context.Background())
+	rm := metricdata.ResourceMetrics{}
+	err := reader.Collect(context.Background(), &rm)
 	assert.NoError(t, err)
 	require.Len(t, rm.ScopeMetrics, 1)
 	require.Len(t, rm.ScopeMetrics[0].Metrics, 1)

--- a/instrumentation/net/http/otelhttp/test/go.mod
+++ b/instrumentation/net/http/otelhttp/test/go.mod
@@ -7,7 +7,7 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.39.0
 	go.opentelemetry.io/otel v1.13.0
 	go.opentelemetry.io/otel/sdk v1.13.0
-	go.opentelemetry.io/otel/sdk/metric v0.36.0
+	go.opentelemetry.io/otel/sdk/metric v0.36.1-0.20230221193137-99ec432679fb
 	go.opentelemetry.io/otel/trace v1.13.0
 )
 
@@ -17,7 +17,7 @@ require (
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/metric v0.36.0 // indirect
+	go.opentelemetry.io/otel/metric v0.36.1-0.20230221193137-99ec432679fb // indirect
 	golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/instrumentation/net/http/otelhttp/test/go.sum
+++ b/instrumentation/net/http/otelhttp/test/go.sum
@@ -20,12 +20,12 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 go.opentelemetry.io/otel v1.13.0 h1:1ZAKnNQKwBBxFtww/GwxNUyTf0AxkZzrukO8MeXqe4Y=
 go.opentelemetry.io/otel v1.13.0/go.mod h1:FH3RtdZCzRkJYFTCsAKDy9l/XYjMdNv6QrkFFB8DvVg=
-go.opentelemetry.io/otel/metric v0.36.0 h1:t0lgGI+L68QWt3QtOIlqM9gXoxqxWLhZ3R/e5oOAY0Q=
-go.opentelemetry.io/otel/metric v0.36.0/go.mod h1:wKVw57sd2HdSZAzyfOM9gTqqE8v7CbqWsYL6AyrH9qk=
+go.opentelemetry.io/otel/metric v0.36.1-0.20230221193137-99ec432679fb h1:ERlouo+/B1ERdSHUNYj1s4zT+zp2gg2J4/f69tbdio0=
+go.opentelemetry.io/otel/metric v0.36.1-0.20230221193137-99ec432679fb/go.mod h1:wKVw57sd2HdSZAzyfOM9gTqqE8v7CbqWsYL6AyrH9qk=
 go.opentelemetry.io/otel/sdk v1.13.0 h1:BHib5g8MvdqS65yo2vV1s6Le42Hm6rrw08qU6yz5JaM=
 go.opentelemetry.io/otel/sdk v1.13.0/go.mod h1:YLKPx5+6Vx/o1TCUYYs+bpymtkmazOMT6zoRrC7AQ7I=
-go.opentelemetry.io/otel/sdk/metric v0.36.0 h1:dEXpkkOAEcHiRiaZdvd63MouV+3bCtAB/bF3jlNKnr8=
-go.opentelemetry.io/otel/sdk/metric v0.36.0/go.mod h1:Lv4HQQPSCSkhyBKzLNtE8YhTSdK4HCwNh3lh7CiR20s=
+go.opentelemetry.io/otel/sdk/metric v0.36.1-0.20230221193137-99ec432679fb h1:/BUwS+4dNdmMI/ucDWKfR8GYnv+Wfh7po5v0kNI+jdI=
+go.opentelemetry.io/otel/sdk/metric v0.36.1-0.20230221193137-99ec432679fb/go.mod h1:Lv4HQQPSCSkhyBKzLNtE8YhTSdK4HCwNh3lh7CiR20s=
 go.opentelemetry.io/otel/trace v1.13.0 h1:CBgRZ6ntv+Amuj1jDsMhZtlAPT6gbyIRdaIzFhfBSdY=
 go.opentelemetry.io/otel/trace v1.13.0/go.mod h1:muCvmmO9KKpvuXSf3KKAXXB2ygNYHQ+ZfI5X08d3tds=
 golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 h1:h+EGohizhe9XlX18rfpa8k8RAc5XyaeamM+0VHRd4lc=

--- a/instrumentation/net/http/otelhttp/test/handler_test.go
+++ b/instrumentation/net/http/otelhttp/test/handler_test.go
@@ -111,7 +111,8 @@ func TestHandlerBasics(t *testing.T) {
 	}
 	h.ServeHTTP(rr, r)
 
-	rm, err := reader.Collect(context.Background())
+	rm := metricdata.ResourceMetrics{}
+	err = reader.Collect(context.Background(), &rm)
 	require.NoError(t, err)
 	require.Len(t, rm.ScopeMetrics, 1)
 	attrs := attribute.NewSet(


### PR DESCRIPTION
With the Collect signature change in https://github.com/open-telemetry/opentelemetry-go/pull/3732 this PR adjusts all uses of Collect to the new signature.