### PR TITLE
[chore] Bump actions/upload-artifact from 3 to 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
         fail_ci_if_error: true
         verbose: true
     - name: Store coverage test output
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: opentelemetry-go-contrib-test-output
         path: ${{ env.TEST_RESULTS }}
@@ -155,9 +155,9 @@ jobs:
         fail_ci_if_error: true
         verbose: true
     - name: Store coverage test output
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-          name: opentelemetry-go-contrib-test-output
+          name: opentelemetry-go-contrib-integration-test-output
           path: ${{ env.TEST_RESULTS }}
 
   test-integration:


### PR DESCRIPTION
Proper fix of https://github.com/open-telemetry/opentelemetry-go-contrib/pull/4742

Take notice that `coverage.out` produced by `test-coverage` and `integration` jobs are different.