### PR TITLE
otelkit: Allow specifying a custom span type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `NewMiddleware` function in `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp`. (#2964)
 - Add the new `go.opentelemetry.io/contrib/instrgen` package to provide auto-generated source code instrumentation. (#3068, #3108)
 - The `go.opentelemetry.io/contrib/exporters/autoexport` package to provide configuration of trace exporters with useful defaults and envar support. (#2753)
+- New `WithSpanType` option in `go.opentelemetry.io/contrib/instrumentation/github.com/go-kit/kit/otelkit`. (#4044)
 
 ### Fixed
 

--- a/instrumentation/github.com/go-kit/kit/otelkit/config.go
+++ b/instrumentation/github.com/go-kit/kit/otelkit/config.go
@@ -47,6 +47,9 @@ type config struct {
 	// GetAttributes is an optional function that can extract trace attributes
 	// from the context and add them to the span.
 	GetAttributes func(ctx context.Context) []attribute.KeyValue
+
+	// SpanKind is the kind of span to be created by this middleware.
+	SpanKind trace.SpanKind
 }
 
 // Option configures an EndpointMiddleware.
@@ -104,5 +107,13 @@ func WithAttributes(attrs ...attribute.KeyValue) Option {
 func WithAttributeGetter(fn func(ctx context.Context) []attribute.KeyValue) Option {
 	return optionFunc(func(o *config) {
 		o.GetAttributes = fn
+	})
+}
+
+// WithSpanKind sets the span kind for spans created by this middleware.
+// If this option is not provided, then trace.SpanKindServer is used.
+func WithSpanKind(kind trace.SpanKind) Option {
+	return optionFunc(func(o *config) {
+		o.SpanKind = kind
 	})
 }

--- a/instrumentation/github.com/go-kit/kit/otelkit/endpoint.go
+++ b/instrumentation/github.com/go-kit/kit/otelkit/endpoint.go
@@ -40,7 +40,9 @@ const (
 // tracing middleware, generic OpenTelemetry transport middleware or custom before
 // and after transport functions.
 func EndpointMiddleware(options ...Option) endpoint.Middleware {
-	cfg := &config{}
+	cfg := &config{
+		SpanKind: trace.SpanKindServer,
+	}
 
 	for _, o := range options {
 		o.apply(cfg)
@@ -71,7 +73,7 @@ func EndpointMiddleware(options ...Option) endpoint.Middleware {
 
 			opts := []trace.SpanStartOption{
 				trace.WithAttributes(cfg.Attributes...),
-				trace.WithSpanKind(trace.SpanKindServer),
+				trace.WithSpanKind(cfg.SpanKind),
 			}
 
 			if cfg.GetAttributes != nil {


### PR DESCRIPTION
This is useful for when an endpoint may be wrapping a call to another service, or when an endpoint is used as a consumer (e.g. with https://github.com/alebabai/go-kit-kafka). [The go-kit opentracing provider supports this via use of `WithTags`](https://github.com/go-kit/kit/blob/dfe43fa6a8d72c23e2205d0b80e762346e203f78/tracing/opentracing/endpoint.go#L100-L118).