### PR TITLE
Avoid NPE when ClientConn is nil 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Add the new `go.opentelemetry.io/contrib/instrgen` package to provide auto-generated source code instrumentation. (#3068, #3108)
+- [otelgrpc] Avoid panic on target lookup when using a client implementation that doesn't use ClientConn struct (#3876)
 
 ### Changed
 

--- a/instrumentation/google.golang.org/grpc/otelgrpc/interceptor.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/interceptor.go
@@ -233,6 +233,15 @@ func (w *clientStream) sendStreamEvent(eventType streamEventType, err error) {
 	}
 }
 
+func target(cc *grpc.ClientConn) string {
+	// Since cc is ClientConn instead of ClientConnInterface, it can be nil in some
+	// situations.
+	if cc == nil {
+		return "unknown"
+	}
+	return cc.Target()
+}
+
 // StreamClientInterceptor returns a grpc.StreamClientInterceptor suitable
 // for use in a grpc.Dial call.
 func StreamClientInterceptor(opts ...Option) grpc.StreamClientInterceptor {
@@ -258,7 +267,7 @@ func StreamClientInterceptor(opts ...Option) grpc.StreamClientInterceptor {
 			return streamer(ctx, desc, cc, method, callOpts...)
 		}
 
-		name, attr := spanInfo(method, cc.Target())
+		name, attr := spanInfo(method, target(cc))
 		var span trace.Span
 		ctx, span = tracer.Start(
 			ctx,


### PR DESCRIPTION
- this can happen when using grpchan's inprocess channel for example