### PR TITLE
Refactor to use t.Setenv instead of os.Setenv

### DIFF
--- a/detectors/aws/ecs/test/ecs_test.go
+++ b/detectors/aws/ecs/test/ecs_test.go
@@ -114,8 +114,7 @@ func TestDetectV4LaunchTypeEc2BadContainerArn(t *testing.T) {
 	}))
 	defer testServer.Close()
 
-	os.Clearenv()
-	_ = os.Setenv(metadataV4EnvVar, testServer.URL)
+	t.Setenv(metadataV4EnvVar, testServer.URL)
 
 	hostname, err := os.Hostname()
 	assert.NoError(t, err, "Error")
@@ -171,8 +170,7 @@ func TestDetectV4LaunchTypeEc2BadTaskArn(t *testing.T) {
 	}))
 	defer testServer.Close()
 
-	os.Clearenv()
-	_ = os.Setenv(metadataV4EnvVar, testServer.URL)
+	t.Setenv(metadataV4EnvVar, testServer.URL)
 
 	hostname, err := os.Hostname()
 	assert.NoError(t, err, "Error")

--- a/detectors/aws/lambda/detector_test.go
+++ b/detectors/aws/lambda/detector_test.go
@@ -28,12 +28,11 @@ import (
 
 // successfully return resource when process is running on Amazon Lambda environment.
 func TestDetectSuccess(t *testing.T) {
-	os.Clearenv()
-	_ = os.Setenv(lambdaFunctionNameEnvVar, "testFunction")
-	_ = os.Setenv(awsRegionEnvVar, "us-texas-1")
-	_ = os.Setenv(lambdaFunctionVersionEnvVar, "$LATEST")
-	_ = os.Setenv(lambdaLogStreamNameEnvVar, "2023/01/01/[$LATEST]5d1edb9e525d486696cf01a3503487bc")
-	_ = os.Setenv(lambdaMemoryLimitEnvVar, "128")
+	t.Setenv(lambdaFunctionNameEnvVar, "testFunction")
+	t.Setenv(awsRegionEnvVar, "us-texas-1")
+	t.Setenv(lambdaFunctionVersionEnvVar, "$LATEST")
+	t.Setenv(lambdaLogStreamNameEnvVar, "2023/01/01/[$LATEST]5d1edb9e525d486696cf01a3503487bc")
+	t.Setenv(lambdaMemoryLimitEnvVar, "128")
 
 	attributes := []attribute.KeyValue{
 		semconv.CloudProviderAWS,

--- a/detectors/gcp/detector_test.go
+++ b/detectors/gcp/detector_test.go
@@ -17,7 +17,6 @@ package gcp // import "go.opentelemetry.io/contrib/detectors/gcp"
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp"
@@ -29,8 +28,7 @@ import (
 
 func TestDetect(t *testing.T) {
 	// Set this before all tests to ensure metadata.onGCE() returns true
-	err := os.Setenv("GCE_METADATA_HOST", "169.254.169.254")
-	assert.NoError(t, err)
+	t.Setenv("GCE_METADATA_HOST", "169.254.169.254")
 
 	for _, tc := range []struct {
 		desc             string

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/test/lambda_test.go
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/test/lambda_test.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -98,13 +97,13 @@ func initMockTracerProvider() (*sdktrace.TracerProvider, *tracetest.InMemoryExpo
 	return tp, exp
 }
 
-func setEnvVars() {
-	_ = os.Setenv("AWS_LAMBDA_FUNCTION_NAME", "testFunction")
-	_ = os.Setenv("AWS_REGION", "us-texas-1")
-	_ = os.Setenv("AWS_LAMBDA_FUNCTION_VERSION", "$LATEST")
-	_ = os.Setenv("AWS_LAMBDA_LOG_STREAM_NAME", "2023/01/01/[$LATEST]5d1edb9e525d486696cf01a3503487bc")
-	_ = os.Setenv("AWS_LAMBDA_FUNCTION_MEMORY_SIZE", "128")
-	_ = os.Setenv("_X_AMZN_TRACE_ID", "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1")
+func setEnvVars(t *testing.T) {
+	t.Setenv("AWS_LAMBDA_FUNCTION_NAME", "testFunction")
+	t.Setenv("AWS_REGION", "us-texas-1")
+	t.Setenv("AWS_LAMBDA_FUNCTION_VERSION", "$LATEST")
+	t.Setenv("AWS_LAMBDA_LOG_STREAM_NAME", "2023/01/01/[$LATEST]5d1edb9e525d486696cf01a3503487bc")
+	t.Setenv("AWS_LAMBDA_FUNCTION_MEMORY_SIZE", "128")
+	t.Setenv("_X_AMZN_TRACE_ID", "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1")
 }
 
 // Vars for Tracing and TracingWithFlusher Tests.
@@ -177,7 +176,7 @@ func assertStubEqualsIgnoreTime(t *testing.T, expected tracetest.SpanStub, actua
 }
 
 func TestInstrumentHandlerTracing(t *testing.T) {
-	setEnvVars()
+	setEnvVars(t)
 	tp, memExporter := initMockTracerProvider()
 
 	customerHandler := func() (string, error) {
@@ -198,7 +197,7 @@ func TestInstrumentHandlerTracing(t *testing.T) {
 }
 
 func TestWrapHandlerTracing(t *testing.T) {
-	setEnvVars()
+	setEnvVars(t)
 	tp, memExporter := initMockTracerProvider()
 
 	// No flusher needed as SimpleSpanProcessor is synchronous
@@ -223,7 +222,7 @@ func (mf *mockFlusher) ForceFlush(context.Context) error {
 var _ otellambda.Flusher = &mockFlusher{}
 
 func TestInstrumentHandlerTracingWithFlusher(t *testing.T) {
-	setEnvVars()
+	setEnvVars(t)
 	tp, memExporter := initMockTracerProvider()
 
 	customerHandler := func() (string, error) {
@@ -246,7 +245,7 @@ func TestInstrumentHandlerTracingWithFlusher(t *testing.T) {
 }
 
 func TestWrapHandlerTracingWithFlusher(t *testing.T) {
-	setEnvVars()
+	setEnvVars(t)
 	tp, memExporter := initMockTracerProvider()
 
 	flusher := mockFlusher{}
@@ -362,7 +361,7 @@ func mockRequestCarrier(eventJSON []byte) propagation.TextMapCarrier {
 }
 
 func TestInstrumentHandlerTracingWithMockPropagator(t *testing.T) {
-	setEnvVars()
+	setEnvVars(t)
 	tp, memExporter := initMockTracerProvider()
 
 	customerHandler := func(event mockRequest) (string, error) {
@@ -387,7 +386,7 @@ func TestInstrumentHandlerTracingWithMockPropagator(t *testing.T) {
 }
 
 func TestWrapHandlerTracingWithMockPropagator(t *testing.T) {
-	setEnvVars()
+	setEnvVars(t)
 	tp, memExporter := initMockTracerProvider()
 
 	// No flusher needed as SimpleSpanProcessor is synchronous

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/xrayconfig/xrayconfig_test.go
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/xrayconfig/xrayconfig_test.go
@@ -35,18 +35,14 @@ import (
 )
 
 func TestEventToCarrier(t *testing.T) {
-	os.Clearenv()
-
-	_ = os.Setenv("_X_AMZN_TRACE_ID", "traceID")
+	t.Setenv("_X_AMZN_TRACE_ID", "traceID")
 	carrier := xrayEventToCarrier([]byte{})
 
 	assert.Equal(t, "traceID", carrier.Get("X-Amzn-Trace-Id"))
 }
 
 func TestEventToCarrierWithPropagator(t *testing.T) {
-	os.Clearenv()
-
-	_ = os.Setenv("_X_AMZN_TRACE_ID", "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1")
+	t.Setenv("_X_AMZN_TRACE_ID", "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1")
 	carrier := xrayEventToCarrier([]byte{})
 	ctx := xray.Propagator{}.Extract(context.Background(), carrier)
 
@@ -63,18 +59,18 @@ func TestEventToCarrierWithPropagator(t *testing.T) {
 	assert.Equal(t, expectedCtx, ctx)
 }
 
-func setEnvVars() {
-	_ = os.Setenv("AWS_LAMBDA_FUNCTION_NAME", "testFunction")
-	_ = os.Setenv("AWS_REGION", "us-texas-1")
-	_ = os.Setenv("AWS_LAMBDA_FUNCTION_VERSION", "$LATEST")
-	_ = os.Setenv("AWS_LAMBDA_LOG_STREAM_NAME", "2023/01/01/[$LATEST]5d1edb9e525d486696cf01a3503487bc")
-	_ = os.Setenv("AWS_LAMBDA_FUNCTION_MEMORY_SIZE", "128")
-	_ = os.Setenv("_X_AMZN_TRACE_ID", "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1")
+func setEnvVars(t *testing.T) {
+	t.Setenv("AWS_LAMBDA_FUNCTION_NAME", "testFunction")
+	t.Setenv("AWS_REGION", "us-texas-1")
+	t.Setenv("AWS_LAMBDA_FUNCTION_VERSION", "$LATEST")
+	t.Setenv("AWS_LAMBDA_LOG_STREAM_NAME", "2023/01/01/[$LATEST]5d1edb9e525d486696cf01a3503487bc")
+	t.Setenv("AWS_LAMBDA_FUNCTION_MEMORY_SIZE", "128")
+	t.Setenv("_X_AMZN_TRACE_ID", "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1")
 
 	// fix issue: "The requested service provider could not be loaded or initialized."
 	// Guess: The env for Windows in GitHub action is incomplete
 	if runtime.GOOS == "windows" && os.Getenv("SYSTEMROOT") == "" {
-		_ = os.Setenv("SYSTEMROOT", `C:\Windows`)
+		t.Setenv("SYSTEMROOT", `C:\Windows`)
 	}
 }
 
@@ -169,7 +165,7 @@ func assertSpanEqualsIgnoreTimeAndSpanID(t *testing.T, expected *v1trace.Resourc
 }
 
 func TestWrapEndToEnd(t *testing.T) {
-	setEnvVars()
+	setEnvVars(t)
 
 	ctx := context.Background()
 	tp, err := NewTracerProvider(ctx)


### PR DESCRIPTION
Following up for https://github.com/open-telemetry/opentelemetry-go-contrib/pull/4618. 

This PR changes the test codes to use `t.Setenv` instead of `os.Setenv`.

