### PR TITLE
Add support to record errors from lambda handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Add the new `go.opentelemetry.io/contrib/instrgen` package to provide auto-generated source code instrumentation. (#3068, #3108)
 - Add `SDK.Shutdown` method in `"go.opentelemetry.io/contrib/config"`. (#4583)
+- Add `"go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda".WithRecordError` which configures the instrumentation to call `span.RecordError(err)` when an error is returned from a wrapped handler. (#4677)
+- Add `"go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda".WithSetStatus` which configures the instrumentation to call `span.SetStatus(codes.Error, err.Error())` when an error is returned from a wrapped handler. (#4677)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Add the new `go.opentelemetry.io/contrib/instrgen` package to provide auto-generated source code instrumentation. (#3068, #3108)
 - Add `SDK.Shutdown` method in `"go.opentelemetry.io/contrib/config"`. (#4583)
-- Add `"go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda".WithRecordError` which configures the instrumentation to call `span.RecordError(err)` when an error is returned from a wrapped handler. (#4677)
-- Add `"go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda".WithSetStatus` which configures the instrumentation to call `span.SetStatus(codes.Error, err.Error())` when an error is returned from a wrapped handler. (#4677)
+- Add `"go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda".WithRecordError` which configures the instrumentation to call `span.RecordError(err, trace.WithStackTrace(...))` when an error is returned from a wrapped handler. (#4677)
+- Call `span.SetStatus(codes.Error, err.Error())` when an error is returned from a wrapped handler. (#4677)
 
 ### Fixed
 

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/config.go
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/config.go
@@ -96,10 +96,9 @@ type config struct {
 	// handler should be recorded on the instrumentation-provided span
 	RecordError bool
 
-	// SetError is used to determine if an error returned from the wrapped
-	// handler should cause the instrumentation-provided span to set the
-	// span status to codes.Error
-	SetError bool
+	// RecordStackTrace is used to determine if the stack trace should be
+	// included when RecordError is true
+	RecordStackTrace bool
 }
 
 // WithTracerProvider configures the TracerProvider used by the
@@ -139,19 +138,9 @@ func WithPropagator(propagator propagation.TextMapPropagator) Option {
 // error returned by the wrapped lambda on the instrumentation-provided span.
 //
 // By default, returned errors are not recorded.
-func WithRecordError(recordError bool) Option {
+func WithRecordError(recordError bool, recordStackTrace bool) Option {
 	return optionFunc(func(c *config) {
 		c.RecordError = recordError
-	})
-}
-
-// WithSetStatus configures whether the instrumentation should set the span
-// status to codes.Error on the instrumentation-provided span when the
-// wrapped handler returns an error.
-//
-// By default, returned the status is not set.
-func WithSetStatus(setError bool) Option {
-	return optionFunc(func(c *config) {
-		c.SetError = setError
+		c.RecordStackTrace = recordError && recordStackTrace
 	})
 }

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/config.go
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/config.go
@@ -91,6 +91,15 @@ type config struct {
 	// The default value of Propagator the global otel Propagator
 	// returned by otel.GetTextMapPropagator()
 	Propagator propagation.TextMapPropagator
+
+	// RecordError is used to determine if an error returned from the wrapped
+	// handler should be recorded on the instrumentation-provided span
+	RecordError bool
+
+	// SetError is used to determine if an error returned from the wrapped
+	// handler should cause the instrumentation-provided span to set the
+	// span status to codes.Error
+	SetError bool
 }
 
 // WithTracerProvider configures the TracerProvider used by the
@@ -123,5 +132,26 @@ func WithEventToCarrier(eventToCarrier EventToCarrier) Option {
 func WithPropagator(propagator propagation.TextMapPropagator) Option {
 	return optionFunc(func(c *config) {
 		c.Propagator = propagator
+	})
+}
+
+// WithRecordError configures whether the instrumentation should record an
+// error returned by the wrapped lambda on the instrumentation-provided span.
+//
+// By default, returned errors are not recorded.
+func WithRecordError(recordError bool) Option {
+	return optionFunc(func(c *config) {
+		c.RecordError = recordError
+	})
+}
+
+// WithSetStatus configures whether the instrumentation should set the span
+// status to codes.Error on the instrumentation-provided span when the
+// wrapped handler returns an error.
+//
+// By default, returned the status is not set.
+func WithSetStatus(setError bool) Option {
+	return optionFunc(func(c *config) {
+		c.SetError = setError
 	})
 }

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/wrapHandler.go
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/wrapHandler.go
@@ -17,6 +17,7 @@ package otellambda // import "go.opentelemetry.io/contrib/instrumentation/github
 import (
 	"context"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/aws/aws-lambda-go/lambda"
 )
@@ -40,11 +41,9 @@ func (h wrappedHandler) Invoke(ctx context.Context, payload []byte) ([]byte, err
 	response, err := h.handler.Invoke(ctx, payload)
 	if err != nil {
 		if h.instrumentor.configuration.RecordError {
-			span.RecordError(err)
+			span.RecordError(err, trace.WithStackTrace(h.instrumentor.configuration.RecordStackTrace))
 		}
-		if h.instrumentor.configuration.SetError {
-			span.SetStatus(codes.Error, err.Error())
-		}
+		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
 

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/wrapHandler.go
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/wrapHandler.go
@@ -16,6 +16,7 @@ package otellambda // import "go.opentelemetry.io/contrib/instrumentation/github
 
 import (
 	"context"
+	"go.opentelemetry.io/otel/codes"
 
 	"github.com/aws/aws-lambda-go/lambda"
 )
@@ -38,6 +39,12 @@ func (h wrappedHandler) Invoke(ctx context.Context, payload []byte) ([]byte, err
 
 	response, err := h.handler.Invoke(ctx, payload)
 	if err != nil {
+		if h.instrumentor.configuration.RecordError {
+			span.RecordError(err)
+		}
+		if h.instrumentor.configuration.SetError {
+			span.SetStatus(codes.Error, err.Error())
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Currently, `otellambda` doesn't update the instrumentation-provided span based on the result of the wrapped handler.

I was surprised by this, as most of my OTel instrumentation work involves [open-telemetry/opentelemetry-dotnet](https://github.com/open-telemetry/opentelemetry-dotnet), so this may well be a sensible default for golang, but given the breadth and scale of the OTel projects, I figured this might also just be an oversight, so wanted to open a PR and contribute some code.

This PR adds two config methods:
1. `WithRecordError(bool)` which instructs the `wrappedHandler` to call `span.RecordError(...)` if `wrappedHandler.Handler.Invoke(...)` returns an error.
2. `WithSetStatus(bool)` which instructs the `wrappedHandler` to call `span.SetStatus(...)` if `wrappedHandler.Handler.Invoke(...)` returns an error.

___

_Off-topic, but in the [dotnet OTel libraries, it's also common to provide enrichment delegates](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry.Instrumentation.Http#enrich-httpclient-api) which can be used to filter/manipulate the instrumentation-provided span in other ways (e.g. setting custom attributes/tags based on the exception being thrown). I considered adding similar functionality here, but decided to hold off on doing anything more until the code owners have had an opportunity to weigh in._


## Background

_based on `go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda v0.46.1`_

![sanitized screencap of Datadog showing a trace's flame graph and error list](https://github.com/open-telemetry/opentelemetry-go-contrib/assets/21338699/a6b26aec-cdce-4658-adcc-65c0c532aac7)

![sanitized screencap of Datadog showing an APM error graph showing a 0% error rate before and a non-zero error rate after](https://github.com/open-telemetry/opentelemetry-go-contrib/assets/21338699/e9dc713d-24b7-4688-bad0-9780d609fb38)

### Sample code based on version `0.0.112` in the above screencap

```go
func main() {
	lambda.Start(otellambda.InstrumentHandler(handle))
}

func handle(ctx context.Context, data []byte) error {
	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer("...").Start(ctx, "...")

	// lots of internal logic
	// ...
	// err := ...

	if err != nil {
		span.RecordError(err)
		span.SetStatus(codes.Error, err.Error())
		return err
	}

	return nil
}
```

### Sample code based on version `0.0.113` in the above screencap

Note that our handler is no longer creating its own internal span. We can work around this by defining our own `wrappingHandler`, but the path of least resistance is to just work with the instrumentation-provided span.

```diff
func main() {
	lambda.Start(otellambda.InstrumentHandler(handle))
}

func handle(ctx context.Context, data []byte) error {
-	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer("...").Start(ctx, "...")
+	span := trace.SpanFromContext(ctx)

	// lots of internal logic
	// ...
	// err := ...

	if err != nil {
		span.RecordError(err)
		span.SetStatus(codes.Error, err.Error())
		return err
	}

	return nil
}
```

### Sample code based on this patch

Now we can create an internal span in our handler _and_ choose whether errors recorded in this layer should _also_ be passed back up to the instrumentation-provided span to be recorded there as well. 

_(Example here might be overly simplified, but underlying all of the required obfuscation there is a real-world business case for this. I can provide more details upon request if required.)_

```diff
func main() {
-	lambda.Start(otellambda.InstrumentHandler(handle))
+	lambda.Start(otellambda.InstrumentHandler(handle, otellambda.WithRecordError(true), otellambda.WithSetStatus(true)))
}

func handle(ctx context.Context, data []byte) error {
-	span := trace.SpanFromContext(ctx)
+	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer("...").Start(ctx, "...")

	// lots of internal logic
	// ...
	// err := ...

	if err != nil {
		span.RecordError(err)
		span.SetStatus(codes.Error, err.Error())
		return err
	}

	return nil
}

```