### PR TITLE
Add WithResource option for the remote sampler constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Add the new `go.opentelemetry.io/contrib/instrgen` package to provide auto-generated source code instrumentation. (#3068, #3108)
+- Add a new Resource Option that can be passed into the AWS XRay Remote Sampling cosntructor in `go.opentelemetry.io/contrib/samplers/aws/xray`. (#3658)
 
 ## [1.16.0-rc.2/0.41.0-rc.2/0.10.0-rc.2] - 2023-03-23
 


### PR DESCRIPTION
To be consistent across the OTel SDK XRay samplers, the service name and cloud platform fields of the Remote Sampler should be able to be retrieved from a Resource. Currently, These fields are only configurable through the Remote Sampler constructor.

Context of Issue:
The resource of the TracerProvider is not available to the sampler ([GH Issue](https://github.com/open-telemetry/opentelemetry-specification/issues/1588)), and it does not look like it will be anytime soon. As an alternative, the resource should be able to be passed into the sampler instantiation.