### PR TITLE
otelhttp: set unit on all instruments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `"go.opentelemetry.io/contrib/config"` package that includes configuration models generated via go-jsonschema. (#4376)
 - Add `NewSDK` function to `"go.opentelemetry.io/contrib/config"`. The initial implementation only returns noop providers. (#4414)
 - Add metrics support (No-op, OTLP and Prometheus) to `go.opentelemetry.io/contrib/exporters/autoexport`. (#4229, #4479)
+- otelhttp: set unit on the server latency histogram (#4500)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `"go.opentelemetry.io/contrib/config"` package that includes configuration models generated via go-jsonschema. (#4376)
 - Add `NewSDK` function to `"go.opentelemetry.io/contrib/config"`. The initial implementation only returns noop providers. (#4414)
 - Add metrics support (No-op, OTLP and Prometheus) to `go.opentelemetry.io/contrib/exporters/autoexport`. (#4229, #4479)
-- otelhttp: set unit on the server latency histogram (#4500)
+- otelhttp: set units on all instruments (#4500)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `"go.opentelemetry.io/contrib/config"` package that includes configuration models generated via go-jsonschema. (#4376)
 - Add `NewSDK` function to `"go.opentelemetry.io/contrib/config"`. The initial implementation only returns noop providers. (#4414)
 - Add metrics support (No-op, OTLP and Prometheus) to `go.opentelemetry.io/contrib/exporters/autoexport`. (#4229, #4479)
-- otelhttp: set units on all instruments (#4500)
+- Set unit and description on all instruments in `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp`. (#4500)
 
 ### Changed
 

--- a/instrumentation/net/http/otelhttp/common.go
+++ b/instrumentation/net/http/otelhttp/common.go
@@ -34,7 +34,7 @@ const (
 	RequestCount          = "http.server.request_count"           // Incoming request count total
 	RequestContentLength  = "http.server.request_content_length"  // Incoming request bytes total
 	ResponseContentLength = "http.server.response_content_length" // Incoming response bytes total
-	ServerLatency         = "http.server.duration"                // Incoming end to end duration, microseconds
+	ServerLatency         = "http.server.duration"                // Incoming end to end duration, milliseconds
 )
 
 // Filter is a predicate used to determine whether a given http.request should

--- a/instrumentation/net/http/otelhttp/handler.go
+++ b/instrumentation/net/http/otelhttp/handler.go
@@ -107,8 +107,11 @@ func (h *middleware) createMeasures() {
 	h.counters = make(map[string]metric.Int64Counter)
 	h.valueRecorders = make(map[string]metric.Float64Histogram)
 
-	requestBytesCounter, err := h.meter.Int64Counter(RequestContentLength, metric.WithUnit("By"),
-		metric.WithDescription("Measures the size of HTTP request content length (uncompressed)"))
+	requestBytesCounter, err := h.meter.Int64Counter(
+		RequestContentLength,
+		metric.WithUnit("By"),
+		metric.WithDescription("Measures the size of HTTP request content length (uncompressed)"),
+	)
 	handleErr(err)
 
 	responseBytesCounter, err := h.meter.Int64Counter(ResponseContentLength, metric.WithUnit("By"),

--- a/instrumentation/net/http/otelhttp/handler.go
+++ b/instrumentation/net/http/otelhttp/handler.go
@@ -114,8 +114,11 @@ func (h *middleware) createMeasures() {
 	)
 	handleErr(err)
 
-	responseBytesCounter, err := h.meter.Int64Counter(ResponseContentLength, metric.WithUnit("By"),
-		metric.WithDescription("Measures the size of HTTP response content length (uncompressed)"))
+	responseBytesCounter, err := h.meter.Int64Counter(
+		ResponseContentLength,
+		metric.WithUnit("By"),
+		metric.WithDescription("Measures the size of HTTP response content length (uncompressed)"),
+	)
 	handleErr(err)
 
 	serverLatencyMeasure, err := h.meter.Float64Histogram(ServerLatency, metric.WithUnit("ms"),

--- a/instrumentation/net/http/otelhttp/handler.go
+++ b/instrumentation/net/http/otelhttp/handler.go
@@ -121,8 +121,11 @@ func (h *middleware) createMeasures() {
 	)
 	handleErr(err)
 
-	serverLatencyMeasure, err := h.meter.Float64Histogram(ServerLatency, metric.WithUnit("ms"),
-		metric.WithDescription("Measures the duration of HTTP request handling"))
+	serverLatencyMeasure, err := h.meter.Float64Histogram(
+		ServerLatency,
+		metric.WithUnit("ms"),
+		metric.WithDescription("Measures the duration of HTTP request handling"),
+	)
 	handleErr(err)
 
 	h.counters[RequestContentLength] = requestBytesCounter

--- a/instrumentation/net/http/otelhttp/handler.go
+++ b/instrumentation/net/http/otelhttp/handler.go
@@ -113,7 +113,7 @@ func (h *middleware) createMeasures() {
 	responseBytesCounter, err := h.meter.Int64Counter(ResponseContentLength)
 	handleErr(err)
 
-	serverLatencyMeasure, err := h.meter.Float64Histogram(ServerLatency)
+	serverLatencyMeasure, err := h.meter.Float64Histogram(ServerLatency, metric.WithUnit("ms"))
 	handleErr(err)
 
 	h.counters[RequestContentLength] = requestBytesCounter

--- a/instrumentation/net/http/otelhttp/handler.go
+++ b/instrumentation/net/http/otelhttp/handler.go
@@ -107,13 +107,16 @@ func (h *middleware) createMeasures() {
 	h.counters = make(map[string]metric.Int64Counter)
 	h.valueRecorders = make(map[string]metric.Float64Histogram)
 
-	requestBytesCounter, err := h.meter.Int64Counter(RequestContentLength)
+	requestBytesCounter, err := h.meter.Int64Counter(RequestContentLength, metric.WithUnit("By"),
+		metric.WithDescription("Measures the size of HTTP request content length (uncompressed)"))
 	handleErr(err)
 
-	responseBytesCounter, err := h.meter.Int64Counter(ResponseContentLength)
+	responseBytesCounter, err := h.meter.Int64Counter(ResponseContentLength, metric.WithUnit("By"),
+		metric.WithDescription("Measures the size of HTTP response content length (uncompressed)"))
 	handleErr(err)
 
-	serverLatencyMeasure, err := h.meter.Float64Histogram(ServerLatency, metric.WithUnit("ms"))
+	serverLatencyMeasure, err := h.meter.Float64Histogram(ServerLatency, metric.WithUnit("ms"),
+		metric.WithDescription("Measures the duration of HTTP request handling"))
 	handleErr(err)
 
 	h.counters[RequestContentLength] = requestBytesCounter

--- a/instrumentation/net/http/otelhttp/test/handler_test.go
+++ b/instrumentation/net/http/otelhttp/test/handler_test.go
@@ -50,7 +50,9 @@ func assertScopeMetrics(t *testing.T, sm metricdata.ScopeMetrics, attrs attribut
 	require.Len(t, sm.Metrics, 3)
 
 	want := metricdata.Metrics{
-		Name: "http.server.request_content_length",
+		Name:        "http.server.request_content_length",
+		Description: "Measures the size of HTTP request content length (uncompressed)",
+		Unit:        "By",
 		Data: metricdata.Sum[int64]{
 			DataPoints:  []metricdata.DataPoint[int64]{{Attributes: attrs, Value: 0}},
 			Temporality: metricdata.CumulativeTemporality,
@@ -60,7 +62,9 @@ func assertScopeMetrics(t *testing.T, sm metricdata.ScopeMetrics, attrs attribut
 	metricdatatest.AssertEqual(t, want, sm.Metrics[0], metricdatatest.IgnoreTimestamp())
 
 	want = metricdata.Metrics{
-		Name: "http.server.response_content_length",
+		Name:        "http.server.response_content_length",
+		Description: "Measures the size of HTTP response content length (uncompressed)",
+		Unit:        "By",
 		Data: metricdata.Sum[int64]{
 			DataPoints:  []metricdata.DataPoint[int64]{{Attributes: attrs, Value: 11}},
 			Temporality: metricdata.CumulativeTemporality,


### PR DESCRIPTION
Currently the histogram metric doesn't have units specified. It's good to have them explicitly specified.

The recorded value is actually milliseconds, not microseconds:

https://github.com/open-telemetry/opentelemetry-go-contrib/blob/bead7e47c4d7e080c8ea6c838b4bbd11cb27eccf/instrumentation/net/http/otelhttp/handler.go#L230-L233