### PR TITLE
Cherrypick #2983: treat http.NoBody the same as a nil body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.35.1]
+
+### Fixed
+
+- Do not wrap http.NoBody in `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp`, which fixes handling of that special request body. (#3514)
 
 ## [1.10.0/0.35.0/0.5.0]
 

--- a/instrumentation/net/http/otelhttp/handler.go
+++ b/instrumentation/net/http/otelhttp/handler.go
@@ -164,10 +164,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var bw bodyWrapper
-	// if request body is nil we don't want to mutate the body as it will affect
-	// the identity of it in an unforeseeable way because we assert ReadCloser
-	// fulfills a certain interface and it is indeed nil.
-	if r.Body != nil {
+	// if request body is nil or NoBody, we don't want to mutate the body as it
+	// will affect the identity of it in an unforeseeable way because we assert
+	// ReadCloser fulfills a certain interface and it is indeed nil or NoBody.
+	if r.Body != nil && r.Body != http.NoBody {
 		bw.ReadCloser = r.Body
 		bw.record = readRecordFunc
 		r.Body = &bw

--- a/instrumentation/net/http/otelhttp/handler_test.go
+++ b/instrumentation/net/http/otelhttp/handler_test.go
@@ -59,3 +59,23 @@ func TestHandlerReadingNilBodySuccess(t *testing.T) {
 	h.ServeHTTP(rr, r)
 	assert.Equal(t, 200, rr.Result().StatusCode)
 }
+
+// This use case is important as we make sure the body isn't mutated
+// when it is NoBody.
+func TestHandlerReadingNoBodySuccess(t *testing.T) {
+	h := otelhttp.NewHandler(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Body != http.NoBody {
+				_, err := io.ReadAll(r.Body)
+				assert.NoError(t, err)
+			}
+		}), "test_handler",
+	)
+
+	r, err := http.NewRequest(http.MethodGet, "http://localhost/", http.NoBody)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, r)
+	assert.Equal(t, 200, rr.Result().StatusCode)
+}

--- a/instrumentation/net/http/otelhttp/version.go
+++ b/instrumentation/net/http/otelhttp/version.go
@@ -16,7 +16,7 @@ package otelhttp // import "go.opentelemetry.io/contrib/instrumentation/net/http
 
 // Version is the current release version of the otelhttp instrumentation.
 func Version() string {
-	return "0.35.0"
+	return "0.35.1"
 	// This string is updated by the pre_release.sh script during release
 }
 


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-go-contrib/issues/3513