### PR TITLE
Fix metrics with high cardinality in otelhttp (#3765)

### DIFF
--- a/instrumentation/net/http/otelhttp/handler.go
+++ b/instrumentation/net/http/otelhttp/handler.go
@@ -219,7 +219,7 @@ func (h *middleware) serveHTTP(w http.ResponseWriter, r *http.Request, next http
 	setAfterServeAttributes(span, bw.read, rww.written, rww.statusCode, bw.err, rww.err)
 
 	// Add metrics
-	attributes := append(labeler.Get(), semconvutil.HTTPServerRequest(h.server, r)...)
+	attributes := append(labeler.Get(), semconvutil.HTTPServerRequestMetric(h.server, r)...)
 	if rww.statusCode > 0 {
 		attributes = append(attributes, semconv.HTTPStatusCode(rww.statusCode))
 	}


### PR DESCRIPTION
Change template to add a new method `semconvutil.HTTPServerRequestMetric` and use it for metrics. This should reduce attributes with high cardinality being introduced into the metrics.