### PR TITLE
net/http/otelhttp mutate request to enable context retrieval from parent middlewares

### DIFF
--- a/instrumentation/net/http/otelhttp/handler.go
+++ b/instrumentation/net/http/otelhttp/handler.go
@@ -226,7 +226,8 @@ func (h *middleware) serveHTTP(w http.ResponseWriter, r *http.Request, next http
 	labeler := &Labeler{}
 	ctx = injectLabeler(ctx, labeler)
 
-	next.ServeHTTP(w, r.WithContext(ctx))
+	*r = *r.WithContext(ctx)
+	next.ServeHTTP(w, r)
 
 	setAfterServeAttributes(span, bw.read, rww.written, rww.statusCode, bw.err, rww.err)
 

--- a/instrumentation/net/http/otelhttp/handler_test.go
+++ b/instrumentation/net/http/otelhttp/handler_test.go
@@ -96,3 +96,15 @@ func TestHandler(t *testing.T) {
 		})
 	}
 }
+
+func TestHandler_request_propagation(t *testing.T) {
+	r, err := http.NewRequest(http.MethodGet, "http://localhost/", nil)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	otelhttp.NewHandler(
+		http.HandlerFunc(func(w http.ResponseWriter, r2 *http.Request) {
+			assert.True(t, r == r2)
+		}), "test_handler",
+	).ServeHTTP(rr, r)
+}


### PR DESCRIPTION
I have a middleware chain that looks like:
panic recovery -> otelhttp -> logger
The logger middleware injects my logger into the request context in a mutating fashion and is used in the panic recovery middleware to enable better tracing.

In order to enable this use case, `otelhttp` would need to mutate the request rather than forwarding a shallow copy of the request.

I'll admit that the middleware chain is fairly brittle as the introduction of another middleware in the chain could break the implied contract but I'm not sure I see another approach.

Here's an example of the use case https://github.com/dillonstreator/template-go-chi/blob/15ca73625798180fb8df7a3c8d16634b6f8c76df/main.go#L40-L82

This example is leveraging my fork of `otelhttp` which includes the request mutating and works pretty nicely https://github.com/dillonstreator/opentelemetry-go-contrib/commit/1e3363d236ad721ee9a61b6008809b918897f79c#diff-70a93fdc86adfd2f20a035bb596f6d9320d6fed7008eaefc6c7d7cde2b1fc97aR229-R230