### PR TITLE
otelhttp: use plain fields

### DIFF
--- a/instrumentation/net/http/otelhttp/handler.go
+++ b/instrumentation/net/http/otelhttp/handler.go
@@ -43,10 +43,12 @@ type middleware struct {
 	writeEvent        bool
 	filters           []Filter
 	spanNameFormatter func(string, *http.Request) string
-	counters          map[string]metric.Int64Counter
-	valueRecorders    map[string]metric.Float64Histogram
 	publicEndpoint    bool
 	publicEndpointFn  func(*http.Request) bool
+
+	requestBytesCounter  metric.Int64Counter
+	responseBytesCounter metric.Int64Counter
+	serverLatencyMeasure metric.Float64Histogram
 }
 
 func defaultHandlerFormatter(operation string, _ *http.Request) string {
@@ -104,33 +106,27 @@ func handleErr(err error) {
 }
 
 func (h *middleware) createMeasures() {
-	h.counters = make(map[string]metric.Int64Counter)
-	h.valueRecorders = make(map[string]metric.Float64Histogram)
-
-	requestBytesCounter, err := h.meter.Int64Counter(
+	var err error
+	h.requestBytesCounter, err = h.meter.Int64Counter(
 		RequestContentLength,
 		metric.WithUnit("By"),
 		metric.WithDescription("Measures the size of HTTP request content length (uncompressed)"),
 	)
 	handleErr(err)
 
-	responseBytesCounter, err := h.meter.Int64Counter(
+	h.responseBytesCounter, err = h.meter.Int64Counter(
 		ResponseContentLength,
 		metric.WithUnit("By"),
 		metric.WithDescription("Measures the size of HTTP response content length (uncompressed)"),
 	)
 	handleErr(err)
 
-	serverLatencyMeasure, err := h.meter.Float64Histogram(
+	h.serverLatencyMeasure, err = h.meter.Float64Histogram(
 		ServerLatency,
 		metric.WithUnit("ms"),
 		metric.WithDescription("Measures the duration of HTTP request handling"),
 	)
 	handleErr(err)
-
-	h.counters[RequestContentLength] = requestBytesCounter
-	h.counters[ResponseContentLength] = responseBytesCounter
-	h.valueRecorders[ServerLatency] = serverLatencyMeasure
 }
 
 // serveHTTP sets up tracing and calls the given next http.Handler with the span
@@ -236,13 +232,13 @@ func (h *middleware) serveHTTP(w http.ResponseWriter, r *http.Request, next http
 		attributes = append(attributes, semconv.HTTPStatusCode(rww.statusCode))
 	}
 	o := metric.WithAttributes(attributes...)
-	h.counters[RequestContentLength].Add(ctx, bw.read, o)
-	h.counters[ResponseContentLength].Add(ctx, rww.written, o)
+	h.requestBytesCounter.Add(ctx, bw.read, o)
+	h.responseBytesCounter.Add(ctx, rww.written, o)
 
 	// Use floating point division here for higher precision (instead of Millisecond method).
 	elapsedTime := float64(time.Since(requestStartTime)) / float64(time.Millisecond)
 
-	h.valueRecorders[ServerLatency].Record(ctx, elapsedTime, o)
+	h.serverLatencyMeasure.Record(ctx, elapsedTime, o)
 }
 
 func setAfterServeAttributes(span trace.Span, read, wrote int64, statusCode int, rerr, werr error) {


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go-contrib/issues/4502.