### PR TITLE
instrgen fixing imports

### DIFF
--- a/instrgen/driver/testdata/basic/fib.go
+++ b/instrgen/driver/testdata/basic/fib.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:all
+//nolint:all // Linter is executed at the same time as tests which leads to race conditions and failures.
 package main
 
 import (

--- a/instrgen/driver/testdata/basic/goroutines.go
+++ b/instrgen/driver/testdata/basic/goroutines.go
@@ -17,8 +17,6 @@ package main
 
 import (
 	"fmt"
-
-	"go.opentelemetry.io/contrib/instrgen/rtlib"
 )
 
 func goroutines() {

--- a/instrgen/driver/testdata/basic/goroutines.go
+++ b/instrgen/driver/testdata/basic/goroutines.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:all
+//nolint:all // Linter is executed at the same time as tests which leads to race conditions and failures.
 package main
 
 import (

--- a/instrgen/driver/testdata/basic/main.go
+++ b/instrgen/driver/testdata/basic/main.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:all
+//nolint:all // Linter is executed at the same time as tests which leads to race conditions and failures.
 package main
 
 import (

--- a/instrgen/driver/testdata/basic/methods.go
+++ b/instrgen/driver/testdata/basic/methods.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:all
+//nolint:all // Linter is executed at the same time as tests which leads to race conditions and failures.
 package main
 
 type element struct {

--- a/instrgen/driver/testdata/basic/methods.go
+++ b/instrgen/driver/testdata/basic/methods.go
@@ -15,10 +15,6 @@
 //nolint:all
 package main
 
-import (
-	"go.opentelemetry.io/contrib/instrgen/rtlib"
-)
-
 type element struct {
 }
 

--- a/instrgen/driver/testdata/basic/package.go
+++ b/instrgen/driver/testdata/basic/package.go
@@ -17,8 +17,6 @@ package main
 
 import (
 	"os"
-
-	"go.opentelemetry.io/contrib/instrgen/rtlib"
 )
 
 func Close() error {

--- a/instrgen/driver/testdata/basic/package.go
+++ b/instrgen/driver/testdata/basic/package.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:all
+//nolint:all // Linter is executed at the same time as tests which leads to race conditions and failures.
 package main
 
 import (

--- a/instrgen/driver/testdata/dummy/main.go
+++ b/instrgen/driver/testdata/dummy/main.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:all
+//nolint:all // Linter is executed at the same time as tests which leads to race conditions and failures.
 package main
 
 func main() {

--- a/instrgen/driver/testdata/expected/basic/fib.go
+++ b/instrgen/driver/testdata/expected/basic/fib.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:all
+//nolint:all // Linter is executed at the same time as tests which leads to race conditions and failures.
 package main
 
 import (

--- a/instrgen/driver/testdata/expected/basic/goroutines.go
+++ b/instrgen/driver/testdata/expected/basic/goroutines.go
@@ -18,8 +18,6 @@ package main
 import (
 	"fmt"
 	__atel_context "context"
-
-	"go.opentelemetry.io/contrib/instrgen/rtlib"
 	__atel_otel "go.opentelemetry.io/otel"
 )
 

--- a/instrgen/driver/testdata/expected/basic/goroutines.go
+++ b/instrgen/driver/testdata/expected/basic/goroutines.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:all
+//nolint:all // Linter is executed at the same time as tests which leads to race conditions and failures.
 package main
 
 import (

--- a/instrgen/driver/testdata/expected/basic/main.go
+++ b/instrgen/driver/testdata/expected/basic/main.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:all
+//nolint:all // Linter is executed at the same time as tests which leads to race conditions and failures.
 package main
 
 import (

--- a/instrgen/driver/testdata/expected/basic/methods.go
+++ b/instrgen/driver/testdata/expected/basic/methods.go
@@ -16,9 +16,8 @@
 package main
 
 import (
-	"go.opentelemetry.io/contrib/instrgen/rtlib"
-	__atel_otel "go.opentelemetry.io/otel"
 	__atel_context "context"
+	__atel_otel "go.opentelemetry.io/otel"
 )
 
 type element struct {

--- a/instrgen/driver/testdata/expected/basic/methods.go
+++ b/instrgen/driver/testdata/expected/basic/methods.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:all
+//nolint:all // Linter is executed at the same time as tests which leads to race conditions and failures.
 package main
 
 import (

--- a/instrgen/driver/testdata/expected/basic/package.go
+++ b/instrgen/driver/testdata/expected/basic/package.go
@@ -18,8 +18,6 @@ package main
 import (
 	"os"
 	__atel_context "context"
-
-	"go.opentelemetry.io/contrib/instrgen/rtlib"
 	__atel_otel "go.opentelemetry.io/otel"
 )
 

--- a/instrgen/driver/testdata/expected/basic/package.go
+++ b/instrgen/driver/testdata/expected/basic/package.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:all
+//nolint:all // Linter is executed at the same time as tests which leads to race conditions and failures.
 package main
 
 import (

--- a/instrgen/driver/testdata/expected/interface/app/impl.go
+++ b/instrgen/driver/testdata/expected/interface/app/impl.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:all
+//nolint:all // Linter is executed at the same time as tests which leads to race conditions and failures.
 package app
 
 import (

--- a/instrgen/driver/testdata/expected/interface/main.go
+++ b/instrgen/driver/testdata/expected/interface/main.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:all
+//nolint:all // Linter is executed at the same time as tests which leads to race conditions and failures.
 package main
 
 import (

--- a/instrgen/driver/testdata/expected/interface/serializer/interface.go
+++ b/instrgen/driver/testdata/expected/interface/serializer/interface.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:all
+//nolint:all // Linter is executed at the same time as tests which leads to race conditions and failures.
 package serializer
 
 import __atel_context "context"

--- a/instrgen/driver/testdata/expected/selector/main.go
+++ b/instrgen/driver/testdata/expected/selector/main.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:all
+//nolint:all // Linter is executed at the same time as tests which leads to race conditions and failures.
 package main
 
 import (

--- a/instrgen/driver/testdata/funwithoutpathtoroot/driver.go
+++ b/instrgen/driver/testdata/funwithoutpathtoroot/driver.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:all
+//nolint:all // Linter is executed at the same time as tests which leads to race conditions and failures.
 package main
 
 import (

--- a/instrgen/driver/testdata/interface/app/impl.go
+++ b/instrgen/driver/testdata/interface/app/impl.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:all
+//nolint:all // Linter is executed at the same time as tests which leads to race conditions and failures.
 package app
 
 import (

--- a/instrgen/driver/testdata/interface/main.go
+++ b/instrgen/driver/testdata/interface/main.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:all
+//nolint:all // Linter is executed at the same time as tests which leads to race conditions and failures.
 package main
 
 import (

--- a/instrgen/driver/testdata/interface/serializer/interface.go
+++ b/instrgen/driver/testdata/interface/serializer/interface.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:all
+//nolint:all // Linter is executed at the same time as tests which leads to race conditions and failures.
 package serializer
 
 type Serializer interface {

--- a/instrgen/driver/testdata/selector/main.go
+++ b/instrgen/driver/testdata/selector/main.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:all
+//nolint:all // Linter is executed at the same time as tests which leads to race conditions and failures.
 package main
 
 import (


### PR DESCRIPTION
Remove import that only is needed in `main.go` from the other test data files so it will not fail the build.