### PR TITLE
Add new gcp host attributes and update gcp semconv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Add `gcp.gce.instance.name` and `gcp.gce.instance.hostname` resource attributes to `go.opentelemetry.io/contrib/detectors/gcp`. (#4263)
 - Add the new `go.opentelemetry.io/contrib/instrgen` package to provide auto-generated source code instrumentation. (#3068, #3108)
 
 ### Changed

--- a/detectors/gcp/detector.go
+++ b/detectors/gcp/detector.go
@@ -23,7 +23,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 )
 
 // NewDetector returns a resource detector which detects resource attributes on:
@@ -87,6 +87,8 @@ func (d *detector) Detect(ctx context.Context) (*resource.Resource, error) {
 		b.add(semconv.HostTypeKey, d.detector.GCEHostType)
 		b.add(semconv.HostIDKey, d.detector.GCEHostID)
 		b.add(semconv.HostNameKey, d.detector.GCEHostName)
+		b.add(semconv.GCPGceInstanceNameKey, d.detector.GCEInstanceName)
+		b.add(semconv.GCPGceInstanceHostnameKey, d.detector.GCEInstanceHostname)
 	default:
 		// We don't support this platform yet, so just return with what we have
 	}

--- a/detectors/gcp/detector_test.go
+++ b/detectors/gcp/detector_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 )
 
 func TestDetect(t *testing.T) {
@@ -77,13 +77,15 @@ func TestDetect(t *testing.T) {
 		{
 			desc: "GCE",
 			detector: &detector{detector: &fakeGCPDetector{
-				projectID:           "my-project",
-				cloudPlatform:       gcp.GCE,
-				gceHostID:           "1472385723456792345",
-				gceHostName:         "my-gke-node-1234",
-				gceHostType:         "n1-standard1",
-				gceAvailabilityZone: "us-central1-c",
-				gceRegion:           "us-central1",
+				projectID:              "my-project",
+				cloudPlatform:          gcp.GCE,
+				gceHostID:              "1472385723456792345",
+				gceHostName:            "my-gke-node-1234",
+				gceHostType:            "n1-standard1",
+				gceAvailabilityZone:    "us-central1-c",
+				gceRegion:              "us-central1",
+				gcpGceInstanceName:     "my-gke-node-1234",
+				gcpGceInstanceHostname: "hostname",
 			}},
 			expectedResource: resource.NewWithAttributes(semconv.SchemaURL,
 				semconv.CloudProviderGCP,
@@ -91,6 +93,8 @@ func TestDetect(t *testing.T) {
 				semconv.CloudPlatformGCPComputeEngine,
 				semconv.HostID("1472385723456792345"),
 				semconv.HostName("my-gke-node-1234"),
+				semconv.GCPGceInstanceNameKey.String("my-gke-node-1234"),
+				semconv.GCPGceInstanceHostnameKey.String("hostname"),
 				semconv.HostType("n1-standard1"),
 				semconv.CloudRegion("us-central1"),
 				semconv.CloudAvailabilityZone("us-central1-c"),
@@ -238,6 +242,8 @@ type fakeGCPDetector struct {
 	gceHostType               string
 	gceHostID                 string
 	gceHostName               string
+	gcpGceInstanceName        string
+	gcpGceInstanceHostname    string
 }
 
 func (f *fakeGCPDetector) ProjectID() (string, error) {
@@ -378,4 +384,18 @@ func (f *fakeGCPDetector) GCEHostName() (string, error) {
 		return "", f.err
 	}
 	return f.gceHostName, nil
+}
+
+func (f *fakeGCPDetector) GCEInstanceName() (string, error) {
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.gcpGceInstanceName, nil
+}
+
+func (f *fakeGCPDetector) GCEInstanceHostname() (string, error) {
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.gcpGceInstanceHostname, nil
 }

--- a/detectors/gcp/types.go
+++ b/detectors/gcp/types.go
@@ -37,4 +37,6 @@ type gcpDetector interface {
 	GCEHostType() (string, error)
 	GCEHostID() (string, error)
 	GCEHostName() (string, error)
+	GCEInstanceHostname() (string, error)
+	GCEInstanceName() (string, error)
 }


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go-contrib/issues/4261#event-10247699894

Add new resource attributes from https://github.com/open-telemetry/semantic-conventions/pull/15 to the gcp resource detector.

~Blocked by https://github.com/open-telemetry/opentelemetry-go-contrib/pull/4198~