### PR TITLE
fix aws sdk span name

### DIFF
--- a/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/aws.go
+++ b/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/aws.go
@@ -60,6 +60,7 @@ func (m otelMiddlewares) initializeMiddlewareAfter(stack *middleware.Stack) erro
 		ctx context.Context, in middleware.InitializeInput, next middleware.InitializeHandler) (
 		out middleware.InitializeOutput, metadata middleware.Metadata, err error) {
 		serviceID := v2Middleware.GetServiceID(ctx)
+		operation := v2Middleware.GetOperationName(ctx)
 
 		attributes := []attribute.KeyValue{
 			ServiceAttr(serviceID),
@@ -70,7 +71,7 @@ func (m otelMiddlewares) initializeMiddlewareAfter(stack *middleware.Stack) erro
 			attributes = append(attributes, setter(ctx, in)...)
 		}
 
-		ctx, span := m.tracer.Start(ctx, serviceID,
+		ctx, span := m.tracer.Start(ctx, serviceID+"."+operation,
 			trace.WithTimestamp(ctx.Value(spanTimestampKey{}).(time.Time)),
 			trace.WithSpanKind(trace.SpanKindClient),
 			trace.WithAttributes(attributes...),

--- a/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/test/aws_test.go
+++ b/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/test/aws_test.go
@@ -138,7 +138,7 @@ func TestAppendMiddlewares(t *testing.T) {
 			require.Len(t, spans, 1)
 			span := spans[0]
 
-			assert.Equal(t, "Route 53", span.Name())
+			assert.Equal(t, "Route 53.ChangeResourceRecordSets", span.Name())
 			assert.Equal(t, trace.SpanKindClient, span.SpanKind())
 			assert.Equal(t, c.expectedError, span.Status().Code)
 			attrs := span.Attributes()

--- a/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/test/dynamodbattributes_test.go
+++ b/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/test/dynamodbattributes_test.go
@@ -93,7 +93,7 @@ func TestDynamodbTags(t *testing.T) {
 		require.Len(t, spans, 1)
 		span := spans[0]
 
-		assert.Equal(t, "DynamoDB", span.Name())
+		assert.Equal(t, "DynamoDB.GetItem", span.Name())
 		assert.Equal(t, trace.SpanKindClient, span.SpanKind())
 		attrs := span.Attributes()
 		assert.Contains(t, attrs, attribute.Int("http.status_code", cases.expectedStatusCode))
@@ -182,7 +182,7 @@ func TestDynamodbTagsCustomSetter(t *testing.T) {
 		require.Len(t, spans, 1)
 		span := spans[0]
 
-		assert.Equal(t, "DynamoDB", span.Name())
+		assert.Equal(t, "DynamoDB.GetItem", span.Name())
 		assert.Equal(t, trace.SpanKindClient, span.SpanKind())
 		attrs := span.Attributes()
 		assert.Contains(t, attrs, attribute.Int("http.status_code", cases.expectedStatusCode))


### PR DESCRIPTION
Fix span name in order to match [semcov](https://github.com/open-telemetry/opentelemetry-specification/blob/66f8c4c884d75ed3882af4f31ab036271bdd2a94/specification/trace/semantic_conventions/instrumentation/aws-sdk.md ) Service.Operation format
