### PR TITLE
Add error as a span event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `"go.opentelemetry.io/contrib/config"` package that includes configuration models generated via go-jsonschema. (#4376)
 - Add `NewSDK` function to `"go.opentelemetry.io/contrib/config"`. The initial implementation only returns noop providers. (#4414)
 - Add metrics support to `go.opentelemetry.io/contrib/exporters/autoexport`. (#4229)
+- Add record error as a span event in a stats handler. (#4488)
 
 ### Changed
 

--- a/instrumentation/google.golang.org/grpc/otelgrpc/stats_handler.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/stats_handler.go
@@ -177,6 +177,7 @@ func handleRPC(ctx context.Context, rs stats.RPCStats) {
 			s, _ := status.FromError(rs.Error)
 			span.SetStatus(codes.Error, s.Message())
 			span.SetAttributes(statusCodeAttr(s.Code()))
+			span.RecordError(rs.Error)
 		} else {
 			span.SetAttributes(statusCodeAttr(grpc_codes.OK))
 		}


### PR DESCRIPTION
This PR adds recording an error info as a span event in a stats handler on stats.End (if an error occured).