### PR TITLE
[chore] fix failures with upload-artifact 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
         fail_ci_if_error: true
         verbose: true
     - name: Store coverage test output
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: opentelemetry-go-contrib-test-output
         path: ${{ env.TEST_RESULTS }}
@@ -155,7 +155,7 @@ jobs:
         fail_ci_if_error: true
         verbose: true
     - name: Store coverage test output
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
           name: opentelemetry-go-contrib-test-output
           path: ${{ env.TEST_RESULTS }}


### PR DESCRIPTION
We saw similar failures in the collector repositories. See an example of a failure: https://github.com/open-telemetry/opentelemetry-go-contrib/actions/runs/7292851552/job/19874703538?pr=4741

There's an open issue around this: https://github.com/actions/upload-artifact/issues/471