### PR TITLE
autoprop: Handle empty env var as unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - `go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace`
   - `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp`
 - Do not modify the origin request in RoundTripper in `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp`. (#4033)
-- Handle empty value of `OTEL_PROPAGATORS` environment variable the same way as when the variable is unset in `go.opentelemetry.io/contrib/propagators/autoprop`. (#4100)
+- Handle empty value of `OTEL_PROPAGATORS` environment variable the same way as when the variable is unset in `go.opentelemetry.io/contrib/propagators/autoprop`. (#4101)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - `go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace`
   - `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp`
 - Do not modify the origin request in RoundTripper in `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp`. (#4033)
+- Handle empty value of `OTEL_PROPAGATORS` environment variable the same way as when the variable is unset in `go.opentelemetry.io/contrib/propagators/autoprop`. (#4100)
 
 ### Deprecated
 

--- a/propagators/autoprop/propagator.go
+++ b/propagators/autoprop/propagator.go
@@ -82,8 +82,8 @@ var errUnknownPropagator = errors.New("unknown propagator")
 // TextMapPropagator will be returned if "none" is defined anywhere in the
 // environment variable.
 func parseEnv() (propagation.TextMapPropagator, error) {
-	propStrs, defined := os.LookupEnv(otelPropagatorsEnvKey)
-	if !defined {
+	propStrs := os.Getenv(otelPropagatorsEnvKey)
+	if propStrs == "" {
 		return nil, nil
 	}
 	return TextMapPropagator(strings.Split(propStrs, ",")...)


### PR DESCRIPTION
## Why

https://github.com/open-telemetry/opentelemetry-specification/blob/v1.23.0/specification/configuration/sdk-environment-variables.md?plain=1#L19

> The SDK MUST interpret an empty value of an environment variable the same way as when the variable is unset.

## What

Handle empty value of `OTEL_PROPAGATORS` environment variable the same way as when the variable is unset

## Testing

The returned result of `autoprop.NewTextMapPropagator` has not changed. The only difference is that we do not log an unnecessary error via

https://github.com/open-telemetry/opentelemetry-go-contrib/blob/3061fc5ecc2eee007916fcc29bbdd756bdee5c75/propagators/autoprop/propagator.go#L53-L54

I am not sure it it is worth to add a unit test for it.
