### PR TITLE
Use `strings.Cut()` instead of `string.SplitN()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Add the new `go.opentelemetry.io/contrib/instrgen` package to provide auto-generated source code instrumentation. (#3068, #3108)
 
+### Changed
+
+- Use `strings.Cut()` instead of `string.SplitN()` for better readability and memory use. (#3822)
+
 ## [1.17.0-rc.1/0.42.0-rc.1/0.11.0-rc.1] - 2023-05-17
 
 ### Changed

--- a/instrumentation/google.golang.org/grpc/otelgrpc/internal/parse.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/internal/parse.go
@@ -26,17 +26,17 @@ import (
 // on a gRPC's FullMethod.
 func ParseFullMethod(fullMethod string) (string, []attribute.KeyValue) {
 	name := strings.TrimLeft(fullMethod, "/")
-	parts := strings.SplitN(name, "/", 2)
-	if len(parts) != 2 {
+	service, method, found := strings.Cut(name, "/")
+	if !found {
 		// Invalid format, does not follow `/package.service/method`.
-		return name, []attribute.KeyValue(nil)
+		return name, nil
 	}
 
 	var attrs []attribute.KeyValue
-	if service := parts[0]; service != "" {
+	if service != "" {
 		attrs = append(attrs, semconv.RPCService(service))
 	}
-	if method := parts[1]; method != "" {
+	if method != "" {
 		attrs = append(attrs, semconv.RPCMethod(method))
 	}
 	return name, attrs


### PR DESCRIPTION
`strings.Cut()` generates less garbage as it does not allocate the slice to hold parts. See also https://github.com/open-telemetry/opentelemetry-go/pull/4049.