### PR TITLE
[grpc] set `rpc.server.duration` metric description

### DIFF
--- a/instrumentation/google.golang.org/grpc/otelgrpc/config.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/config.go
@@ -72,7 +72,10 @@ func newConfig(opts []Option) *config {
 		metric.WithSchemaURL(semconv.SchemaURL),
 	)
 	var err error
-	if c.rpcServerDuration, err = c.meter.Int64Histogram("rpc.server.duration", metric.WithUnit("ms")); err != nil {
+	c.rpcServerDuration, err = c.meter.Int64Histogram("rpc.server.duration",
+		metric.WithDescription("Measures the duration of inbound RPC."),
+		metric.WithUnit("ms"))
+	if err != nil {
 		otel.Handle(err)
 	}
 


### PR DESCRIPTION
Fixes #4301 

This sets the description for the `rpc.server.duration` metric. This description is set as defined by the [semantic convention](https://github.com/open-telemetry/semantic-conventions/blob/main/model/metrics/rpc-metrics.yaml#L23) for this metric.

When used with other services written in other languages that emit the same metric, all services must emit the same metric metadata (name, description) when used in conjunction with a Prometheus backend. The OpenTelemetry Collector, Prometheus exporter, will drop metrics that match the name but not the description against already received metrics. We have faced this problem as part of the OpenTelemetry demo project.