### PR TITLE
Fix handling of non-standard HTTP status codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - AWS XRay Remote Sampling to cap quotaBalance to 1x quota in `go.opentelemetry.io/contrib/samplers/aws/xray`. (#3651, #3652)
 - Do not panic when the HTTP request has the "Expect: 100-continue" header in `go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace`. (#3892)
+- Fix span status value set for non-standard HTTP status codes in modules listed below. (#3966)
+  - `go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful`
+  - `go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin`
+  - `go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux`
+  - `go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho`
+  - `go.opentelemetry.io/contrib/instrumentation/gopkg.in/macaron.v1/otelmacaron`
+  - `go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace`
+  - `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp`
 
 ### Removed
 

--- a/instrumentation/github.com/emicklei/go-restful/otelrestful/internal/semconvutil/httpconv_test.go
+++ b/instrumentation/github.com/emicklei/go-restful/otelrestful/internal/semconvutil/httpconv_test.go
@@ -332,7 +332,7 @@ func TestHTTPClientStatus(t *testing.T) {
 		{http.StatusSeeOther, codes.Unset, false},
 		{http.StatusNotModified, codes.Unset, false},
 		{http.StatusUseProxy, codes.Unset, false},
-		{306, codes.Error, true},
+		{306, codes.Unset, false},
 		{http.StatusTemporaryRedirect, codes.Unset, false},
 		{http.StatusPermanentRedirect, codes.Unset, false},
 		{http.StatusBadRequest, codes.Error, false},
@@ -364,6 +364,7 @@ func TestHTTPClientStatus(t *testing.T) {
 		{http.StatusTooManyRequests, codes.Error, false},
 		{http.StatusRequestHeaderFieldsTooLarge, codes.Error, false},
 		{http.StatusUnavailableForLegalReasons, codes.Error, false},
+		{499, codes.Error, false},
 		{http.StatusInternalServerError, codes.Error, false},
 		{http.StatusNotImplemented, codes.Error, false},
 		{http.StatusBadGateway, codes.Error, false},
@@ -379,13 +380,15 @@ func TestHTTPClientStatus(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		c, msg := HTTPClientStatus(test.code)
-		assert.Equal(t, test.stat, c)
-		if test.msg && msg == "" {
-			t.Errorf("expected non-empty message for %d", test.code)
-		} else if !test.msg && msg != "" {
-			t.Errorf("expected empty message for %d, got: %s", test.code, msg)
-		}
+		t.Run(strconv.Itoa(test.code), func(t *testing.T) {
+			c, msg := HTTPClientStatus(test.code)
+			assert.Equal(t, test.stat, c)
+			if test.msg && msg == "" {
+				t.Errorf("expected non-empty message for %d", test.code)
+			} else if !test.msg && msg != "" {
+				t.Errorf("expected empty message for %d, got: %s", test.code, msg)
+			}
+		})
 	}
 }
 
@@ -416,7 +419,7 @@ func TestHTTPServerStatus(t *testing.T) {
 		{http.StatusSeeOther, codes.Unset, false},
 		{http.StatusNotModified, codes.Unset, false},
 		{http.StatusUseProxy, codes.Unset, false},
-		{306, codes.Error, true},
+		{306, codes.Unset, false},
 		{http.StatusTemporaryRedirect, codes.Unset, false},
 		{http.StatusPermanentRedirect, codes.Unset, false},
 		{http.StatusBadRequest, codes.Unset, false},
@@ -448,6 +451,7 @@ func TestHTTPServerStatus(t *testing.T) {
 		{http.StatusTooManyRequests, codes.Unset, false},
 		{http.StatusRequestHeaderFieldsTooLarge, codes.Unset, false},
 		{http.StatusUnavailableForLegalReasons, codes.Unset, false},
+		{499, codes.Unset, false},
 		{http.StatusInternalServerError, codes.Error, false},
 		{http.StatusNotImplemented, codes.Error, false},
 		{http.StatusBadGateway, codes.Error, false},

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/internal/semconvutil/httpconv_test.go
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/internal/semconvutil/httpconv_test.go
@@ -332,7 +332,7 @@ func TestHTTPClientStatus(t *testing.T) {
 		{http.StatusSeeOther, codes.Unset, false},
 		{http.StatusNotModified, codes.Unset, false},
 		{http.StatusUseProxy, codes.Unset, false},
-		{306, codes.Error, true},
+		{306, codes.Unset, false},
 		{http.StatusTemporaryRedirect, codes.Unset, false},
 		{http.StatusPermanentRedirect, codes.Unset, false},
 		{http.StatusBadRequest, codes.Error, false},
@@ -364,6 +364,7 @@ func TestHTTPClientStatus(t *testing.T) {
 		{http.StatusTooManyRequests, codes.Error, false},
 		{http.StatusRequestHeaderFieldsTooLarge, codes.Error, false},
 		{http.StatusUnavailableForLegalReasons, codes.Error, false},
+		{499, codes.Error, false},
 		{http.StatusInternalServerError, codes.Error, false},
 		{http.StatusNotImplemented, codes.Error, false},
 		{http.StatusBadGateway, codes.Error, false},
@@ -379,13 +380,15 @@ func TestHTTPClientStatus(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		c, msg := HTTPClientStatus(test.code)
-		assert.Equal(t, test.stat, c)
-		if test.msg && msg == "" {
-			t.Errorf("expected non-empty message for %d", test.code)
-		} else if !test.msg && msg != "" {
-			t.Errorf("expected empty message for %d, got: %s", test.code, msg)
-		}
+		t.Run(strconv.Itoa(test.code), func(t *testing.T) {
+			c, msg := HTTPClientStatus(test.code)
+			assert.Equal(t, test.stat, c)
+			if test.msg && msg == "" {
+				t.Errorf("expected non-empty message for %d", test.code)
+			} else if !test.msg && msg != "" {
+				t.Errorf("expected empty message for %d, got: %s", test.code, msg)
+			}
+		})
 	}
 }
 
@@ -416,7 +419,7 @@ func TestHTTPServerStatus(t *testing.T) {
 		{http.StatusSeeOther, codes.Unset, false},
 		{http.StatusNotModified, codes.Unset, false},
 		{http.StatusUseProxy, codes.Unset, false},
-		{306, codes.Error, true},
+		{306, codes.Unset, false},
 		{http.StatusTemporaryRedirect, codes.Unset, false},
 		{http.StatusPermanentRedirect, codes.Unset, false},
 		{http.StatusBadRequest, codes.Unset, false},
@@ -448,6 +451,7 @@ func TestHTTPServerStatus(t *testing.T) {
 		{http.StatusTooManyRequests, codes.Unset, false},
 		{http.StatusRequestHeaderFieldsTooLarge, codes.Unset, false},
 		{http.StatusUnavailableForLegalReasons, codes.Unset, false},
+		{499, codes.Unset, false},
 		{http.StatusInternalServerError, codes.Error, false},
 		{http.StatusNotImplemented, codes.Error, false},
 		{http.StatusBadGateway, codes.Error, false},

--- a/instrumentation/github.com/gorilla/mux/otelmux/internal/semconvutil/httpconv_test.go
+++ b/instrumentation/github.com/gorilla/mux/otelmux/internal/semconvutil/httpconv_test.go
@@ -332,7 +332,7 @@ func TestHTTPClientStatus(t *testing.T) {
 		{http.StatusSeeOther, codes.Unset, false},
 		{http.StatusNotModified, codes.Unset, false},
 		{http.StatusUseProxy, codes.Unset, false},
-		{306, codes.Error, true},
+		{306, codes.Unset, false},
 		{http.StatusTemporaryRedirect, codes.Unset, false},
 		{http.StatusPermanentRedirect, codes.Unset, false},
 		{http.StatusBadRequest, codes.Error, false},
@@ -364,6 +364,7 @@ func TestHTTPClientStatus(t *testing.T) {
 		{http.StatusTooManyRequests, codes.Error, false},
 		{http.StatusRequestHeaderFieldsTooLarge, codes.Error, false},
 		{http.StatusUnavailableForLegalReasons, codes.Error, false},
+		{499, codes.Error, false},
 		{http.StatusInternalServerError, codes.Error, false},
 		{http.StatusNotImplemented, codes.Error, false},
 		{http.StatusBadGateway, codes.Error, false},
@@ -379,13 +380,15 @@ func TestHTTPClientStatus(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		c, msg := HTTPClientStatus(test.code)
-		assert.Equal(t, test.stat, c)
-		if test.msg && msg == "" {
-			t.Errorf("expected non-empty message for %d", test.code)
-		} else if !test.msg && msg != "" {
-			t.Errorf("expected empty message for %d, got: %s", test.code, msg)
-		}
+		t.Run(strconv.Itoa(test.code), func(t *testing.T) {
+			c, msg := HTTPClientStatus(test.code)
+			assert.Equal(t, test.stat, c)
+			if test.msg && msg == "" {
+				t.Errorf("expected non-empty message for %d", test.code)
+			} else if !test.msg && msg != "" {
+				t.Errorf("expected empty message for %d, got: %s", test.code, msg)
+			}
+		})
 	}
 }
 
@@ -416,7 +419,7 @@ func TestHTTPServerStatus(t *testing.T) {
 		{http.StatusSeeOther, codes.Unset, false},
 		{http.StatusNotModified, codes.Unset, false},
 		{http.StatusUseProxy, codes.Unset, false},
-		{306, codes.Error, true},
+		{306, codes.Unset, false},
 		{http.StatusTemporaryRedirect, codes.Unset, false},
 		{http.StatusPermanentRedirect, codes.Unset, false},
 		{http.StatusBadRequest, codes.Unset, false},
@@ -448,6 +451,7 @@ func TestHTTPServerStatus(t *testing.T) {
 		{http.StatusTooManyRequests, codes.Unset, false},
 		{http.StatusRequestHeaderFieldsTooLarge, codes.Unset, false},
 		{http.StatusUnavailableForLegalReasons, codes.Unset, false},
+		{499, codes.Unset, false},
 		{http.StatusInternalServerError, codes.Error, false},
 		{http.StatusNotImplemented, codes.Error, false},
 		{http.StatusBadGateway, codes.Error, false},

--- a/instrumentation/github.com/labstack/echo/otelecho/internal/semconvutil/httpconv_test.go
+++ b/instrumentation/github.com/labstack/echo/otelecho/internal/semconvutil/httpconv_test.go
@@ -332,7 +332,7 @@ func TestHTTPClientStatus(t *testing.T) {
 		{http.StatusSeeOther, codes.Unset, false},
 		{http.StatusNotModified, codes.Unset, false},
 		{http.StatusUseProxy, codes.Unset, false},
-		{306, codes.Error, true},
+		{306, codes.Unset, false},
 		{http.StatusTemporaryRedirect, codes.Unset, false},
 		{http.StatusPermanentRedirect, codes.Unset, false},
 		{http.StatusBadRequest, codes.Error, false},
@@ -364,6 +364,7 @@ func TestHTTPClientStatus(t *testing.T) {
 		{http.StatusTooManyRequests, codes.Error, false},
 		{http.StatusRequestHeaderFieldsTooLarge, codes.Error, false},
 		{http.StatusUnavailableForLegalReasons, codes.Error, false},
+		{499, codes.Error, false},
 		{http.StatusInternalServerError, codes.Error, false},
 		{http.StatusNotImplemented, codes.Error, false},
 		{http.StatusBadGateway, codes.Error, false},
@@ -379,13 +380,15 @@ func TestHTTPClientStatus(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		c, msg := HTTPClientStatus(test.code)
-		assert.Equal(t, test.stat, c)
-		if test.msg && msg == "" {
-			t.Errorf("expected non-empty message for %d", test.code)
-		} else if !test.msg && msg != "" {
-			t.Errorf("expected empty message for %d, got: %s", test.code, msg)
-		}
+		t.Run(strconv.Itoa(test.code), func(t *testing.T) {
+			c, msg := HTTPClientStatus(test.code)
+			assert.Equal(t, test.stat, c)
+			if test.msg && msg == "" {
+				t.Errorf("expected non-empty message for %d", test.code)
+			} else if !test.msg && msg != "" {
+				t.Errorf("expected empty message for %d, got: %s", test.code, msg)
+			}
+		})
 	}
 }
 
@@ -416,7 +419,7 @@ func TestHTTPServerStatus(t *testing.T) {
 		{http.StatusSeeOther, codes.Unset, false},
 		{http.StatusNotModified, codes.Unset, false},
 		{http.StatusUseProxy, codes.Unset, false},
-		{306, codes.Error, true},
+		{306, codes.Unset, false},
 		{http.StatusTemporaryRedirect, codes.Unset, false},
 		{http.StatusPermanentRedirect, codes.Unset, false},
 		{http.StatusBadRequest, codes.Unset, false},
@@ -448,6 +451,7 @@ func TestHTTPServerStatus(t *testing.T) {
 		{http.StatusTooManyRequests, codes.Unset, false},
 		{http.StatusRequestHeaderFieldsTooLarge, codes.Unset, false},
 		{http.StatusUnavailableForLegalReasons, codes.Unset, false},
+		{499, codes.Unset, false},
 		{http.StatusInternalServerError, codes.Error, false},
 		{http.StatusNotImplemented, codes.Error, false},
 		{http.StatusBadGateway, codes.Error, false},

--- a/instrumentation/gopkg.in/macaron.v1/otelmacaron/internal/semconvutil/httpconv_test.go
+++ b/instrumentation/gopkg.in/macaron.v1/otelmacaron/internal/semconvutil/httpconv_test.go
@@ -332,7 +332,7 @@ func TestHTTPClientStatus(t *testing.T) {
 		{http.StatusSeeOther, codes.Unset, false},
 		{http.StatusNotModified, codes.Unset, false},
 		{http.StatusUseProxy, codes.Unset, false},
-		{306, codes.Error, true},
+		{306, codes.Unset, false},
 		{http.StatusTemporaryRedirect, codes.Unset, false},
 		{http.StatusPermanentRedirect, codes.Unset, false},
 		{http.StatusBadRequest, codes.Error, false},
@@ -364,6 +364,7 @@ func TestHTTPClientStatus(t *testing.T) {
 		{http.StatusTooManyRequests, codes.Error, false},
 		{http.StatusRequestHeaderFieldsTooLarge, codes.Error, false},
 		{http.StatusUnavailableForLegalReasons, codes.Error, false},
+		{499, codes.Error, false},
 		{http.StatusInternalServerError, codes.Error, false},
 		{http.StatusNotImplemented, codes.Error, false},
 		{http.StatusBadGateway, codes.Error, false},
@@ -379,13 +380,15 @@ func TestHTTPClientStatus(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		c, msg := HTTPClientStatus(test.code)
-		assert.Equal(t, test.stat, c)
-		if test.msg && msg == "" {
-			t.Errorf("expected non-empty message for %d", test.code)
-		} else if !test.msg && msg != "" {
-			t.Errorf("expected empty message for %d, got: %s", test.code, msg)
-		}
+		t.Run(strconv.Itoa(test.code), func(t *testing.T) {
+			c, msg := HTTPClientStatus(test.code)
+			assert.Equal(t, test.stat, c)
+			if test.msg && msg == "" {
+				t.Errorf("expected non-empty message for %d", test.code)
+			} else if !test.msg && msg != "" {
+				t.Errorf("expected empty message for %d, got: %s", test.code, msg)
+			}
+		})
 	}
 }
 
@@ -416,7 +419,7 @@ func TestHTTPServerStatus(t *testing.T) {
 		{http.StatusSeeOther, codes.Unset, false},
 		{http.StatusNotModified, codes.Unset, false},
 		{http.StatusUseProxy, codes.Unset, false},
-		{306, codes.Error, true},
+		{306, codes.Unset, false},
 		{http.StatusTemporaryRedirect, codes.Unset, false},
 		{http.StatusPermanentRedirect, codes.Unset, false},
 		{http.StatusBadRequest, codes.Unset, false},
@@ -448,6 +451,7 @@ func TestHTTPServerStatus(t *testing.T) {
 		{http.StatusTooManyRequests, codes.Unset, false},
 		{http.StatusRequestHeaderFieldsTooLarge, codes.Unset, false},
 		{http.StatusUnavailableForLegalReasons, codes.Unset, false},
+		{499, codes.Unset, false},
 		{http.StatusInternalServerError, codes.Error, false},
 		{http.StatusNotImplemented, codes.Error, false},
 		{http.StatusBadGateway, codes.Error, false},

--- a/instrumentation/net/http/httptrace/otelhttptrace/internal/semconvutil/httpconv_test.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/internal/semconvutil/httpconv_test.go
@@ -332,7 +332,7 @@ func TestHTTPClientStatus(t *testing.T) {
 		{http.StatusSeeOther, codes.Unset, false},
 		{http.StatusNotModified, codes.Unset, false},
 		{http.StatusUseProxy, codes.Unset, false},
-		{306, codes.Error, true},
+		{306, codes.Unset, false},
 		{http.StatusTemporaryRedirect, codes.Unset, false},
 		{http.StatusPermanentRedirect, codes.Unset, false},
 		{http.StatusBadRequest, codes.Error, false},
@@ -364,6 +364,7 @@ func TestHTTPClientStatus(t *testing.T) {
 		{http.StatusTooManyRequests, codes.Error, false},
 		{http.StatusRequestHeaderFieldsTooLarge, codes.Error, false},
 		{http.StatusUnavailableForLegalReasons, codes.Error, false},
+		{499, codes.Error, false},
 		{http.StatusInternalServerError, codes.Error, false},
 		{http.StatusNotImplemented, codes.Error, false},
 		{http.StatusBadGateway, codes.Error, false},
@@ -379,13 +380,15 @@ func TestHTTPClientStatus(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		c, msg := HTTPClientStatus(test.code)
-		assert.Equal(t, test.stat, c)
-		if test.msg && msg == "" {
-			t.Errorf("expected non-empty message for %d", test.code)
-		} else if !test.msg && msg != "" {
-			t.Errorf("expected empty message for %d, got: %s", test.code, msg)
-		}
+		t.Run(strconv.Itoa(test.code), func(t *testing.T) {
+			c, msg := HTTPClientStatus(test.code)
+			assert.Equal(t, test.stat, c)
+			if test.msg && msg == "" {
+				t.Errorf("expected non-empty message for %d", test.code)
+			} else if !test.msg && msg != "" {
+				t.Errorf("expected empty message for %d, got: %s", test.code, msg)
+			}
+		})
 	}
 }
 
@@ -416,7 +419,7 @@ func TestHTTPServerStatus(t *testing.T) {
 		{http.StatusSeeOther, codes.Unset, false},
 		{http.StatusNotModified, codes.Unset, false},
 		{http.StatusUseProxy, codes.Unset, false},
-		{306, codes.Error, true},
+		{306, codes.Unset, false},
 		{http.StatusTemporaryRedirect, codes.Unset, false},
 		{http.StatusPermanentRedirect, codes.Unset, false},
 		{http.StatusBadRequest, codes.Unset, false},
@@ -448,6 +451,7 @@ func TestHTTPServerStatus(t *testing.T) {
 		{http.StatusTooManyRequests, codes.Unset, false},
 		{http.StatusRequestHeaderFieldsTooLarge, codes.Unset, false},
 		{http.StatusUnavailableForLegalReasons, codes.Unset, false},
+		{499, codes.Unset, false},
 		{http.StatusInternalServerError, codes.Error, false},
 		{http.StatusNotImplemented, codes.Error, false},
 		{http.StatusBadGateway, codes.Error, false},

--- a/instrumentation/net/http/otelhttp/internal/semconvutil/httpconv_test.go
+++ b/instrumentation/net/http/otelhttp/internal/semconvutil/httpconv_test.go
@@ -332,7 +332,7 @@ func TestHTTPClientStatus(t *testing.T) {
 		{http.StatusSeeOther, codes.Unset, false},
 		{http.StatusNotModified, codes.Unset, false},
 		{http.StatusUseProxy, codes.Unset, false},
-		{306, codes.Error, true},
+		{306, codes.Unset, false},
 		{http.StatusTemporaryRedirect, codes.Unset, false},
 		{http.StatusPermanentRedirect, codes.Unset, false},
 		{http.StatusBadRequest, codes.Error, false},
@@ -364,6 +364,7 @@ func TestHTTPClientStatus(t *testing.T) {
 		{http.StatusTooManyRequests, codes.Error, false},
 		{http.StatusRequestHeaderFieldsTooLarge, codes.Error, false},
 		{http.StatusUnavailableForLegalReasons, codes.Error, false},
+		{499, codes.Error, false},
 		{http.StatusInternalServerError, codes.Error, false},
 		{http.StatusNotImplemented, codes.Error, false},
 		{http.StatusBadGateway, codes.Error, false},
@@ -379,13 +380,15 @@ func TestHTTPClientStatus(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		c, msg := HTTPClientStatus(test.code)
-		assert.Equal(t, test.stat, c)
-		if test.msg && msg == "" {
-			t.Errorf("expected non-empty message for %d", test.code)
-		} else if !test.msg && msg != "" {
-			t.Errorf("expected empty message for %d, got: %s", test.code, msg)
-		}
+		t.Run(strconv.Itoa(test.code), func(t *testing.T) {
+			c, msg := HTTPClientStatus(test.code)
+			assert.Equal(t, test.stat, c)
+			if test.msg && msg == "" {
+				t.Errorf("expected non-empty message for %d", test.code)
+			} else if !test.msg && msg != "" {
+				t.Errorf("expected empty message for %d, got: %s", test.code, msg)
+			}
+		})
 	}
 }
 
@@ -416,7 +419,7 @@ func TestHTTPServerStatus(t *testing.T) {
 		{http.StatusSeeOther, codes.Unset, false},
 		{http.StatusNotModified, codes.Unset, false},
 		{http.StatusUseProxy, codes.Unset, false},
-		{306, codes.Error, true},
+		{306, codes.Unset, false},
 		{http.StatusTemporaryRedirect, codes.Unset, false},
 		{http.StatusPermanentRedirect, codes.Unset, false},
 		{http.StatusBadRequest, codes.Unset, false},
@@ -448,6 +451,7 @@ func TestHTTPServerStatus(t *testing.T) {
 		{http.StatusTooManyRequests, codes.Unset, false},
 		{http.StatusRequestHeaderFieldsTooLarge, codes.Unset, false},
 		{http.StatusUnavailableForLegalReasons, codes.Unset, false},
+		{499, codes.Unset, false},
 		{http.StatusInternalServerError, codes.Error, false},
 		{http.StatusNotImplemented, codes.Error, false},
 		{http.StatusBadGateway, codes.Error, false},

--- a/internal/shared/semconvutil/httpconv_test.go.tmpl
+++ b/internal/shared/semconvutil/httpconv_test.go.tmpl
@@ -332,7 +332,7 @@ func TestHTTPClientStatus(t *testing.T) {
 		{http.StatusSeeOther, codes.Unset, false},
 		{http.StatusNotModified, codes.Unset, false},
 		{http.StatusUseProxy, codes.Unset, false},
-		{306, codes.Error, true},
+		{306, codes.Unset, false},
 		{http.StatusTemporaryRedirect, codes.Unset, false},
 		{http.StatusPermanentRedirect, codes.Unset, false},
 		{http.StatusBadRequest, codes.Error, false},
@@ -364,6 +364,7 @@ func TestHTTPClientStatus(t *testing.T) {
 		{http.StatusTooManyRequests, codes.Error, false},
 		{http.StatusRequestHeaderFieldsTooLarge, codes.Error, false},
 		{http.StatusUnavailableForLegalReasons, codes.Error, false},
+		{499, codes.Error, false},
 		{http.StatusInternalServerError, codes.Error, false},
 		{http.StatusNotImplemented, codes.Error, false},
 		{http.StatusBadGateway, codes.Error, false},
@@ -379,13 +380,15 @@ func TestHTTPClientStatus(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		c, msg := HTTPClientStatus(test.code)
-		assert.Equal(t, test.stat, c)
-		if test.msg && msg == "" {
-			t.Errorf("expected non-empty message for %d", test.code)
-		} else if !test.msg && msg != "" {
-			t.Errorf("expected empty message for %d, got: %s", test.code, msg)
-		}
+		t.Run(strconv.Itoa(test.code), func(t *testing.T) {
+			c, msg := HTTPClientStatus(test.code)
+			assert.Equal(t, test.stat, c)
+			if test.msg && msg == "" {
+				t.Errorf("expected non-empty message for %d", test.code)
+			} else if !test.msg && msg != "" {
+				t.Errorf("expected empty message for %d, got: %s", test.code, msg)
+			}
+		})
 	}
 }
 
@@ -416,7 +419,7 @@ func TestHTTPServerStatus(t *testing.T) {
 		{http.StatusSeeOther, codes.Unset, false},
 		{http.StatusNotModified, codes.Unset, false},
 		{http.StatusUseProxy, codes.Unset, false},
-		{306, codes.Error, true},
+		{306, codes.Unset, false},
 		{http.StatusTemporaryRedirect, codes.Unset, false},
 		{http.StatusPermanentRedirect, codes.Unset, false},
 		{http.StatusBadRequest, codes.Unset, false},
@@ -448,6 +451,7 @@ func TestHTTPServerStatus(t *testing.T) {
 		{http.StatusTooManyRequests, codes.Unset, false},
 		{http.StatusRequestHeaderFieldsTooLarge, codes.Unset, false},
 		{http.StatusUnavailableForLegalReasons, codes.Unset, false},
+		{499, codes.Unset, false},
 		{http.StatusInternalServerError, codes.Error, false},
 		{http.StatusNotImplemented, codes.Error, false},
 		{http.StatusBadGateway, codes.Error, false},


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go-contrib/issues/3902

Also from https://greenbytes.de/tech/webdav/draft-ietf-httpbis-p2-semantics-25.html#rfc.section.6.p.2:

> HTTP status codes are extensible. HTTP clients are not required to understand the meaning of all registered status codes, though such understanding is obviously desirable. However, a client must understand the class of any status code, as indicated by the first digit, and treat an unrecognized status code as being equivalent to the x00 status code of that class, with the exception that a recipient must not cache a response with an unrecognized status code.