### PR TITLE
otelgrpc: Simplify the config Option.

### DIFF
--- a/instrumentation/google.golang.org/grpc/otelgrpc/semconv.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/semconv.go
@@ -36,6 +36,9 @@ const (
 	// The uncompressed size of the message transmitted or received in
 	// bytes.
 	RPCMessageUncompressedSizeKey = attribute.Key("message.uncompressed_size")
+
+	// GRPCStatusCodeKey is convention for numeric status code of a gRPC request.
+	GRPCStatusCodeKey = attribute.Key("rpc.grpc.status_code")
 )
 
 // Semantic conventions for common RPC attributes.


### PR DESCRIPTION
- Avoid creating a struct and for each configuration option by changing option from:
  ```go
  type Option interface {
      apply(*config)
  }
  ```
  To: 
  ```go
  type Option func(*config)
  ```

- Move `GRPCStatusCodeKey = attribute.Key("rpc.grpc.status_code")` from `config.go` to `semconv.go` file to be with his other attribute friends since in my mind made more sense