### PR TITLE
Add the Go inst approvers to owners of instrgen

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -57,4 +57,4 @@ samplers/jaegerremote/                                                  @open-te
 samplers/probability/consistent/                                        @open-telemetry/go-approvers @MadVikingGod
 
 zpages/                                                                 @open-telemetry/go-approvers
-instrgen/                                                               @open-telemetry/go-approvers @MrAlias @pdelewski
+instrgen/                                                               @open-telemetry/go-approvers @open-telemetry/go-instrumentation-approvers @MrAlias @pdelewski


### PR DESCRIPTION
The @open-telemetry/go-instrumentation-approvers team needs to be notified and a review requested when changes to instrgen occur.