### PR TITLE
Update HTTP span names to match semantic conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Add the new `go.opentelemetry.io/contrib/instrgen` package to provide auto-generated source code instrumentation. (#3068, #3108)
+- Update HTTP span names to match semantic conventions. (#3771)
 
 ## [1.16.1/0.41.1/0.10.1] - 2023-05-02
 
@@ -52,7 +53,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- AWS SDK rename attributes `aws.operation`, `aws.service` to `rpc.method`,`rpc.service` in `go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws`. (#3582, #3617) 
+- AWS SDK rename attributes `aws.operation`, `aws.service` to `rpc.method`,`rpc.service` in `go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws`. (#3582, #3617)
 - AWS SDK span name to be of the format `Service.Operation` in `go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws`. (#3582, #3521)
 - Prevent sampler configuration reset from erroneously sampling first span in `go.opentelemetry.io/contrib/samplers/jaegerremote`. (#3603, #3604)
 

--- a/instrumentation/net/http/otelhttp/test/client_test.go
+++ b/instrumentation/net/http/otelhttp/test/client_test.go
@@ -80,10 +80,10 @@ func TestConvenienceWrappers(t *testing.T) {
 
 	spans := sr.Ended()
 	require.Equal(t, 4, len(spans))
-	assert.Equal(t, "HTTP GET", spans[0].Name())
-	assert.Equal(t, "HTTP HEAD", spans[1].Name())
-	assert.Equal(t, "HTTP POST", spans[2].Name())
-	assert.Equal(t, "HTTP POST", spans[3].Name())
+	assert.Equal(t, "GET", spans[0].Name())
+	assert.Equal(t, "HEAD", spans[1].Name())
+	assert.Equal(t, "POST", spans[2].Name())
+	assert.Equal(t, "POST", spans[3].Name())
 }
 
 func TestClientWithTraceContext(t *testing.T) {
@@ -112,7 +112,7 @@ func TestClientWithTraceContext(t *testing.T) {
 
 	spans := sr.Ended()
 	require.Equal(t, 2, len(spans))
-	assert.Equal(t, "HTTP GET", spans[0].Name())
+	assert.Equal(t, "GET", spans[0].Name())
 	assert.Equal(t, "http requests", spans[1].Name())
 	assert.NotEmpty(t, spans[0].Parent().SpanID())
 	assert.Equal(t, spans[1].SpanContext().SpanID(), spans[0].Parent().SpanID())

--- a/instrumentation/net/http/otelhttp/test/config_test.go
+++ b/instrumentation/net/http/otelhttp/test/config_test.go
@@ -85,10 +85,10 @@ func TestSpanNameFormatter(t *testing.T) {
 		},
 		{
 			name: "default transport formatter",
-			formatter: func(_ string, r *http.Request) string {
-				return "HTTP " + r.Method
+			formatter: func(s string, r *http.Request) string {
+				return "HTTP " + r.Method + " " + r.URL.Path
 			},
-			expected: "HTTP GET",
+			expected: "HTTP GET /hello",
 		},
 		{
 			name: "custom formatter",

--- a/instrumentation/net/http/otelhttp/test/config_test.go
+++ b/instrumentation/net/http/otelhttp/test/config_test.go
@@ -15,7 +15,6 @@
 package test
 
 import (
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -31,9 +30,9 @@ import (
 func testDefaultTransportFormatter(_ string, r *http.Request) string {
 	path := r.URL.Path
 	if path == "" {
-		return fmt.Sprintf("HTTP %s", r.Method)
+		return r.Method
 	}
-	return fmt.Sprintf("HTTP %s %s", r.Method, path)
+	return r.Method + " " + path
 }
 
 func TestBasicFilter(t *testing.T) {
@@ -95,7 +94,7 @@ func TestSpanNameFormatter(t *testing.T) {
 		{
 			name: "default transport formatter",
 			formatter: testDefaultTransportFormatter,
-			expected: "HTTP GET /hello",
+			expected: "GET /hello",
 		},
 		{
 			name: "custom formatter",

--- a/instrumentation/net/http/otelhttp/test/config_test.go
+++ b/instrumentation/net/http/otelhttp/test/config_test.go
@@ -15,6 +15,7 @@
 package test
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -26,6 +27,14 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
+
+func testDefaultTransportFormatter(_ string, r *http.Request) string {
+	path := r.URL.Path
+	if path == "" {
+		return fmt.Sprintf("HTTP %s", r.Method)
+	}
+	return fmt.Sprintf("HTTP %s %s", r.Method, path)
+}
 
 func TestBasicFilter(t *testing.T) {
 	rr := httptest.NewRecorder()
@@ -85,9 +94,7 @@ func TestSpanNameFormatter(t *testing.T) {
 		},
 		{
 			name: "default transport formatter",
-			formatter: func(s string, r *http.Request) string {
-				return "HTTP " + r.Method + " " + r.URL.Path
-			},
+			formatter: testDefaultTransportFormatter,
 			expected: "HTTP GET /hello",
 		},
 		{

--- a/instrumentation/net/http/otelhttp/test/config_test.go
+++ b/instrumentation/net/http/otelhttp/test/config_test.go
@@ -92,9 +92,9 @@ func TestSpanNameFormatter(t *testing.T) {
 			expected:  "test_operation",
 		},
 		{
-			name: "default transport formatter",
+			name:      "default transport formatter",
 			formatter: testDefaultTransportFormatter,
-			expected: "GET /hello",
+			expected:  "GET /hello",
 		},
 		{
 			name: "custom formatter",

--- a/instrumentation/net/http/otelhttp/test/transport_test.go
+++ b/instrumentation/net/http/otelhttp/test/transport_test.go
@@ -73,7 +73,7 @@ func TestTransportUsesFormatter(t *testing.T) {
 
 	spans := spanRecorder.Ended()
 	spanName := spans[0].Name()
-	expectedName := "HTTP GET"
+	expectedName := "GET"
 	if spanName != expectedName {
 		t.Fatalf("unexpected name: got %s, expected %s", spanName, expectedName)
 	}
@@ -171,7 +171,7 @@ func TestTransportRequestWithTraceContext(t *testing.T) {
 	require.Len(t, spans, 2)
 
 	assert.Equal(t, "test_span", spans[0].Name())
-	assert.Equal(t, "HTTP GET", spans[1].Name())
+	assert.Equal(t, "GET", spans[1].Name())
 	assert.NotEmpty(t, spans[1].Parent().SpanID())
 	assert.Equal(t, spans[0].SpanContext().SpanID(), spans[1].Parent().SpanID())
 }
@@ -232,7 +232,7 @@ func TestWithHTTPTrace(t *testing.T) {
 
 	assert.Equal(t, "httptrace.GetConn", spans[0].Name())
 	assert.Equal(t, "test_span", spans[1].Name())
-	assert.Equal(t, "HTTP GET", spans[2].Name())
+	assert.Equal(t, "GET", spans[2].Name())
 	assert.NotEmpty(t, spans[0].Parent().SpanID())
 	assert.NotEmpty(t, spans[2].Parent().SpanID())
 	assert.Equal(t, spans[2].SpanContext().SpanID(), spans[0].Parent().SpanID())

--- a/instrumentation/net/http/otelhttp/transport.go
+++ b/instrumentation/net/http/otelhttp/transport.go
@@ -16,7 +16,6 @@ package otelhttp // import "go.opentelemetry.io/contrib/instrumentation/net/http
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptrace"
@@ -80,9 +79,9 @@ func (t *Transport) applyConfig(c *config) {
 func defaultTransportFormatter(_ string, r *http.Request) string {
 	path := r.URL.Path
 	if path == "" {
-		return fmt.Sprintf("HTTP %s", r.Method)
+		return r.Method
 	}
-	return fmt.Sprintf("HTTP %s %s", r.Method, path)
+	return r.Method + " " + path
 }
 
 // RoundTrip creates a Span and propagates its context via the provided request's headers

--- a/instrumentation/net/http/otelhttp/transport.go
+++ b/instrumentation/net/http/otelhttp/transport.go
@@ -16,6 +16,7 @@ package otelhttp // import "go.opentelemetry.io/contrib/instrumentation/net/http
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptrace"
@@ -77,7 +78,11 @@ func (t *Transport) applyConfig(c *config) {
 }
 
 func defaultTransportFormatter(_ string, r *http.Request) string {
-	return "HTTP " + r.Method
+	path := r.URL.Path
+	if path == "" {
+		return fmt.Sprintf("HTTP %s", r.Method)
+	}
+	return fmt.Sprintf("HTTP %s %s", r.Method, path)
 }
 
 // RoundTrip creates a Span and propagates its context via the provided request's headers

--- a/instrumentation/net/http/otelhttp/transport_test.go
+++ b/instrumentation/net/http/otelhttp/transport_test.go
@@ -32,14 +32,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-func testDefaultTransportFormatter(_ string, r *http.Request) string {
-	path := r.URL.Path
-	if path == "" {
-		return r.Method
-	}
-	return r.Method + " " + path
-}
-
 func TestTransportFormatter(t *testing.T) {
 	var httpMethods = []struct {
 		name     string
@@ -99,7 +91,7 @@ func TestTransportFormatter(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			formattedName := testDefaultTransportFormatter("", r)
+			formattedName := defaultTransportFormatter("", r)
 
 			if formattedName != tc.expected {
 				t.Fatalf("unexpected name: got %s, expected %s", formattedName, tc.expected)

--- a/instrumentation/net/http/otelhttp/transport_test.go
+++ b/instrumentation/net/http/otelhttp/transport_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -36,9 +35,9 @@ import (
 func testDefaultTransportFormatter(_ string, r *http.Request) string {
 	path := r.URL.Path
 	if path == "" {
-		return fmt.Sprintf("HTTP %s", r.Method)
+		return r.Method
 	}
-	return fmt.Sprintf("HTTP %s %s", r.Method, path)
+	return r.Method + " " + path
 }
 
 func TestTransportFormatter(t *testing.T) {
@@ -50,47 +49,47 @@ func TestTransportFormatter(t *testing.T) {
 		{
 			"GET method",
 			http.MethodGet,
-			"HTTP GET",
+			"GET",
 		},
 		{
 			"HEAD method",
 			http.MethodHead,
-			"HTTP HEAD",
+			"HEAD",
 		},
 		{
 			"POST method",
 			http.MethodPost,
-			"HTTP POST",
+			"POST",
 		},
 		{
 			"PUT method",
 			http.MethodPut,
-			"HTTP PUT",
+			"PUT",
 		},
 		{
 			"PATCH method",
 			http.MethodPatch,
-			"HTTP PATCH",
+			"PATCH",
 		},
 		{
 			"DELETE method",
 			http.MethodDelete,
-			"HTTP DELETE",
+			"DELETE",
 		},
 		{
 			"CONNECT method",
 			http.MethodConnect,
-			"HTTP CONNECT",
+			"CONNECT",
 		},
 		{
 			"OPTIONS method",
 			http.MethodOptions,
-			"HTTP OPTIONS",
+			"OPTIONS",
 		},
 		{
 			"TRACE method",
 			http.MethodTrace,
-			"HTTP TRACE",
+			"TRACE",
 		},
 	}
 


### PR DESCRIPTION
### What problem is this PR solving

- Closes #726 

### Short description of the changes

Current [semantic conventions](https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/http/#name) for http span names do not include "HTTP" and suggest including the route.

This PR:

- updates http span name to include URL path
- removes "HTTP" from the span name
- adds a function for config testing that matches the `defaultTransportFormatter`

Because the `defaultTransportFormatter` is not publicly accessible outside the package, I couldn't pull it into the `config_test` directly, which is why I created a matching function in the tests. Without this, the tests were hardcoded and were not failing as expected when I made changes. This is still somewhat brittle because it doesn't change when the `defaultTransportFormatter` function changes, but it's more reliable than it was.

### How to verify this has the expected result

HTTP Span names should change from, for example, `HTTP GET` to `GET /hello`
