### PR TITLE
AWS ECS detector should detect otel CloudRegion/CloudAccountID/CloudAvailabilityZone/CloudResourceID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Add the new `go.opentelemetry.io/contrib/instrgen` package to provide auto-generated source code instrumentation. (#3068, #3108)
+- `go.opentelemetry.io/contrib/detectors/aws/ecs` attempts to detect and add `semconv.CloudRegion`, `semconv.CloudAccountID`, `semconv.CloudAvailabilityZone` and `semconv.CloudResourceID`
 
 ## [1.22.0/0.47.0/0.16.0/0.2.0] - 2024-01-18
 

--- a/detectors/aws/ecs/ecs.go
+++ b/detectors/aws/ecs/ecs.go
@@ -134,6 +134,25 @@ func (detector *resourceDetector) Detect(ctx context.Context) (*resource.Resourc
 			attributes = append(attributes, logAttributes...)
 		}
 
+		// Calculate region and account ID from baseArn
+		awsRegion := ""
+		awsAccountId := ""
+		if baseArn != "" {
+			arnParts := strings.Split(baseArn, ":")
+			if len(arnParts) >= 4 {
+				awsRegion = arnParts[3]
+			}
+			if len(arnParts) >= 5 {
+				awsAccountId = arnParts[4]
+			}
+		}
+		if len(awsRegion) > 0 {
+			attributes = append(attributes, semconv.CloudRegion(awsRegion))
+		}
+		if len(awsAccountId) > 0 {
+			attributes = append(attributes, semconv.CloudAccountID(awsAccountId))
+		}
+
 		attributes = append(
 			attributes,
 			semconv.AWSECSContainerARN(containerMetadata.ContainerARN),
@@ -142,6 +161,8 @@ func (detector *resourceDetector) Detect(ctx context.Context) (*resource.Resourc
 			semconv.AWSECSTaskARN(taskMetadata.TaskARN),
 			semconv.AWSECSTaskFamily(taskMetadata.Family),
 			semconv.AWSECSTaskRevision(taskMetadata.Revision),
+			semconv.CloudAvailabilityZone(taskMetadata.AvailabilityZone),
+			semconv.CloudResourceID(containerMetadata.ContainerARN),
 		)
 	}
 

--- a/detectors/aws/ecs/test/ecs_test.go
+++ b/detectors/aws/ecs/test/ecs_test.go
@@ -81,6 +81,10 @@ func TestDetectV4LaunchTypeEc2(t *testing.T) {
 		semconv.AWSLogGroupARNs("arn:aws:logs:us-west-2:111122223333:log-group:/ecs/metadata:*"),
 		semconv.AWSLogStreamNames("ecs/curl/8f03e41243824aea923aca126495f665"),
 		semconv.AWSLogStreamARNs("arn:aws:logs:us-west-2:111122223333:log-group:/ecs/metadata:log-stream:ecs/curl/8f03e41243824aea923aca126495f665"),
+		semconv.CloudRegion("us-west-2"),
+		semconv.CloudAccountID("111122223333"),
+		semconv.CloudAvailabilityZone("us-west-2d"),
+		semconv.CloudResourceID("arn:aws:ecs:us-west-2:111122223333:container/0206b271-b33f-47ab-86c6-a0ba208a70a9"),
 	}
 	expectedResource := resource.NewWithAttributes(semconv.SchemaURL, attributes...)
 	detector := ecs.NewResourceDetector()
@@ -137,6 +141,10 @@ func TestDetectV4LaunchTypeEc2BadContainerArn(t *testing.T) {
 		semconv.AWSLogGroupARNs("arn:aws:logs:us-west-2:111122223333:log-group:/ecs/metadata:*"),
 		semconv.AWSLogStreamNames("ecs/curl/8f03e41243824aea923aca126495f665"),
 		semconv.AWSLogStreamARNs("arn:aws:logs:us-west-2:111122223333:log-group:/ecs/metadata:log-stream:ecs/curl/8f03e41243824aea923aca126495f665"),
+		semconv.CloudRegion("us-west-2"),
+		semconv.CloudAccountID("111122223333"),
+		semconv.CloudAvailabilityZone("us-west-2d"),
+		semconv.CloudResourceID("arn:aws:ecs:us-west-2:111122223333:container/0206b271-b33f-47ab-86c6-a0ba208a70a9"),
 	}
 	expectedResource := resource.NewWithAttributes(semconv.SchemaURL, attributes...)
 	detector := ecs.NewResourceDetector()
@@ -193,6 +201,10 @@ func TestDetectV4LaunchTypeEc2BadTaskArn(t *testing.T) {
 		semconv.AWSLogGroupARNs("arn:aws:logs:us-west-2:111122223333:log-group:/ecs/metadata:*"),
 		semconv.AWSLogStreamNames("ecs/curl/8f03e41243824aea923aca126495f665"),
 		semconv.AWSLogStreamARNs("arn:aws:logs:us-west-2:111122223333:log-group:/ecs/metadata:log-stream:ecs/curl/8f03e41243824aea923aca126495f665"),
+		semconv.CloudRegion("us-west-2"),
+		semconv.CloudAccountID("111122223333"),
+		semconv.CloudAvailabilityZone("us-west-2d"),
+		semconv.CloudResourceID("arn:aws:ecs:us-west-2:111122223333:container/0206b271-b33f-47ab-86c6-a0ba208a70a9"),
 	}
 	expectedResource := resource.NewWithAttributes(semconv.SchemaURL, attributes...)
 	detector := ecs.NewResourceDetector()
@@ -249,6 +261,10 @@ func TestDetectV4LaunchTypeFargate(t *testing.T) {
 		semconv.AWSLogGroupARNs("arn:aws:logs:us-west-2:111122223333:log-group:/ecs/containerlogs:*"),
 		semconv.AWSLogStreamNames("ecs/curl/cd189a933e5849daa93386466019ab50"),
 		semconv.AWSLogStreamARNs("arn:aws:logs:us-west-2:111122223333:log-group:/ecs/containerlogs:log-stream:ecs/curl/cd189a933e5849daa93386466019ab50"),
+		semconv.CloudRegion("us-west-2"),
+		semconv.CloudAccountID("111122223333"),
+		semconv.CloudAvailabilityZone("us-west-2a"),
+		semconv.CloudResourceID("arn:aws:ecs:us-west-2:111122223333:container/05966557-f16c-49cb-9352-24b3a0dcd0e1"),
 	}
 	expectedResource := resource.NewWithAttributes(semconv.SchemaURL, attributes...)
 	detector := ecs.NewResourceDetector()


### PR DESCRIPTION
Some applications rely on the otel non-vendored cloud tags being populated in metrics/traces. For ECS workloads, we can populate these from the data that's already returned from the ECS Metadata API, so this can be used to add to the resource's attributes.