### PR TITLE
[otelhttp] add options to disable traces/metrics in otelhttp.NewHandler

### DIFF
--- a/instrumentation/net/http/otelhttp/config.go
+++ b/instrumentation/net/http/otelhttp/config.go
@@ -44,6 +44,8 @@ type config struct {
 	Filters           []Filter
 	SpanNameFormatter func(string, *http.Request) string
 	ClientTrace       func(context.Context) *httptrace.ClientTrace
+	DisableTraces     bool
+	DisableMetrics    bool
 
 	TracerProvider trace.TracerProvider
 	MeterProvider  metric.MeterProvider
@@ -204,5 +206,19 @@ func WithClientTrace(f func(context.Context) *httptrace.ClientTrace) Option {
 func WithServerName(server string) Option {
 	return optionFunc(func(c *config) {
 		c.ServerName = server
+	})
+}
+
+// WithDisableTraces disables traces processing.
+func WithDisableTraces(disableTraces bool) Option {
+	return optionFunc(func(cfg *config) {
+		cfg.DisableTraces = disableTraces
+	})
+}
+
+// WithDisableMetrics disables metrics processing.
+func WithDisableMetrics(disableMetrics bool) Option {
+	return optionFunc(func(cfg *config) {
+		cfg.DisableMetrics = disableMetrics
 	})
 }


### PR DESCRIPTION
`otelhttp.NewHandler` handles both traces and metrics.

When we use other libraries for traces, for instance, `otelmux`, which doesn't have metrics, we would like to use the default metrics to be consistent, but currently it is not possible to use just metrics.

I tried to add a `noop` tracer provider option, but [it seems that it is not intended to be used this way](https://github.com/open-telemetry/opentelemetry-go/issues/4027).

This PR adds 2 new options: `WithDisableTraces` and `WithDisableMetrics`. The "disable" name is used to keep compatilibity with the default being "enabled".