### PR TITLE
Avoid NPE when ClientConn is nil in otelgrpc interceptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Add the new `go.opentelemetry.io/contrib/instrgen` package to provide auto-generated source code instrumentation. (#3068)
+- [otelgrpc] Avoid panic on target lookup when using a client implementation that doesn't use ClientConn struct #3537
 
 ## [1.16.0-rc.1/0.41.0-rc.1/0.9.0-rc.1] - 2023-03-02
 

--- a/instrumentation/google.golang.org/grpc/otelgrpc/interceptor.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/interceptor.go
@@ -82,7 +82,7 @@ func UnaryClientInterceptor(opts ...Option) grpc.UnaryClientInterceptor {
 			return invoker(ctx, method, req, reply, cc, callOpts...)
 		}
 
-		name, attr := spanInfo(method, cc.Target())
+		name, attr := spanInfo(method, target(cc))
 		var span trace.Span
 		ctx, span = tracer.Start(
 			ctx,
@@ -232,6 +232,15 @@ func (w *clientStream) sendStreamEvent(eventType streamEventType, err error) {
 	}
 }
 
+func target(cc *grpc.ClientConn) string {
+	// Since cc is ClientConn instead of ClientConnInterface, it  can be null in some
+	// situations.
+	if cc == nil {
+		return "unknown"
+	}
+	return cc.Target()
+}
+
 // StreamClientInterceptor returns a grpc.StreamClientInterceptor suitable
 // for use in a grpc.Dial call.
 func StreamClientInterceptor(opts ...Option) grpc.StreamClientInterceptor {
@@ -257,7 +266,7 @@ func StreamClientInterceptor(opts ...Option) grpc.StreamClientInterceptor {
 			return streamer(ctx, desc, cc, method, callOpts...)
 		}
 
-		name, attr := spanInfo(method, cc.Target())
+		name, attr := spanInfo(method, target(cc))
 		var span trace.Span
 		ctx, span = tracer.Start(
 			ctx,


### PR DESCRIPTION
When using some libraries, ClientConn is undefined. In these situations, avoid a panic when trying to retrieve the name of the target. Example scenario is when using the [inprocess channel](https://github.com/fullstorydev/grpchan/tree/master/inprocgrpc) in [github.com/fullstorydev/grpchan](https://github.com/fullstorydev/grpchan)