### PR TITLE
Fix deprecation notices in GCP detector

### DIFF
--- a/detectors/gcp/cloud-function.go
+++ b/detectors/gcp/cloud-function.go
@@ -28,6 +28,7 @@ const (
 )
 
 // NewCloudFunction will return a GCP Cloud Function resource detector.
+//
 // Deprecated: Use gcp.NewDetector() instead, which sets the same resource attributes.
 func NewCloudFunction() resource.Detector {
 	return &cloudFunction{

--- a/detectors/gcp/cloud-run.go
+++ b/detectors/gcp/cloud-run.go
@@ -38,6 +38,7 @@ type metadataClient interface {
 }
 
 // CloudRun collects resource information of Cloud Run instance.
+//
 // Deprecated: Use gcp.NewDetector() instead. Note that it sets faas.* resource attributes instead of service.* attributes.
 type CloudRun struct {
 	mc     metadataClient
@@ -50,6 +51,7 @@ type CloudRun struct {
 var _ resource.Detector = (*CloudRun)(nil)
 
 // NewCloudRun creates a CloudRun detector.
+//
 // Deprecated: Use gcp.NewDetector() instead. Note that it sets faas.* resource attributes instead of service.* attributes.
 func NewCloudRun() *CloudRun {
 	return &CloudRun{

--- a/detectors/gcp/gce.go
+++ b/detectors/gcp/gce.go
@@ -28,6 +28,7 @@ import (
 )
 
 // GCE collects resource information of GCE computing instances.
+//
 // Deprecated: Use gcp.NewDetector() instead, which sets the same resource attributes on GCE.
 type GCE struct{}
 

--- a/detectors/gcp/gke.go
+++ b/detectors/gcp/gke.go
@@ -27,6 +27,7 @@ import (
 )
 
 // GKE collects resource information of GKE computing instances.
+//
 // Deprecated: Use gcp.NewDetector() instead, which does NOT detect container, pod, and namespace attributes.
 // Set those using name using the OTEL_RESOURCE_ATTRIBUTES env var instead.
 type GKE struct{}


### PR DESCRIPTION
Similar to https://github.com/open-telemetry/opentelemetry-go/pull/4470#pullrequestreview-1599816539, the deprecation comments aren't properly formatted.  It isn't properly formatted in the godocs: https://pkg.go.dev/go.opentelemetry.io/contrib/detectors/gcp#pkg-functions

![Screenshot 2023-08-29 at 9 28 50 AM](https://github.com/open-telemetry/opentelemetry-go-contrib/assets/3262098/9f723f1d-416f-4dd9-9f2b-d19655c325e3)
