### PR TITLE
update gin services name key is service.name

### DIFF
--- a/instrumentation/github.com/gin-gonic/gin/otelgin/internal/semconvutil/netconv.go
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/internal/semconvutil/netconv.go
@@ -69,7 +69,7 @@ type netConv struct {
 }
 
 var nc = &netConv{
-	NetHostNameKey:     semconv.NetHostNameKey,
+	NetHostNameKey:     semconv.ServiceNameKey,
 	NetHostPortKey:     semconv.NetHostPortKey,
 	NetPeerNameKey:     semconv.NetPeerNameKey,
 	NetPeerPortKey:     semconv.NetPeerPortKey,


### PR DESCRIPTION
fix  [#4476](https://github.com/open-telemetry/opentelemetry-go-contrib/issues/4476)