### PR TITLE
Fix dependabot-check and vanity-import-check targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ misspell: | $(MISSPELL)
 
 .PHONY: vanity-import-check
 vanity-import-check: | $(PORTO)
-	@$(PORTO) --include-internal -l . || echo "(run: make vanity-import-fix)"
+	@$(PORTO) --include-internal -l . || ( echo "(run: make vanity-import-fix)"; exit 1 )
 
 .PHONY: lint
 lint: go-mod-tidy golangci-lint misspell
@@ -186,7 +186,7 @@ registry-links-check:
 DEPENDABOT_CONFIG = .github/dependabot.yml
 .PHONY: dependabot-check
 dependabot-check: | $(DBOTCONF)
-	@$(DBOTCONF) verify $(DEPENDABOT_CONFIG) || echo "(run: make dependabot-generate)"
+	@$(DBOTCONF) verify $(DEPENDABOT_CONFIG) || ( echo "(run: make dependabot-generate)"; exit 1 )
 
 .PHONY: dependabot-generate
 dependabot-generate: | $(DBOTCONF)


### PR DESCRIPTION
Same as https://github.com/open-telemetry/opentelemetry-go/pull/4273