### PR TITLE
docs: spell out unpacking OTEL_RESOURCE_ATTRIBUTES

### DIFF
--- a/detectors/gcp/README.md
+++ b/detectors/gcp/README.md
@@ -39,7 +39,7 @@ tp := trace.NewTracerProvider(
 Previous iterations of GCP resource detection attempted to detect
 `container.name`, `k8s.pod.name` and `k8s.namespace.name`.  When using this detector,
 you should use this in your Pod Spec to set these using
-`OTEL_RESOURCE_ATTRIBUTES`:
+[`OTEL_RESOURCE_ATTRIBUTES`](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/resource/sdk.md#specifying-resource-information-via-an-environment-variable):
 
 ```yaml
 env:
@@ -55,3 +55,21 @@ env:
   value: my-container-name
 - name: OTEL_RESOURCE_ATTRIBUTES
   value: k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(NAMESPACE_NAME),k8s.container.name=$(CONTAINER_NAME)
+```
+To have a detector unpack the `OTEL_RESOURCE_ATTRIBUTES` envvar, use the `WithFromEnv` option:
+
+```golang
+...
+// Detect your resources
+res, err := resource.New(ctx,
+    resource.WithDetectors(gcp.NewDetector()),
+    resource.WithTelemetrySDK(),
+    resource.WithFromEnv(), // unpacks OTEL_RESOURCE_ATTRIBUTES
+    // Add your own custom attributes to identify your application
+    resource.WithAttributes(
+        semconv.ServiceNameKey.String("my-application"),
+        semconv.ServiceNamespaceKey.String("my-company-frontend-team"),
+    ),
+)
+...
+```


### PR DESCRIPTION
We recently migrated from OpenCensus to OTEL and had some back and forth on how to detect our containerized resource as a [`k8s_container`](https://cloud.google.com/monitoring/api/resources#tag_k8s_container) resource in GCP. I think the extra detail could help folks that just want a 1-1 migration. 