### PR TITLE
[chore] Update dependabot-pr branch name

### DIFF
--- a/.github/workflows/scripts/dependabot-pr.sh
+++ b/.github/workflows/scripts/dependabot-pr.sh
@@ -17,8 +17,8 @@
 git config user.name opentelemetrybot
 git config user.email 107717825+opentelemetrybot@users.noreply.github.com
 
-PR_NAME=dependabot-prs/`date +'%Y-%m-%dT%H%M%S'`
-git checkout -b $PR_NAME
+BRANCH=dependabot/dependabot-prs/`date +'%Y-%m-%dT%H%M%S'`
+git checkout -b $BRANCH
 
 IFS=$'\n'
 requests=($( gh pr list --search "author:app/dependabot" -l "go" --json title --jq '.[].title' ))
@@ -60,6 +60,6 @@ git add go.sum go.mod
 git add "**/go.sum" "**/go.mod"
 git commit -m "dependabot updates `date`
 $message"
-git push origin $PR_NAME
+git push origin $BRANCH
 
 gh pr create --title "[chore] dependabot updates `date`" --body "$message"


### PR DESCRIPTION
Same as https://github.com/open-telemetry/opentelemetry-go/pull/4191

## Why 

`depedabot.pr.sh` [stopped working](https://github.com/open-telemetry/opentelemetry-go/actions/runs/5169728715/jobs/9312164274) after setting up the [dependabot branch protection rule.](https://github.com/open-telemetry/community/blob/main/docs/how-to-configure-new-repository.md#branch-protection-rule-dependabot)

## What

Update the branch name created by `dependabot-pr.sh` so that it matches the branch name defined in the [dependabot branch protection rule.](https://github.com/open-telemetry/community/blob/main/docs/how-to-configure-new-repository.md#branch-protection-rule-dependabot)