### PR TITLE
otelgrpc: gctx nil check before make metricAttrs

### DIFF
--- a/instrumentation/google.golang.org/grpc/otelgrpc/stats_handler.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/stats_handler.go
@@ -143,8 +143,11 @@ func (c *config) handleRPC(ctx context.Context, rs stats.RPCStats, isServer bool
 	span := trace.SpanFromContext(ctx)
 	gctx, _ := ctx.Value(gRPCContextKey{}).(*gRPCContext)
 	var messageId int64
-	metricAttrs := make([]attribute.KeyValue, 0, len(gctx.metricAttrs)+1)
-	metricAttrs = append(metricAttrs, gctx.metricAttrs...)
+	var metricAttrs []attribute.KeyValue
+	if gctx != nil {
+		metricAttrs := make([]attribute.KeyValue, 0, len(gctx.metricAttrs)+1)
+		metricAttrs = append(metricAttrs, gctx.metricAttrs...)
+	}
 	wctx := withoutCancel(ctx)
 
 	switch rs := rs.(type) {

--- a/instrumentation/google.golang.org/grpc/otelgrpc/stats_handler.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/stats_handler.go
@@ -145,7 +145,7 @@ func (c *config) handleRPC(ctx context.Context, rs stats.RPCStats, isServer bool
 	var messageId int64
 	var metricAttrs []attribute.KeyValue
 	if gctx != nil {
-		metricAttrs := make([]attribute.KeyValue, 0, len(gctx.metricAttrs)+1)
+		metricAttrs = make([]attribute.KeyValue, 0, len(gctx.metricAttrs)+1)
 		metricAttrs = append(metricAttrs, gctx.metricAttrs...)
 	}
 	wctx := withoutCancel(ctx)
@@ -209,8 +209,10 @@ func (c *config) handleRPC(ctx context.Context, rs stats.RPCStats, isServer bool
 		elapsedTime := float64(rs.EndTime.Sub(rs.BeginTime)) / float64(time.Millisecond)
 
 		c.rpcDuration.Record(wctx, elapsedTime, metric.WithAttributes(metricAttrs...))
-		c.rpcRequestsPerRPC.Record(wctx, atomic.LoadInt64(&gctx.messagesReceived), metric.WithAttributes(metricAttrs...))
-		c.rpcResponsesPerRPC.Record(wctx, atomic.LoadInt64(&gctx.messagesSent), metric.WithAttributes(metricAttrs...))
+		if gctx != nil {
+			c.rpcRequestsPerRPC.Record(wctx, atomic.LoadInt64(&gctx.messagesReceived), metric.WithAttributes(metricAttrs...))
+			c.rpcResponsesPerRPC.Record(wctx, atomic.LoadInt64(&gctx.messagesSent), metric.WithAttributes(metricAttrs...))
+		}
 	default:
 		return
 	}


### PR DESCRIPTION
If wrapped otelgrpc.StatsHander, sometimes occur nil panic.