### PR TITLE
Remove "aws" from issue template for gcp detector

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_detector_gcp.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_detector_gcp.md
@@ -1,8 +1,8 @@
 ---
-name: '[detector: aws:gcp] Bug report'
+name: '[detector: gcp] Bug report'
 about: Create a report of invalid behavior about the gcp package to help us improve
 title: ''
-labels: 'bug, area: detector, detector: aws:gcp'
+labels: 'bug, area: detector, detector: gcp'
 
 ---
 


### PR DESCRIPTION
Remove unnecessary aws words from issue template for gcp detector.