### PR TITLE
otelhttp: Modify request to provide span info to upstream middleware

### DIFF
--- a/instrumentation/net/http/otelhttp/handler.go
+++ b/instrumentation/net/http/otelhttp/handler.go
@@ -214,7 +214,8 @@ func (h *middleware) serveHTTP(w http.ResponseWriter, r *http.Request, next http
 	labeler := &Labeler{}
 	ctx = injectLabeler(ctx, labeler)
 
-	next.ServeHTTP(w, r.WithContext(ctx))
+	*r = *r.WithContext(ctx)
+	next.ServeHTTP(w, r)
 
 	setAfterServeAttributes(span, bw.read, rww.written, rww.statusCode, bw.err, rww.err)
 


### PR DESCRIPTION
# Problem

The current implementation of `otelhttp.Handler.ServeHTTP()` stores the span-contained context on a _copy_ of `*http.Request`. While this makes the span available to downstream middleware, it prevents any upstream middleware from observing span info. For example:

```go
func TestHandler(t *testing.T) {
	// myMiddleware -> otelhttp.Handler -> nopHandler
	h := nopHandler(t)
	h = otelhttp.NewHandler(h, "/")
	h = myMiddleware(t)(h)
	
	r := httptest.NewRequest(http.MethodGET, "/", nil)
	w := httptest.NewRecorder()
	h.ServeHTTP(w, r)
	t.FailNow() // ensure logging
}

func myMiddleware(t testing.TB) func(next http.Handler) http.Handler {
	return func(next http.Handler) http.Handler {
		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
			next(w, r)
			spanctx := trace.SpanFromContext(r.Context()).SpanContext()
			if spanctx.IsSampled() {
				t.Log("hit in middleware")
			}
		})
	}
}

func nopHandler(t testing.TB) http.HandlerFunc {
	return func(http.ResponseWriter, r *http.Request) {
		spanctx := trace.SpanFromContext(r.Context()).SpanContext()
		if spanctx.IsSampled() {
			t.Log("hit in handler")
		}
	}
}
```

If you run the test above you'll see that `nopHandler()` logs but `myMiddleware()` does not.

# Solution
Modify the request before sending downstream:

```go
// h.handler.ServeHTTP(w, r.WithContext(ctx))
*r = *r.WithContext(ctx)
h.handler.ServeHTTP(w, r)
```