### PR TITLE
chore: Update root README with link to exporters dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Collection of 3rd-party packages for [OpenTelemetry-Go](https://github.com/open-
 - [Instrumentation](./instrumentation/): Packages providing OpenTelemetry instrumentation for 3rd-party libraries.
 - [Propagators](./propagators/): Packages providing OpenTelemetry context propagators for 3rd-party propagation formats.
 - [Detectors](./detectors/): Packages providing OpenTelemetry resource detectors for 3rd-party cloud computing environments.
-- [Samplers](./samplers/): Packages providing additional implementations of OpenTelemetry samplers.
 - [Exporters](./exporters/): Packages providing OpenTelemetry exporters for 3rd-party export formats.
+- [Samplers](./samplers/): Packages providing additional implementations of OpenTelemetry samplers.
 
 ## Project Status
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Collection of 3rd-party packages for [OpenTelemetry-Go](https://github.com/open-
 - [Propagators](./propagators/): Packages providing OpenTelemetry context propagators for 3rd-party propagation formats.
 - [Detectors](./detectors/): Packages providing OpenTelemetry resource detectors for 3rd-party cloud computing environments.
 - [Samplers](./samplers/): Packages providing additional implementations of OpenTelemetry samplers.
+- [Exporters](./exporters/): Packages providing OpenTelemetry exporters for 3rd-party export formats.
 
 ## Project Status
 


### PR DESCRIPTION
Updates root readme with links to exporter packages (eg autoexport was added in #2753). I've followed the same text pattern as for other sub directories, but as there is only one package for now it doesn't quite feel correct. Happy for suggestions to make it better.

PS This can have the "skip-changelog" label added.