### PR TITLE
Fix dependabot-pr worfklow, wrap 1.20 in quotes for proper parsing

### DIFF
--- a/.github/workflows/create-dependabot-pr.yml
+++ b/.github/workflows/create-dependabot-pr.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: '1.20'
 
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
The create-dependabot-pr workflow has been broken since #3516 due to needing quotes around 1.20 for the go-version with the setup-go action.


Current failing runs are downloading Go 1.2.2:
https://github.com/open-telemetry/opentelemetry-go-contrib/actions/runs/4356051858/jobs/7613516442