### PR TITLE
Refactor to use testing.T.Setenv in aws:ecs

### DIFF
--- a/detectors/aws/ecs/ecs_test.go
+++ b/detectors/aws/ecs/ecs_test.go
@@ -16,7 +16,6 @@ package ecs
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -46,8 +45,7 @@ func (detectorUtils *MockDetectorUtils) getContainerName() (string, error) {
 // successfully returns resource when process is running on Amazon ECS environment
 // with no Metadata v4.
 func TestDetectV3(t *testing.T) {
-	os.Clearenv()
-	_ = os.Setenv(metadataV3EnvVar, "3")
+	t.Setenv(metadataV3EnvVar, "3")
 
 	detectorUtils := new(MockDetectorUtils)
 
@@ -69,8 +67,7 @@ func TestDetectV3(t *testing.T) {
 
 // returns empty resource when detector cannot read container ID.
 func TestDetectCannotReadContainerID(t *testing.T) {
-	os.Clearenv()
-	_ = os.Setenv(metadataV3EnvVar, "3")
+	t.Setenv(metadataV3EnvVar, "3")
 	detectorUtils := new(MockDetectorUtils)
 
 	detectorUtils.On("getContainerName").Return("container-Name", nil)
@@ -92,9 +89,8 @@ func TestDetectCannotReadContainerID(t *testing.T) {
 
 // returns empty resource when detector cannot read container Name.
 func TestDetectCannotReadContainerName(t *testing.T) {
-	os.Clearenv()
-	_ = os.Setenv(metadataV3EnvVar, "3")
-	_ = os.Setenv(metadataV4EnvVar, "4")
+	t.Setenv(metadataV3EnvVar, "3")
+	t.Setenv(metadataV4EnvVar, "4")
 	detectorUtils := new(MockDetectorUtils)
 
 	detectorUtils.On("getContainerName").Return("", errCannotReadContainerName)
@@ -109,7 +105,6 @@ func TestDetectCannotReadContainerName(t *testing.T) {
 
 // returns empty resource when process is not running ECS.
 func TestReturnsIfNoEnvVars(t *testing.T) {
-	os.Clearenv()
 	detector := &resourceDetector{utils: nil}
 	res, err := detector.Detect(context.Background())
 
@@ -120,7 +115,6 @@ func TestReturnsIfNoEnvVars(t *testing.T) {
 
 // handles alternative aws partitions (e.g. AWS GovCloud).
 func TestLogsAttributesAlternatePartition(t *testing.T) {
-	os.Clearenv()
 	detector := &resourceDetector{utils: nil}
 
 	containerMetadata := &metadata.ContainerMetadataV4{

--- a/detectors/aws/ecs/test/ecs_test.go
+++ b/detectors/aws/ecs/test/ecs_test.go
@@ -58,8 +58,7 @@ func TestDetectV4LaunchTypeEc2(t *testing.T) {
 	}))
 	defer testServer.Close()
 
-	os.Clearenv()
-	_ = os.Setenv(metadataV4EnvVar, testServer.URL)
+	t.Setenv(metadataV4EnvVar, testServer.URL)
 
 	hostname, err := os.Hostname()
 	assert.NoError(t, err, "Error")
@@ -229,8 +228,7 @@ func TestDetectV4LaunchTypeFargate(t *testing.T) {
 	}))
 	defer testServer.Close()
 
-	os.Clearenv()
-	_ = os.Setenv(metadataV4EnvVar, testServer.URL)
+	t.Setenv(metadataV4EnvVar, testServer.URL)
 
 	hostname, err := os.Hostname()
 	assert.NoError(t, err, "Error")


### PR DESCRIPTION
Closes https://github.com/open-telemetry/opentelemetry-go-contrib/issues/4616.

During this refactoring, I also find the other modules are also using `os.Setenv` for testing. Maybe we can update them by just doing the same. 
