### PR TITLE
Fix cardinality issue for rpc.server.duration (#3536)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ Thumbs.db
 .tools/
 .idea/
 .vscode/
+vendor/
 *.iml
 *.so
 coverage.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - Prevent taking from reservoir in AWS XRay Remote Sampler when there is zero capacity in `go.opentelemetry.io/contrib/samplers/aws/xray`. (#3684)
+- Improved `go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc` to optionally, off by default, use peer information as an attribute for the meter rpc.server.duration (#3536)
 
 ## [1.16.0-rc.2/0.41.0-rc.2/0.10.0-rc.2] - 2023-03-23
 

--- a/instrumentation/google.golang.org/grpc/otelgrpc/config.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/config.go
@@ -43,8 +43,9 @@ type config struct {
 	TracerProvider trace.TracerProvider
 	MeterProvider  metric.MeterProvider
 
-	meter             metric.Meter
-	rpcServerDuration instrument.Int64Histogram
+	meter                           metric.Meter
+	rpcServerDuration               instrument.Int64Histogram
+	includeRPCServerDurationPeerCtx bool
 }
 
 // Option applies an option value for a config.
@@ -125,6 +126,20 @@ func (o meterProviderOption) apply(c *config) {
 	if o.mp != nil {
 		c.MeterProvider = o.mp
 	}
+}
+
+type includePeerAddrAsAttribute struct {
+	use bool
+}
+
+// WithPeerAddrAsAttribute returns an Option to use peer details when
+// recording with the meter rpc.server.duration.
+func WithPeerAddrAsAttribute(peerAddrAsAttribute bool) Option {
+	return includePeerAddrAsAttribute{use: peerAddrAsAttribute}
+}
+
+func (o includePeerAddrAsAttribute) apply(c *config) {
+	c.includeRPCServerDurationPeerCtx = o.use
 }
 
 // WithMeterProvider returns an Option to use the MeterProvider when

--- a/instrumentation/google.golang.org/grpc/otelgrpc/test/bufconn_mock.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/test/bufconn_mock.go
@@ -1,0 +1,102 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"google.golang.org/grpc/test/bufconn"
+	"net"
+	"time"
+)
+
+const (
+	mockIp   = "1.1.1.1"
+	mockPort = 1234
+)
+
+var (
+	mockAddr, _ = net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:%d", mockIp, mockPort))
+)
+
+// bufConnMock wraps a bufconn.Lister for the sake of returning a valid address. This is so we can properly test
+// returning net.sock.peer.addr and net.sock.peer.port attributes
+type bufConnMock struct {
+	listener *bufconn.Listener
+}
+
+func NewMockBufConn(size int) *bufConnMock {
+	return &bufConnMock{
+		listener: bufconn.Listen(size),
+	}
+}
+
+func (b *bufConnMock) Accept() (net.Conn, error) {
+	conn, err := b.listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+
+	return &bufConn{
+		conn: conn,
+	}, nil
+}
+
+func (b *bufConnMock) Close() error {
+	return b.listener.Close()
+}
+
+func (b *bufConnMock) Addr() net.Addr {
+	return mockAddr
+}
+
+func (b *bufConnMock) Dial() (net.Conn, error) {
+	// bufConnect's listener Dial implementation just calls
+	// DialContext under the covers so don't wrap the connection in our mock here
+	return b.listener.DialContext(context.Background())
+}
+
+func (b *bufConnMock) DialContext(ctx context.Context) (net.Conn, error) {
+	conn, err := b.listener.DialContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &bufConn{
+		conn: conn,
+	}, nil
+}
+
+type bufConn struct {
+	conn net.Conn
+}
+
+func (b *bufConn) Read(bytes []byte) (n int, err error) {
+	return b.conn.Read(bytes)
+}
+
+func (b *bufConn) Write(bytes []byte) (n int, err error) {
+	return b.conn.Write(bytes)
+}
+
+func (b *bufConn) Close() error {
+	return b.conn.Close()
+}
+
+func (b *bufConn) LocalAddr() net.Addr {
+	return mockAddr
+}
+
+func (b *bufConn) RemoteAddr() net.Addr {
+	return mockAddr
+}
+
+func (b *bufConn) SetDeadline(t time.Time) error {
+	return b.conn.SetDeadline(t)
+}
+
+func (b *bufConn) SetReadDeadline(t time.Time) error {
+	return b.conn.SetReadDeadline(t)
+}
+
+func (b *bufConn) SetWriteDeadline(t time.Time) error {
+	return b.conn.SetWriteDeadline(t)
+}

--- a/instrumentation/google.golang.org/grpc/otelgrpc/test/interceptor_test.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/test/interceptor_test.go
@@ -694,10 +694,22 @@ func assertServerSpan(t *testing.T, wantSpanCode codes.Code, wantSpanStatusDescr
 }
 
 // TestUnaryServerInterceptor tests the server interceptor for unary RPCs.
-func TestUnaryServerInterceptor(t *testing.T) {
+func TestUnaryServerInterceptorWithPeerAddrAsAttribute(t *testing.T) {
 	sr := tracetest.NewSpanRecorder()
 	tp := trace.NewTracerProvider(trace.WithSpanProcessor(sr))
-	usi := otelgrpc.UnaryServerInterceptor(otelgrpc.WithTracerProvider(tp))
+	usi := otelgrpc.UnaryServerInterceptor(otelgrpc.WithTracerProvider(tp), otelgrpc.WithPeerAddrAsAttribute(true))
+	runServerChecks(t, usi, sr)
+}
+
+// TestUnaryServerInterceptor tests the server interceptor for unary RPCs.
+func TestUnaryServerInterceptorWithoutPeerAddrAsAttribute(t *testing.T) {
+	sr := tracetest.NewSpanRecorder()
+	tp := trace.NewTracerProvider(trace.WithSpanProcessor(sr))
+	usi := otelgrpc.UnaryServerInterceptor(otelgrpc.WithTracerProvider(tp), otelgrpc.WithPeerAddrAsAttribute(false))
+	runServerChecks(t, usi, sr)
+}
+
+func runServerChecks(t *testing.T, usi grpc.UnaryServerInterceptor, sr *tracetest.SpanRecorder) {
 	for _, check := range serverChecks {
 		name := check.grpcCode.String()
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
Added an optional parameter for allowing peer information to be added as an attribute. By default the gRPC interceptor will ignore peer details for the sake of performance.

Related issue: https://github.com/open-telemetry/opentelemetry-go-contrib/issues/3536