### PR TITLE
Fix flaky tests in samplers/jaegerremote

### DIFF
--- a/samplers/jaegerremote/sampler_remote_test.go
+++ b/samplers/jaegerremote/sampler_remote_test.go
@@ -121,6 +121,7 @@ func TestRemoteSamplerOptions(t *testing.T) {
 		withUpdaters(updaters...),
 		WithLogger(logger),
 	)
+	defer sampler.Close()
 	assert.Equal(t, 42, sampler.posParams.MaxOperations)
 	assert.True(t, sampler.posParams.OperationNameLateBinding)
 	assert.Same(t, initSampler, sampler.sampler)
@@ -130,7 +131,6 @@ func TestRemoteSamplerOptions(t *testing.T) {
 	assert.Same(t, parser, sampler.samplingParser)
 	assert.EqualValues(t, sampler.updaters[0], &perOperationSamplerUpdater{MaxOperations: 42, OperationNameLateBinding: true})
 	assert.Equal(t, logger, sampler.logger)
-	sampler.Close()
 }
 
 func TestRemoteSamplerOptionsDefaults(t *testing.T) {
@@ -496,8 +496,8 @@ func TestRemotelyControlledSampler_updateRateLimitingOrProbabilisticSampler(t *t
 					new(rateLimitingSamplerUpdater),
 				),
 			)
+			defer remoteSampler.Close()
 			err := remoteSampler.updateSamplerViaUpdaters(testCase.res)
-			remoteSampler.Close()
 			if testCase.shouldErr {
 				require.Error(t, err)
 				return

--- a/samplers/jaegerremote/sampler_remote_test.go
+++ b/samplers/jaegerremote/sampler_remote_test.go
@@ -130,6 +130,7 @@ func TestRemoteSamplerOptions(t *testing.T) {
 	assert.Same(t, parser, sampler.samplingParser)
 	assert.EqualValues(t, sampler.updaters[0], &perOperationSamplerUpdater{MaxOperations: 42, OperationNameLateBinding: true})
 	assert.Equal(t, logger, sampler.logger)
+	sampler.Close()
 }
 
 func TestRemoteSamplerOptionsDefaults(t *testing.T) {
@@ -496,6 +497,7 @@ func TestRemotelyControlledSampler_updateRateLimitingOrProbabilisticSampler(t *t
 				),
 			)
 			err := remoteSampler.updateSamplerViaUpdaters(testCase.res)
+			remoteSampler.Close()
 			if testCase.shouldErr {
 				require.Error(t, err)
 				return


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go-contrib/issues/4296

Fixes 2 flaky tests in `samplers/jaegerremote`:
- `TestRemoteSamplerOptions`
- `TestRemotelyControlledSampler_updateRateLimitingOrProbabilisticSampler`