### PR TITLE
Add HTTP Request Method Name to otelecho span name

### DIFF
--- a/instrumentation/github.com/labstack/echo/otelecho/echo.go
+++ b/instrumentation/github.com/labstack/echo/otelecho/echo.go
@@ -77,7 +77,7 @@ func Middleware(service string, opts ...Option) echo.MiddlewareFunc {
 				rAttr := semconv.HTTPRoute(path)
 				opts = append(opts, oteltrace.WithAttributes(rAttr))
 			}
-			spanName := c.Path()
+			spanName := c.Request().Method + " " + c.Path()
 			if spanName == "" {
 				spanName = fmt.Sprintf("HTTP %s route not found", request.Method)
 			}


### PR DESCRIPTION
Hi,

I have added the HTTP Request Method Name to the otel-echo span name.

Currently, the HTTP Method Name is not included, which can make it challenging to differentiate between GET and POST requests with the same path when analyzing tracing data.

I took inspiration from other APM libraries that include the HTTP method in the span name:
- ex:
  - [apm-agent-go/module/apmechov4/middleware.go at main · elastic/apm-agent-go](https://github.com/elastic/apm-agent-go/blob/main/module/apmechov4/middleware.go#L53-L53)
  - [dd-trace-go/contrib/labstack/echo.v4/echotrace.go at main · DataDog/dd-trace-go](https://github.com/DataDog/dd-trace-go/blob/main/contrib/labstack/echo.v4/echotrace.go#L59-L59)


After this addition, the APM analysis screen will look like this:

- before
![before. trace span name begin with endpoint name](https://github.com/open-telemetry/opentelemetry-go-contrib/assets/59611617/148fd26b-ae14-4470-8d37-d97c325129c6)


- after
![after. trace span name begin with HTTP Request Method](https://github.com/open-telemetry/opentelemetry-go-contrib/assets/59611617/c86fdf91-9f7e-44ae-bbf4-ed1970c5d3f3)


Thank you for your consideration and feedback.