### PR TITLE
Fix panic in otelhttptrace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - AWS XRay Remote Sampling to cap quotaBalance to 1x quota in `go.opentelemetry.io/contrib/samplers/aws/xray`. (#3651, #3652)
+- Do not panic when the HTTP request has the "Expect: 100-continue" header in `go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace`. (#3892)
 
 ## [1.17.0/0.42.0/0.11.0] - 2023-05-23
 

--- a/instrumentation/net/http/httptrace/otelhttptrace/clienttrace.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/clienttrace.go
@@ -370,7 +370,7 @@ func (ct *clientTracer) got100Continue() {
 func (ct *clientTracer) wait100Continue() {
 	span := ct.root
 	if ct.useSpans {
-		span = ct.span("http.receive")
+		span = ct.span("http.send")
 	}
 	span.AddEvent("GOT 100 - Wait")
 }

--- a/instrumentation/net/http/httptrace/otelhttptrace/test/clienttrace_test.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/test/clienttrace_test.go
@@ -15,11 +15,13 @@
 package test
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httptrace"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -503,4 +505,41 @@ func TestHTTPRequestWithTraceContext(t *testing.T) {
 
 	require.Equal(t, parent.SpanContext().TraceID(), getconn.SpanContext().TraceID())
 	require.Equal(t, parent.SpanContext().SpanID(), getconn.Parent().SpanID())
+}
+
+func TestHTTPRequestWithExpect100Continue(t *testing.T) {
+	fixture := prepareClientTraceTest(t)
+
+	ctx, span := otel.Tracer("oteltest").Start(context.Background(), "root")
+	ctx = httptrace.WithClientTrace(ctx, otelhttptrace.NewClientTrace(ctx))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fixture.URL, bytes.NewReader([]byte("test")))
+	require.NoError(t, err)
+
+	// Set Expect: 100-continue
+	req.Header.Set("Expect", "100-continue")
+	resp, err := fixture.Client.Do(req)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	span.End()
+
+	// Wait for http.send span as per https://pkg.go.dev/net/http/httptrace#ClientTrace:
+	// Functions may be called concurrently from different goroutines and some may be called
+	// after the request has completed
+	var httpSendSpan trace.ReadOnlySpan
+	require.Eventually(t, func() bool {
+		var ok bool
+		httpSendSpan, ok = getSpanFromRecorder(fixture.SpanRecorder, "http.send")
+		return ok
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// Fount http.send span must contains "GOT 100 - Wait" event
+	found := false
+	for _, v := range httpSendSpan.Events() {
+		if v.Name == "GOT 100 - Wait" {
+			found = true
+			break
+		}
+	}
+	require.True(t, found)
 }

--- a/instrumentation/net/http/httptrace/otelhttptrace/test/clienttrace_test.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/test/clienttrace_test.go
@@ -533,7 +533,7 @@ func TestHTTPRequestWithExpect100Continue(t *testing.T) {
 		return ok
 	}, 5*time.Second, 10*time.Millisecond)
 
-	// Fount http.send span must contains "GOT 100 - Wait" event
+	// Found http.send span must contain "GOT 100 - Wait" event
 	found := false
 	for _, v := range httpSendSpan.Events() {
 		if v.Name == "GOT 100 - Wait" {


### PR DESCRIPTION
Wait100Continue trace event is sent here before "http.receive" phase which results with a panic


Wait100Continue is called here : https://cs.opensource.google/go/go/+/refs/tags/go1.20.4:src/net/http/request.go;l=688 while "http.receive" phase is started in the defer here : https://cs.opensource.google/go/go/+/refs/tags/go1.20.4:src/net/http/request.go;l=559

Thus, the span grab here : https://github.com/open-telemetry/opentelemetry-go-contrib/blob/instrumentation/net/http/httptrace/otelhttptrace/example/v0.42.0/instrumentation/net/http/httptrace/otelhttptrace/clienttrace.go#L373 is nil and https://github.com/open-telemetry/opentelemetry-go-contrib/blob/instrumentation/net/http/httptrace/otelhttptrace/example/v0.42.0/instrumentation/net/http/httptrace/otelhttptrace/clienttrace.go#L375 panics

See reproducer at https://gist.github.com/Alkorin/ba749e56911d887d1acbf1de23604095