### PR TITLE
fix otelhttp client span end

### DIFF
--- a/instrumentation/net/http/otelhttp/transport.go
+++ b/instrumentation/net/http/otelhttp/transport.go
@@ -104,6 +104,7 @@ func (t *Transport) RoundTrip(r *http.Request) (*http.Response, error) {
 	opts := append([]trace.SpanStartOption{}, t.spanStartOptions...) // start with the configured options
 
 	ctx, span := tracer.Start(r.Context(), t.spanNameFormatter("", r), opts...)
+	defer span.End()
 
 	if t.clientTrace != nil {
 		ctx = httptrace.WithClientTrace(ctx, t.clientTrace(ctx))
@@ -117,7 +118,6 @@ func (t *Transport) RoundTrip(r *http.Request) (*http.Response, error) {
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
-		span.End()
 		return res, err
 	}
 


### PR DESCRIPTION
Issue: otelhttp client does not end span when err is nil, users will not get the right spans
This PR fix the issue