### PR TITLE
otelgrpc: Stablize TestInterceptors

### DIFF
--- a/instrumentation/google.golang.org/grpc/otelgrpc/test/grpc_test.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/test/grpc_test.go
@@ -133,31 +133,25 @@ func TestInterceptors(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("UnaryClientSpans", func(t *testing.T) {
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, clientUnarySR.Ended(), 2)
-		}, 5*time.Second, 100*time.Millisecond)
 		checkUnaryClientSpans(t, clientUnarySR.Ended(), listener.Addr().String())
 	})
 
 	t.Run("StreamClientSpans", func(t *testing.T) {
+		// StreamClientInterceptor ends the spans asynchronously.
+		// We need to wait for all spans before asserting them.
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			assert.Len(c, clientStreamSR.Ended(), 3)
 		}, 5*time.Second, 100*time.Millisecond)
+
 		checkStreamClientSpans(t, clientStreamSR.Ended(), listener.Addr().String())
 	})
 
 	t.Run("UnaryServerSpans", func(t *testing.T) {
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, serverUnarySR.Ended(), 2)
-		}, 5*time.Second, 100*time.Millisecond)
 		checkUnaryServerSpans(t, serverUnarySR.Ended())
 		checkUnaryServerRecords(t, serverUnaryMetricReader)
 	})
 
 	t.Run("StreamServerSpans", func(t *testing.T) {
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, serverStreamSR.Ended(), 3)
-		}, 5*time.Second, 100*time.Millisecond)
 		checkStreamServerSpans(t, serverStreamSR.Ended())
 	})
 }

--- a/instrumentation/google.golang.org/grpc/otelgrpc/test/grpc_test.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/test/grpc_test.go
@@ -19,6 +19,7 @@ import (
 	"net"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -132,19 +133,31 @@ func TestInterceptors(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("UnaryClientSpans", func(t *testing.T) {
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.Len(c, clientUnarySR.Ended(), 2)
+		}, 5*time.Second, 100*time.Millisecond)
 		checkUnaryClientSpans(t, clientUnarySR.Ended(), listener.Addr().String())
 	})
 
 	t.Run("StreamClientSpans", func(t *testing.T) {
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.Len(c, clientStreamSR.Ended(), 3)
+		}, 5*time.Second, 100*time.Millisecond)
 		checkStreamClientSpans(t, clientStreamSR.Ended(), listener.Addr().String())
 	})
 
 	t.Run("UnaryServerSpans", func(t *testing.T) {
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.Len(c, serverUnarySR.Ended(), 2)
+		}, 5*time.Second, 100*time.Millisecond)
 		checkUnaryServerSpans(t, serverUnarySR.Ended())
 		checkUnaryServerRecords(t, serverUnaryMetricReader)
 	})
 
 	t.Run("StreamServerSpans", func(t *testing.T) {
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.Len(c, serverStreamSR.Ended(), 3)
+		}, 5*time.Second, 100*time.Millisecond)
 		checkStreamServerSpans(t, serverStreamSR.Ended())
 	})
 }


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go-contrib/issues/1352

The problem is that `StreamClientInterceptor` ends the spans asynchronously: https://github.com/open-telemetry/opentelemetry-go-contrib/blob/b44dfc9092b157625a5815cb437583cee663333b/instrumentation/google.golang.org/grpc/otelgrpc/interceptor.go#L305-L319

It may seem that it would be better to reimplement `StreamClientInterceptor`. However, I do not find it pragmatic given that we want to deprecate the interceptors anyway.

EDIT: I think I have implemented a fix for the `StreamClientInterceptor` here: https://github.com/open-telemetry/opentelemetry-go-contrib/pull/4537.