### PR TITLE
[chore] Update go versions used in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
   # backwards compatibility with the previous two minor releases and we
   # explicitly test our code for these versions so keeping this at prior
   # versions does not add value.
-  DEFAULT_GO_VERSION: "1.21"
+  DEFAULT_GO_VERSION: "~1.21.1"
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -117,7 +117,7 @@ jobs:
   compatibility-test:
     strategy:
       matrix:
-        go-version: ["1.21", "1.20", 1.19]
+        go-version: ["~1.21.1", "~1.20.8", 1.19]
         os: [ubuntu-latest, macos-latest, windows-latest]
         # GitHub Actions does not support arm* architectures on default
         # runners. It is possible to acomplish this with a self-hosted runner

--- a/.github/workflows/create-dependabot-pr.yml
+++ b/.github/workflows/create-dependabot-pr.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: '~1.21.1'
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -13,7 +13,7 @@ jobs:
         ref: ${{ github.head_ref }}
     - uses: actions/setup-go@v4
       with:
-        go-version: '^1.21.0'
+        go-version: '^1.21.1'
     - uses: evantorrie/mott-the-tidier@v1-beta
       id: modtidy
       with:


### PR DESCRIPTION
This is a defensive PR to update the minimum go version used in workflows. The latest patch versions contain security related fixes. 