### PR TITLE
Disable adding the mongo 'db.statement' tag by default

### DIFF
--- a/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/config.go
+++ b/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/config.go
@@ -33,7 +33,8 @@ type config struct {
 // newConfig returns a config with all Options set.
 func newConfig(opts ...Option) config {
 	cfg := config{
-		TracerProvider: otel.GetTracerProvider(),
+		TracerProvider:           otel.GetTracerProvider(),
+		CommandAttributeDisabled: true,
 	}
 	for _, opt := range opts {
 		opt.apply(&cfg)
@@ -68,7 +69,8 @@ func WithTracerProvider(provider trace.TracerProvider) Option {
 }
 
 // WithCommandAttributeDisabled specifies if the MongoDB command is added as an attribute to Spans or not.
-// The MongoDB command will be added as an attribute to Spans by default if this option is not provided.
+// This is disabled by default and the MongoDB command will not be added as an attribute
+// to Spans if this option is not provided.
 func WithCommandAttributeDisabled(disabled bool) Option {
 	return optionFunc(func(cfg *config) {
 		cfg.CommandAttributeDisabled = disabled


### PR DESCRIPTION
As of now, the 'db.statement' tag is not obfuscated, which can lead to sensitive information being leaked through the tag.

See #3388.