### PR TITLE
Remove unused portions of the internal semconvutil

### DIFF
--- a/instrumentation/github.com/emicklei/go-restful/otelrestful/internal/semconvutil/httpconv.go
+++ b/instrumentation/github.com/emicklei/go-restful/otelrestful/internal/semconvutil/httpconv.go
@@ -114,36 +114,6 @@ func HTTPServerStatus(code int) (codes.Code, string) {
 	return hc.ServerStatus(code)
 }
 
-// HTTPRequestHeader returns the contents of h as attributes.
-//
-// Instrumentation should require an explicit configuration of which headers to
-// captured and then prune what they pass here. Including all headers can be a
-// security risk - explicit configuration helps avoid leaking sensitive
-// information.
-//
-// The User-Agent header is already captured in the http.user_agent attribute
-// from ClientRequest and ServerRequest. Instrumentation may provide an option
-// to capture that header here even though it is not recommended. Otherwise,
-// instrumentation should filter that out of what is passed.
-func HTTPRequestHeader(h http.Header) []attribute.KeyValue {
-	return hc.RequestHeader(h)
-}
-
-// HTTPResponseHeader returns the contents of h as attributes.
-//
-// Instrumentation should require an explicit configuration of which headers to
-// captured and then prune what they pass here. Including all headers can be a
-// security risk - explicit configuration helps avoid leaking sensitive
-// information.
-//
-// The User-Agent header is already captured in the http.user_agent attribute
-// from ClientRequest and ServerRequest. Instrumentation may provide an option
-// to capture that header here even though it is not recommended. Otherwise,
-// instrumentation should filter that out of what is passed.
-func HTTPResponseHeader(h http.Header) []attribute.KeyValue {
-	return hc.ResponseHeader(h)
-}
-
 // httpConv are the HTTP semantic convention attributes defined for a version
 // of the OpenTelemetry specification.
 type httpConv struct {
@@ -549,31 +519,6 @@ func firstHostPort(source ...string) (host string, port int) {
 		}
 	}
 	return
-}
-
-// RequestHeader returns the contents of h as OpenTelemetry attributes.
-func (c *httpConv) RequestHeader(h http.Header) []attribute.KeyValue {
-	return c.header("http.request.header", h)
-}
-
-// ResponseHeader returns the contents of h as OpenTelemetry attributes.
-func (c *httpConv) ResponseHeader(h http.Header) []attribute.KeyValue {
-	return c.header("http.response.header", h)
-}
-
-func (c *httpConv) header(prefix string, h http.Header) []attribute.KeyValue {
-	key := func(k string) attribute.Key {
-		k = strings.ToLower(k)
-		k = strings.ReplaceAll(k, "-", "_")
-		k = fmt.Sprintf("%s.%s", prefix, k)
-		return attribute.Key(k)
-	}
-
-	attrs := make([]attribute.KeyValue, 0, len(h))
-	for k, v := range h {
-		attrs = append(attrs, key(k).StringSlice(v))
-	}
-	return attrs
 }
 
 // ClientStatus returns a span status code and message for an HTTP status code

--- a/instrumentation/github.com/emicklei/go-restful/otelrestful/internal/semconvutil/httpconv_test.go
+++ b/instrumentation/github.com/emicklei/go-restful/otelrestful/internal/semconvutil/httpconv_test.go
@@ -290,32 +290,6 @@ func TestFirstHostPort(t *testing.T) {
 	}
 }
 
-func TestHTTPRequestHeader(t *testing.T) {
-	ips := []string{"127.0.0.5", "127.0.0.9"}
-	user := []string{"alice"}
-	h := http.Header{"ips": ips, "user": user}
-
-	got := HTTPRequestHeader(h)
-	assert.Equal(t, 2, cap(got), "slice capacity")
-	assert.ElementsMatch(t, []attribute.KeyValue{
-		attribute.StringSlice("http.request.header.ips", ips),
-		attribute.StringSlice("http.request.header.user", user),
-	}, got)
-}
-
-func TestHTTPReponseHeader(t *testing.T) {
-	ips := []string{"127.0.0.5", "127.0.0.9"}
-	user := []string{"alice"}
-	h := http.Header{"ips": ips, "user": user}
-
-	got := HTTPResponseHeader(h)
-	assert.Equal(t, 2, cap(got), "slice capacity")
-	assert.ElementsMatch(t, []attribute.KeyValue{
-		attribute.StringSlice("http.response.header.ips", ips),
-		attribute.StringSlice("http.response.header.user", user),
-	}, got)
-}
-
 func TestHTTPClientStatus(t *testing.T) {
 	tests := []struct {
 		code int

--- a/instrumentation/github.com/emicklei/go-restful/otelrestful/internal/semconvutil/netconv.go
+++ b/instrumentation/github.com/emicklei/go-restful/otelrestful/internal/semconvutil/netconv.go
@@ -32,24 +32,6 @@ func NetTransport(network string) attribute.KeyValue {
 	return nc.Transport(network)
 }
 
-// NetClient returns trace attributes for a client network connection to address.
-// See net.Dial for information about acceptable address values, address should
-// be the same as the one used to create conn. If conn is nil, only network
-// peer attributes will be returned that describe address. Otherwise, the
-// socket level information about conn will also be included.
-func NetClient(address string, conn net.Conn) []attribute.KeyValue {
-	return nc.Client(address, conn)
-}
-
-// NetServer returns trace attributes for a network listener listening at address.
-// See net.Listen for information about acceptable address values, address
-// should be the same as the one used to create ln. If ln is nil, only network
-// host attributes will be returned that describe address. Otherwise, the
-// socket level information about ln will also be included.
-func NetServer(address string, ln net.Listener) []attribute.KeyValue {
-	return nc.Server(address, ln)
-}
-
 // netConv are the network semantic convention attributes defined for a version
 // of the OpenTelemetry specification.
 type netConv struct {
@@ -125,137 +107,12 @@ func (c *netConv) Host(address string) []attribute.KeyValue {
 	return attrs
 }
 
-// Server returns attributes for a network listener listening at address. See
-// net.Listen for information about acceptable address values, address should
-// be the same as the one used to create ln. If ln is nil, only network host
-// attributes will be returned that describe address. Otherwise, the socket
-// level information about ln will also be included.
-func (c *netConv) Server(address string, ln net.Listener) []attribute.KeyValue {
-	if ln == nil {
-		return c.Host(address)
-	}
-
-	lAddr := ln.Addr()
-	if lAddr == nil {
-		return c.Host(address)
-	}
-
-	hostName, hostPort := splitHostPort(address)
-	sockHostAddr, sockHostPort := splitHostPort(lAddr.String())
-	network := lAddr.Network()
-	sockFamily := family(network, sockHostAddr)
-
-	n := nonZeroStr(hostName, network, sockHostAddr, sockFamily)
-	n += positiveInt(hostPort, sockHostPort)
-	attr := make([]attribute.KeyValue, 0, n)
-	if hostName != "" {
-		attr = append(attr, c.HostName(hostName))
-		if hostPort > 0 {
-			// Only if net.host.name is set should net.host.port be.
-			attr = append(attr, c.HostPort(hostPort))
-		}
-	}
-	if network != "" {
-		attr = append(attr, c.Transport(network))
-	}
-	if sockFamily != "" {
-		attr = append(attr, c.NetSockFamilyKey.String(sockFamily))
-	}
-	if sockHostAddr != "" {
-		attr = append(attr, c.NetSockHostAddrKey.String(sockHostAddr))
-		if sockHostPort > 0 {
-			// Only if net.sock.host.addr is set should net.sock.host.port be.
-			attr = append(attr, c.NetSockHostPortKey.Int(sockHostPort))
-		}
-	}
-	return attr
-}
-
 func (c *netConv) HostName(name string) attribute.KeyValue {
 	return c.NetHostNameKey.String(name)
 }
 
 func (c *netConv) HostPort(port int) attribute.KeyValue {
 	return c.NetHostPortKey.Int(port)
-}
-
-// Client returns attributes for a client network connection to address. See
-// net.Dial for information about acceptable address values, address should be
-// the same as the one used to create conn. If conn is nil, only network peer
-// attributes will be returned that describe address. Otherwise, the socket
-// level information about conn will also be included.
-func (c *netConv) Client(address string, conn net.Conn) []attribute.KeyValue {
-	if conn == nil {
-		return c.Peer(address)
-	}
-
-	lAddr, rAddr := conn.LocalAddr(), conn.RemoteAddr()
-
-	var network string
-	switch {
-	case lAddr != nil:
-		network = lAddr.Network()
-	case rAddr != nil:
-		network = rAddr.Network()
-	default:
-		return c.Peer(address)
-	}
-
-	peerName, peerPort := splitHostPort(address)
-	var (
-		sockFamily   string
-		sockPeerAddr string
-		sockPeerPort int
-		sockHostAddr string
-		sockHostPort int
-	)
-
-	if lAddr != nil {
-		sockHostAddr, sockHostPort = splitHostPort(lAddr.String())
-	}
-
-	if rAddr != nil {
-		sockPeerAddr, sockPeerPort = splitHostPort(rAddr.String())
-	}
-
-	switch {
-	case sockHostAddr != "":
-		sockFamily = family(network, sockHostAddr)
-	case sockPeerAddr != "":
-		sockFamily = family(network, sockPeerAddr)
-	}
-
-	n := nonZeroStr(peerName, network, sockPeerAddr, sockHostAddr, sockFamily)
-	n += positiveInt(peerPort, sockPeerPort, sockHostPort)
-	attr := make([]attribute.KeyValue, 0, n)
-	if peerName != "" {
-		attr = append(attr, c.PeerName(peerName))
-		if peerPort > 0 {
-			// Only if net.peer.name is set should net.peer.port be.
-			attr = append(attr, c.PeerPort(peerPort))
-		}
-	}
-	if network != "" {
-		attr = append(attr, c.Transport(network))
-	}
-	if sockFamily != "" {
-		attr = append(attr, c.NetSockFamilyKey.String(sockFamily))
-	}
-	if sockPeerAddr != "" {
-		attr = append(attr, c.NetSockPeerAddrKey.String(sockPeerAddr))
-		if sockPeerPort > 0 {
-			// Only if net.sock.peer.addr is set should net.sock.peer.port be.
-			attr = append(attr, c.NetSockPeerPortKey.Int(sockPeerPort))
-		}
-	}
-	if sockHostAddr != "" {
-		attr = append(attr, c.NetSockHostAddrKey.String(sockHostAddr))
-		if sockHostPort > 0 {
-			// Only if net.sock.host.addr is set should net.sock.host.port be.
-			attr = append(attr, c.NetSockHostPortKey.Int(sockHostPort))
-		}
-	}
-	return attr
 }
 
 func family(network, address string) string {
@@ -271,26 +128,6 @@ func family(network, address string) string {
 		}
 	}
 	return ""
-}
-
-func nonZeroStr(strs ...string) int {
-	var n int
-	for _, str := range strs {
-		if str != "" {
-			n++
-		}
-	}
-	return n
-}
-
-func positiveInt(ints ...int) int {
-	var n int
-	for _, i := range ints {
-		if i > 0 {
-			n++
-		}
-	}
-	return n
 }
 
 // Peer returns attributes for a network peer address.

--- a/instrumentation/github.com/emicklei/go-restful/otelrestful/internal/semconvutil/netconv_test.go
+++ b/instrumentation/github.com/emicklei/go-restful/otelrestful/internal/semconvutil/netconv_test.go
@@ -17,12 +17,9 @@
 package semconvutil
 
 import (
-	"net"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel/attribute"
 )
@@ -54,53 +51,6 @@ func TestNetTransport(t *testing.T) {
 	}
 }
 
-func TestNetServerNilListener(t *testing.T) {
-	const addr = "127.0.0.1:8080"
-	got := NetServer(addr, nil)
-	expected := nc.Host(addr)
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-type listener struct{ net.Listener }
-
-func (listener) Addr() net.Addr { return nil }
-
-func TestNetServerNilAddr(t *testing.T) {
-	const addr = "127.0.0.1:8080"
-	got := NetServer(addr, listener{})
-	expected := nc.Host(addr)
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-func newTCPListener() (net.Listener, error) {
-	return net.Listen("tcp4", "127.0.0.1:0")
-}
-
-func TestNetServerTCP(t *testing.T) {
-	ln, err := newTCPListener()
-	require.NoError(t, err)
-	defer func() { require.NoError(t, ln.Close()) }()
-
-	host, pStr, err := net.SplitHostPort(ln.Addr().String())
-	require.NoError(t, err)
-	port, err := strconv.Atoi(pStr)
-	require.NoError(t, err)
-
-	got := NetServer("example.com:8080", ln)
-	expected := []attribute.KeyValue{
-		nc.HostName("example.com"),
-		nc.HostPort(8080),
-		nc.NetTransportTCP,
-		nc.NetSockFamilyKey.String("inet"),
-		nc.NetSockHostAddrKey.String(host),
-		nc.NetSockHostPortKey.Int(port),
-	}
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
 func TestNetHost(t *testing.T) {
 	testAddrs(t, []addrTest{
 		{address: "", expected: nil},
@@ -122,103 +72,6 @@ func TestNetHostName(t *testing.T) {
 func TestNetHostPort(t *testing.T) {
 	expected := attribute.Key("net.host.port").Int(port)
 	assert.Equal(t, expected, nc.HostPort(port))
-}
-
-func TestNetClientNilConn(t *testing.T) {
-	const addr = "127.0.0.1:8080"
-	got := NetClient(addr, nil)
-	expected := nc.Peer(addr)
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-type conn struct{ net.Conn }
-
-func (conn) LocalAddr() net.Addr  { return nil }
-func (conn) RemoteAddr() net.Addr { return nil }
-
-func TestNetClientNilAddr(t *testing.T) {
-	const addr = "127.0.0.1:8080"
-	got := NetClient(addr, conn{})
-	expected := nc.Peer(addr)
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-func newTCPConn() (net.Conn, net.Listener, error) {
-	ln, err := newTCPListener()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	conn, err := net.Dial("tcp4", ln.Addr().String())
-	if err != nil {
-		_ = ln.Close()
-		return nil, nil, err
-	}
-
-	return conn, ln, nil
-}
-
-func TestNetClientTCP(t *testing.T) {
-	conn, ln, err := newTCPConn()
-	require.NoError(t, err)
-	defer func() { require.NoError(t, ln.Close()) }()
-	defer func() { require.NoError(t, conn.Close()) }()
-
-	lHost, pStr, err := net.SplitHostPort(conn.LocalAddr().String())
-	require.NoError(t, err)
-	lPort, err := strconv.Atoi(pStr)
-	require.NoError(t, err)
-
-	rHost, pStr, err := net.SplitHostPort(conn.RemoteAddr().String())
-	require.NoError(t, err)
-	rPort, err := strconv.Atoi(pStr)
-	require.NoError(t, err)
-
-	got := NetClient("example.com:8080", conn)
-	expected := []attribute.KeyValue{
-		nc.PeerName("example.com"),
-		nc.PeerPort(8080),
-		nc.NetTransportTCP,
-		nc.NetSockFamilyKey.String("inet"),
-		nc.NetSockPeerAddrKey.String(rHost),
-		nc.NetSockPeerPortKey.Int(rPort),
-		nc.NetSockHostAddrKey.String(lHost),
-		nc.NetSockHostPortKey.Int(lPort),
-	}
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-type remoteOnlyConn struct{ net.Conn }
-
-func (remoteOnlyConn) LocalAddr() net.Addr { return nil }
-
-func TestNetClientTCPNilLocal(t *testing.T) {
-	conn, ln, err := newTCPConn()
-	require.NoError(t, err)
-	defer func() { require.NoError(t, ln.Close()) }()
-	defer func() { require.NoError(t, conn.Close()) }()
-
-	conn = remoteOnlyConn{conn}
-
-	rHost, pStr, err := net.SplitHostPort(conn.RemoteAddr().String())
-	require.NoError(t, err)
-	rPort, err := strconv.Atoi(pStr)
-	require.NoError(t, err)
-
-	got := NetClient("example.com:8080", conn)
-	expected := []attribute.KeyValue{
-		nc.PeerName("example.com"),
-		nc.PeerPort(8080),
-		nc.NetTransportTCP,
-		nc.NetSockFamilyKey.String("inet"),
-		nc.NetSockPeerAddrKey.String(rHost),
-		nc.NetSockPeerPortKey.Int(rPort),
-	}
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
 }
 
 func TestNetPeer(t *testing.T) {

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/internal/semconvutil/httpconv.go
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/internal/semconvutil/httpconv.go
@@ -114,36 +114,6 @@ func HTTPServerStatus(code int) (codes.Code, string) {
 	return hc.ServerStatus(code)
 }
 
-// HTTPRequestHeader returns the contents of h as attributes.
-//
-// Instrumentation should require an explicit configuration of which headers to
-// captured and then prune what they pass here. Including all headers can be a
-// security risk - explicit configuration helps avoid leaking sensitive
-// information.
-//
-// The User-Agent header is already captured in the http.user_agent attribute
-// from ClientRequest and ServerRequest. Instrumentation may provide an option
-// to capture that header here even though it is not recommended. Otherwise,
-// instrumentation should filter that out of what is passed.
-func HTTPRequestHeader(h http.Header) []attribute.KeyValue {
-	return hc.RequestHeader(h)
-}
-
-// HTTPResponseHeader returns the contents of h as attributes.
-//
-// Instrumentation should require an explicit configuration of which headers to
-// captured and then prune what they pass here. Including all headers can be a
-// security risk - explicit configuration helps avoid leaking sensitive
-// information.
-//
-// The User-Agent header is already captured in the http.user_agent attribute
-// from ClientRequest and ServerRequest. Instrumentation may provide an option
-// to capture that header here even though it is not recommended. Otherwise,
-// instrumentation should filter that out of what is passed.
-func HTTPResponseHeader(h http.Header) []attribute.KeyValue {
-	return hc.ResponseHeader(h)
-}
-
 // httpConv are the HTTP semantic convention attributes defined for a version
 // of the OpenTelemetry specification.
 type httpConv struct {
@@ -549,31 +519,6 @@ func firstHostPort(source ...string) (host string, port int) {
 		}
 	}
 	return
-}
-
-// RequestHeader returns the contents of h as OpenTelemetry attributes.
-func (c *httpConv) RequestHeader(h http.Header) []attribute.KeyValue {
-	return c.header("http.request.header", h)
-}
-
-// ResponseHeader returns the contents of h as OpenTelemetry attributes.
-func (c *httpConv) ResponseHeader(h http.Header) []attribute.KeyValue {
-	return c.header("http.response.header", h)
-}
-
-func (c *httpConv) header(prefix string, h http.Header) []attribute.KeyValue {
-	key := func(k string) attribute.Key {
-		k = strings.ToLower(k)
-		k = strings.ReplaceAll(k, "-", "_")
-		k = fmt.Sprintf("%s.%s", prefix, k)
-		return attribute.Key(k)
-	}
-
-	attrs := make([]attribute.KeyValue, 0, len(h))
-	for k, v := range h {
-		attrs = append(attrs, key(k).StringSlice(v))
-	}
-	return attrs
 }
 
 // ClientStatus returns a span status code and message for an HTTP status code

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/internal/semconvutil/httpconv_test.go
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/internal/semconvutil/httpconv_test.go
@@ -290,32 +290,6 @@ func TestFirstHostPort(t *testing.T) {
 	}
 }
 
-func TestHTTPRequestHeader(t *testing.T) {
-	ips := []string{"127.0.0.5", "127.0.0.9"}
-	user := []string{"alice"}
-	h := http.Header{"ips": ips, "user": user}
-
-	got := HTTPRequestHeader(h)
-	assert.Equal(t, 2, cap(got), "slice capacity")
-	assert.ElementsMatch(t, []attribute.KeyValue{
-		attribute.StringSlice("http.request.header.ips", ips),
-		attribute.StringSlice("http.request.header.user", user),
-	}, got)
-}
-
-func TestHTTPReponseHeader(t *testing.T) {
-	ips := []string{"127.0.0.5", "127.0.0.9"}
-	user := []string{"alice"}
-	h := http.Header{"ips": ips, "user": user}
-
-	got := HTTPResponseHeader(h)
-	assert.Equal(t, 2, cap(got), "slice capacity")
-	assert.ElementsMatch(t, []attribute.KeyValue{
-		attribute.StringSlice("http.response.header.ips", ips),
-		attribute.StringSlice("http.response.header.user", user),
-	}, got)
-}
-
 func TestHTTPClientStatus(t *testing.T) {
 	tests := []struct {
 		code int

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/internal/semconvutil/netconv.go
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/internal/semconvutil/netconv.go
@@ -32,24 +32,6 @@ func NetTransport(network string) attribute.KeyValue {
 	return nc.Transport(network)
 }
 
-// NetClient returns trace attributes for a client network connection to address.
-// See net.Dial for information about acceptable address values, address should
-// be the same as the one used to create conn. If conn is nil, only network
-// peer attributes will be returned that describe address. Otherwise, the
-// socket level information about conn will also be included.
-func NetClient(address string, conn net.Conn) []attribute.KeyValue {
-	return nc.Client(address, conn)
-}
-
-// NetServer returns trace attributes for a network listener listening at address.
-// See net.Listen for information about acceptable address values, address
-// should be the same as the one used to create ln. If ln is nil, only network
-// host attributes will be returned that describe address. Otherwise, the
-// socket level information about ln will also be included.
-func NetServer(address string, ln net.Listener) []attribute.KeyValue {
-	return nc.Server(address, ln)
-}
-
 // netConv are the network semantic convention attributes defined for a version
 // of the OpenTelemetry specification.
 type netConv struct {
@@ -125,137 +107,12 @@ func (c *netConv) Host(address string) []attribute.KeyValue {
 	return attrs
 }
 
-// Server returns attributes for a network listener listening at address. See
-// net.Listen for information about acceptable address values, address should
-// be the same as the one used to create ln. If ln is nil, only network host
-// attributes will be returned that describe address. Otherwise, the socket
-// level information about ln will also be included.
-func (c *netConv) Server(address string, ln net.Listener) []attribute.KeyValue {
-	if ln == nil {
-		return c.Host(address)
-	}
-
-	lAddr := ln.Addr()
-	if lAddr == nil {
-		return c.Host(address)
-	}
-
-	hostName, hostPort := splitHostPort(address)
-	sockHostAddr, sockHostPort := splitHostPort(lAddr.String())
-	network := lAddr.Network()
-	sockFamily := family(network, sockHostAddr)
-
-	n := nonZeroStr(hostName, network, sockHostAddr, sockFamily)
-	n += positiveInt(hostPort, sockHostPort)
-	attr := make([]attribute.KeyValue, 0, n)
-	if hostName != "" {
-		attr = append(attr, c.HostName(hostName))
-		if hostPort > 0 {
-			// Only if net.host.name is set should net.host.port be.
-			attr = append(attr, c.HostPort(hostPort))
-		}
-	}
-	if network != "" {
-		attr = append(attr, c.Transport(network))
-	}
-	if sockFamily != "" {
-		attr = append(attr, c.NetSockFamilyKey.String(sockFamily))
-	}
-	if sockHostAddr != "" {
-		attr = append(attr, c.NetSockHostAddrKey.String(sockHostAddr))
-		if sockHostPort > 0 {
-			// Only if net.sock.host.addr is set should net.sock.host.port be.
-			attr = append(attr, c.NetSockHostPortKey.Int(sockHostPort))
-		}
-	}
-	return attr
-}
-
 func (c *netConv) HostName(name string) attribute.KeyValue {
 	return c.NetHostNameKey.String(name)
 }
 
 func (c *netConv) HostPort(port int) attribute.KeyValue {
 	return c.NetHostPortKey.Int(port)
-}
-
-// Client returns attributes for a client network connection to address. See
-// net.Dial for information about acceptable address values, address should be
-// the same as the one used to create conn. If conn is nil, only network peer
-// attributes will be returned that describe address. Otherwise, the socket
-// level information about conn will also be included.
-func (c *netConv) Client(address string, conn net.Conn) []attribute.KeyValue {
-	if conn == nil {
-		return c.Peer(address)
-	}
-
-	lAddr, rAddr := conn.LocalAddr(), conn.RemoteAddr()
-
-	var network string
-	switch {
-	case lAddr != nil:
-		network = lAddr.Network()
-	case rAddr != nil:
-		network = rAddr.Network()
-	default:
-		return c.Peer(address)
-	}
-
-	peerName, peerPort := splitHostPort(address)
-	var (
-		sockFamily   string
-		sockPeerAddr string
-		sockPeerPort int
-		sockHostAddr string
-		sockHostPort int
-	)
-
-	if lAddr != nil {
-		sockHostAddr, sockHostPort = splitHostPort(lAddr.String())
-	}
-
-	if rAddr != nil {
-		sockPeerAddr, sockPeerPort = splitHostPort(rAddr.String())
-	}
-
-	switch {
-	case sockHostAddr != "":
-		sockFamily = family(network, sockHostAddr)
-	case sockPeerAddr != "":
-		sockFamily = family(network, sockPeerAddr)
-	}
-
-	n := nonZeroStr(peerName, network, sockPeerAddr, sockHostAddr, sockFamily)
-	n += positiveInt(peerPort, sockPeerPort, sockHostPort)
-	attr := make([]attribute.KeyValue, 0, n)
-	if peerName != "" {
-		attr = append(attr, c.PeerName(peerName))
-		if peerPort > 0 {
-			// Only if net.peer.name is set should net.peer.port be.
-			attr = append(attr, c.PeerPort(peerPort))
-		}
-	}
-	if network != "" {
-		attr = append(attr, c.Transport(network))
-	}
-	if sockFamily != "" {
-		attr = append(attr, c.NetSockFamilyKey.String(sockFamily))
-	}
-	if sockPeerAddr != "" {
-		attr = append(attr, c.NetSockPeerAddrKey.String(sockPeerAddr))
-		if sockPeerPort > 0 {
-			// Only if net.sock.peer.addr is set should net.sock.peer.port be.
-			attr = append(attr, c.NetSockPeerPortKey.Int(sockPeerPort))
-		}
-	}
-	if sockHostAddr != "" {
-		attr = append(attr, c.NetSockHostAddrKey.String(sockHostAddr))
-		if sockHostPort > 0 {
-			// Only if net.sock.host.addr is set should net.sock.host.port be.
-			attr = append(attr, c.NetSockHostPortKey.Int(sockHostPort))
-		}
-	}
-	return attr
 }
 
 func family(network, address string) string {
@@ -271,26 +128,6 @@ func family(network, address string) string {
 		}
 	}
 	return ""
-}
-
-func nonZeroStr(strs ...string) int {
-	var n int
-	for _, str := range strs {
-		if str != "" {
-			n++
-		}
-	}
-	return n
-}
-
-func positiveInt(ints ...int) int {
-	var n int
-	for _, i := range ints {
-		if i > 0 {
-			n++
-		}
-	}
-	return n
 }
 
 // Peer returns attributes for a network peer address.

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/internal/semconvutil/netconv_test.go
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/internal/semconvutil/netconv_test.go
@@ -17,12 +17,9 @@
 package semconvutil
 
 import (
-	"net"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel/attribute"
 )
@@ -54,53 +51,6 @@ func TestNetTransport(t *testing.T) {
 	}
 }
 
-func TestNetServerNilListener(t *testing.T) {
-	const addr = "127.0.0.1:8080"
-	got := NetServer(addr, nil)
-	expected := nc.Host(addr)
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-type listener struct{ net.Listener }
-
-func (listener) Addr() net.Addr { return nil }
-
-func TestNetServerNilAddr(t *testing.T) {
-	const addr = "127.0.0.1:8080"
-	got := NetServer(addr, listener{})
-	expected := nc.Host(addr)
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-func newTCPListener() (net.Listener, error) {
-	return net.Listen("tcp4", "127.0.0.1:0")
-}
-
-func TestNetServerTCP(t *testing.T) {
-	ln, err := newTCPListener()
-	require.NoError(t, err)
-	defer func() { require.NoError(t, ln.Close()) }()
-
-	host, pStr, err := net.SplitHostPort(ln.Addr().String())
-	require.NoError(t, err)
-	port, err := strconv.Atoi(pStr)
-	require.NoError(t, err)
-
-	got := NetServer("example.com:8080", ln)
-	expected := []attribute.KeyValue{
-		nc.HostName("example.com"),
-		nc.HostPort(8080),
-		nc.NetTransportTCP,
-		nc.NetSockFamilyKey.String("inet"),
-		nc.NetSockHostAddrKey.String(host),
-		nc.NetSockHostPortKey.Int(port),
-	}
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
 func TestNetHost(t *testing.T) {
 	testAddrs(t, []addrTest{
 		{address: "", expected: nil},
@@ -122,103 +72,6 @@ func TestNetHostName(t *testing.T) {
 func TestNetHostPort(t *testing.T) {
 	expected := attribute.Key("net.host.port").Int(port)
 	assert.Equal(t, expected, nc.HostPort(port))
-}
-
-func TestNetClientNilConn(t *testing.T) {
-	const addr = "127.0.0.1:8080"
-	got := NetClient(addr, nil)
-	expected := nc.Peer(addr)
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-type conn struct{ net.Conn }
-
-func (conn) LocalAddr() net.Addr  { return nil }
-func (conn) RemoteAddr() net.Addr { return nil }
-
-func TestNetClientNilAddr(t *testing.T) {
-	const addr = "127.0.0.1:8080"
-	got := NetClient(addr, conn{})
-	expected := nc.Peer(addr)
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-func newTCPConn() (net.Conn, net.Listener, error) {
-	ln, err := newTCPListener()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	conn, err := net.Dial("tcp4", ln.Addr().String())
-	if err != nil {
-		_ = ln.Close()
-		return nil, nil, err
-	}
-
-	return conn, ln, nil
-}
-
-func TestNetClientTCP(t *testing.T) {
-	conn, ln, err := newTCPConn()
-	require.NoError(t, err)
-	defer func() { require.NoError(t, ln.Close()) }()
-	defer func() { require.NoError(t, conn.Close()) }()
-
-	lHost, pStr, err := net.SplitHostPort(conn.LocalAddr().String())
-	require.NoError(t, err)
-	lPort, err := strconv.Atoi(pStr)
-	require.NoError(t, err)
-
-	rHost, pStr, err := net.SplitHostPort(conn.RemoteAddr().String())
-	require.NoError(t, err)
-	rPort, err := strconv.Atoi(pStr)
-	require.NoError(t, err)
-
-	got := NetClient("example.com:8080", conn)
-	expected := []attribute.KeyValue{
-		nc.PeerName("example.com"),
-		nc.PeerPort(8080),
-		nc.NetTransportTCP,
-		nc.NetSockFamilyKey.String("inet"),
-		nc.NetSockPeerAddrKey.String(rHost),
-		nc.NetSockPeerPortKey.Int(rPort),
-		nc.NetSockHostAddrKey.String(lHost),
-		nc.NetSockHostPortKey.Int(lPort),
-	}
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-type remoteOnlyConn struct{ net.Conn }
-
-func (remoteOnlyConn) LocalAddr() net.Addr { return nil }
-
-func TestNetClientTCPNilLocal(t *testing.T) {
-	conn, ln, err := newTCPConn()
-	require.NoError(t, err)
-	defer func() { require.NoError(t, ln.Close()) }()
-	defer func() { require.NoError(t, conn.Close()) }()
-
-	conn = remoteOnlyConn{conn}
-
-	rHost, pStr, err := net.SplitHostPort(conn.RemoteAddr().String())
-	require.NoError(t, err)
-	rPort, err := strconv.Atoi(pStr)
-	require.NoError(t, err)
-
-	got := NetClient("example.com:8080", conn)
-	expected := []attribute.KeyValue{
-		nc.PeerName("example.com"),
-		nc.PeerPort(8080),
-		nc.NetTransportTCP,
-		nc.NetSockFamilyKey.String("inet"),
-		nc.NetSockPeerAddrKey.String(rHost),
-		nc.NetSockPeerPortKey.Int(rPort),
-	}
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
 }
 
 func TestNetPeer(t *testing.T) {

--- a/instrumentation/github.com/gorilla/mux/otelmux/internal/semconvutil/httpconv.go
+++ b/instrumentation/github.com/gorilla/mux/otelmux/internal/semconvutil/httpconv.go
@@ -114,36 +114,6 @@ func HTTPServerStatus(code int) (codes.Code, string) {
 	return hc.ServerStatus(code)
 }
 
-// HTTPRequestHeader returns the contents of h as attributes.
-//
-// Instrumentation should require an explicit configuration of which headers to
-// captured and then prune what they pass here. Including all headers can be a
-// security risk - explicit configuration helps avoid leaking sensitive
-// information.
-//
-// The User-Agent header is already captured in the http.user_agent attribute
-// from ClientRequest and ServerRequest. Instrumentation may provide an option
-// to capture that header here even though it is not recommended. Otherwise,
-// instrumentation should filter that out of what is passed.
-func HTTPRequestHeader(h http.Header) []attribute.KeyValue {
-	return hc.RequestHeader(h)
-}
-
-// HTTPResponseHeader returns the contents of h as attributes.
-//
-// Instrumentation should require an explicit configuration of which headers to
-// captured and then prune what they pass here. Including all headers can be a
-// security risk - explicit configuration helps avoid leaking sensitive
-// information.
-//
-// The User-Agent header is already captured in the http.user_agent attribute
-// from ClientRequest and ServerRequest. Instrumentation may provide an option
-// to capture that header here even though it is not recommended. Otherwise,
-// instrumentation should filter that out of what is passed.
-func HTTPResponseHeader(h http.Header) []attribute.KeyValue {
-	return hc.ResponseHeader(h)
-}
-
 // httpConv are the HTTP semantic convention attributes defined for a version
 // of the OpenTelemetry specification.
 type httpConv struct {
@@ -549,31 +519,6 @@ func firstHostPort(source ...string) (host string, port int) {
 		}
 	}
 	return
-}
-
-// RequestHeader returns the contents of h as OpenTelemetry attributes.
-func (c *httpConv) RequestHeader(h http.Header) []attribute.KeyValue {
-	return c.header("http.request.header", h)
-}
-
-// ResponseHeader returns the contents of h as OpenTelemetry attributes.
-func (c *httpConv) ResponseHeader(h http.Header) []attribute.KeyValue {
-	return c.header("http.response.header", h)
-}
-
-func (c *httpConv) header(prefix string, h http.Header) []attribute.KeyValue {
-	key := func(k string) attribute.Key {
-		k = strings.ToLower(k)
-		k = strings.ReplaceAll(k, "-", "_")
-		k = fmt.Sprintf("%s.%s", prefix, k)
-		return attribute.Key(k)
-	}
-
-	attrs := make([]attribute.KeyValue, 0, len(h))
-	for k, v := range h {
-		attrs = append(attrs, key(k).StringSlice(v))
-	}
-	return attrs
 }
 
 // ClientStatus returns a span status code and message for an HTTP status code

--- a/instrumentation/github.com/gorilla/mux/otelmux/internal/semconvutil/httpconv_test.go
+++ b/instrumentation/github.com/gorilla/mux/otelmux/internal/semconvutil/httpconv_test.go
@@ -290,32 +290,6 @@ func TestFirstHostPort(t *testing.T) {
 	}
 }
 
-func TestHTTPRequestHeader(t *testing.T) {
-	ips := []string{"127.0.0.5", "127.0.0.9"}
-	user := []string{"alice"}
-	h := http.Header{"ips": ips, "user": user}
-
-	got := HTTPRequestHeader(h)
-	assert.Equal(t, 2, cap(got), "slice capacity")
-	assert.ElementsMatch(t, []attribute.KeyValue{
-		attribute.StringSlice("http.request.header.ips", ips),
-		attribute.StringSlice("http.request.header.user", user),
-	}, got)
-}
-
-func TestHTTPReponseHeader(t *testing.T) {
-	ips := []string{"127.0.0.5", "127.0.0.9"}
-	user := []string{"alice"}
-	h := http.Header{"ips": ips, "user": user}
-
-	got := HTTPResponseHeader(h)
-	assert.Equal(t, 2, cap(got), "slice capacity")
-	assert.ElementsMatch(t, []attribute.KeyValue{
-		attribute.StringSlice("http.response.header.ips", ips),
-		attribute.StringSlice("http.response.header.user", user),
-	}, got)
-}
-
 func TestHTTPClientStatus(t *testing.T) {
 	tests := []struct {
 		code int

--- a/instrumentation/github.com/gorilla/mux/otelmux/internal/semconvutil/netconv.go
+++ b/instrumentation/github.com/gorilla/mux/otelmux/internal/semconvutil/netconv.go
@@ -32,24 +32,6 @@ func NetTransport(network string) attribute.KeyValue {
 	return nc.Transport(network)
 }
 
-// NetClient returns trace attributes for a client network connection to address.
-// See net.Dial for information about acceptable address values, address should
-// be the same as the one used to create conn. If conn is nil, only network
-// peer attributes will be returned that describe address. Otherwise, the
-// socket level information about conn will also be included.
-func NetClient(address string, conn net.Conn) []attribute.KeyValue {
-	return nc.Client(address, conn)
-}
-
-// NetServer returns trace attributes for a network listener listening at address.
-// See net.Listen for information about acceptable address values, address
-// should be the same as the one used to create ln. If ln is nil, only network
-// host attributes will be returned that describe address. Otherwise, the
-// socket level information about ln will also be included.
-func NetServer(address string, ln net.Listener) []attribute.KeyValue {
-	return nc.Server(address, ln)
-}
-
 // netConv are the network semantic convention attributes defined for a version
 // of the OpenTelemetry specification.
 type netConv struct {
@@ -125,137 +107,12 @@ func (c *netConv) Host(address string) []attribute.KeyValue {
 	return attrs
 }
 
-// Server returns attributes for a network listener listening at address. See
-// net.Listen for information about acceptable address values, address should
-// be the same as the one used to create ln. If ln is nil, only network host
-// attributes will be returned that describe address. Otherwise, the socket
-// level information about ln will also be included.
-func (c *netConv) Server(address string, ln net.Listener) []attribute.KeyValue {
-	if ln == nil {
-		return c.Host(address)
-	}
-
-	lAddr := ln.Addr()
-	if lAddr == nil {
-		return c.Host(address)
-	}
-
-	hostName, hostPort := splitHostPort(address)
-	sockHostAddr, sockHostPort := splitHostPort(lAddr.String())
-	network := lAddr.Network()
-	sockFamily := family(network, sockHostAddr)
-
-	n := nonZeroStr(hostName, network, sockHostAddr, sockFamily)
-	n += positiveInt(hostPort, sockHostPort)
-	attr := make([]attribute.KeyValue, 0, n)
-	if hostName != "" {
-		attr = append(attr, c.HostName(hostName))
-		if hostPort > 0 {
-			// Only if net.host.name is set should net.host.port be.
-			attr = append(attr, c.HostPort(hostPort))
-		}
-	}
-	if network != "" {
-		attr = append(attr, c.Transport(network))
-	}
-	if sockFamily != "" {
-		attr = append(attr, c.NetSockFamilyKey.String(sockFamily))
-	}
-	if sockHostAddr != "" {
-		attr = append(attr, c.NetSockHostAddrKey.String(sockHostAddr))
-		if sockHostPort > 0 {
-			// Only if net.sock.host.addr is set should net.sock.host.port be.
-			attr = append(attr, c.NetSockHostPortKey.Int(sockHostPort))
-		}
-	}
-	return attr
-}
-
 func (c *netConv) HostName(name string) attribute.KeyValue {
 	return c.NetHostNameKey.String(name)
 }
 
 func (c *netConv) HostPort(port int) attribute.KeyValue {
 	return c.NetHostPortKey.Int(port)
-}
-
-// Client returns attributes for a client network connection to address. See
-// net.Dial for information about acceptable address values, address should be
-// the same as the one used to create conn. If conn is nil, only network peer
-// attributes will be returned that describe address. Otherwise, the socket
-// level information about conn will also be included.
-func (c *netConv) Client(address string, conn net.Conn) []attribute.KeyValue {
-	if conn == nil {
-		return c.Peer(address)
-	}
-
-	lAddr, rAddr := conn.LocalAddr(), conn.RemoteAddr()
-
-	var network string
-	switch {
-	case lAddr != nil:
-		network = lAddr.Network()
-	case rAddr != nil:
-		network = rAddr.Network()
-	default:
-		return c.Peer(address)
-	}
-
-	peerName, peerPort := splitHostPort(address)
-	var (
-		sockFamily   string
-		sockPeerAddr string
-		sockPeerPort int
-		sockHostAddr string
-		sockHostPort int
-	)
-
-	if lAddr != nil {
-		sockHostAddr, sockHostPort = splitHostPort(lAddr.String())
-	}
-
-	if rAddr != nil {
-		sockPeerAddr, sockPeerPort = splitHostPort(rAddr.String())
-	}
-
-	switch {
-	case sockHostAddr != "":
-		sockFamily = family(network, sockHostAddr)
-	case sockPeerAddr != "":
-		sockFamily = family(network, sockPeerAddr)
-	}
-
-	n := nonZeroStr(peerName, network, sockPeerAddr, sockHostAddr, sockFamily)
-	n += positiveInt(peerPort, sockPeerPort, sockHostPort)
-	attr := make([]attribute.KeyValue, 0, n)
-	if peerName != "" {
-		attr = append(attr, c.PeerName(peerName))
-		if peerPort > 0 {
-			// Only if net.peer.name is set should net.peer.port be.
-			attr = append(attr, c.PeerPort(peerPort))
-		}
-	}
-	if network != "" {
-		attr = append(attr, c.Transport(network))
-	}
-	if sockFamily != "" {
-		attr = append(attr, c.NetSockFamilyKey.String(sockFamily))
-	}
-	if sockPeerAddr != "" {
-		attr = append(attr, c.NetSockPeerAddrKey.String(sockPeerAddr))
-		if sockPeerPort > 0 {
-			// Only if net.sock.peer.addr is set should net.sock.peer.port be.
-			attr = append(attr, c.NetSockPeerPortKey.Int(sockPeerPort))
-		}
-	}
-	if sockHostAddr != "" {
-		attr = append(attr, c.NetSockHostAddrKey.String(sockHostAddr))
-		if sockHostPort > 0 {
-			// Only if net.sock.host.addr is set should net.sock.host.port be.
-			attr = append(attr, c.NetSockHostPortKey.Int(sockHostPort))
-		}
-	}
-	return attr
 }
 
 func family(network, address string) string {
@@ -271,26 +128,6 @@ func family(network, address string) string {
 		}
 	}
 	return ""
-}
-
-func nonZeroStr(strs ...string) int {
-	var n int
-	for _, str := range strs {
-		if str != "" {
-			n++
-		}
-	}
-	return n
-}
-
-func positiveInt(ints ...int) int {
-	var n int
-	for _, i := range ints {
-		if i > 0 {
-			n++
-		}
-	}
-	return n
 }
 
 // Peer returns attributes for a network peer address.

--- a/instrumentation/github.com/gorilla/mux/otelmux/internal/semconvutil/netconv_test.go
+++ b/instrumentation/github.com/gorilla/mux/otelmux/internal/semconvutil/netconv_test.go
@@ -17,12 +17,9 @@
 package semconvutil
 
 import (
-	"net"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel/attribute"
 )
@@ -54,53 +51,6 @@ func TestNetTransport(t *testing.T) {
 	}
 }
 
-func TestNetServerNilListener(t *testing.T) {
-	const addr = "127.0.0.1:8080"
-	got := NetServer(addr, nil)
-	expected := nc.Host(addr)
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-type listener struct{ net.Listener }
-
-func (listener) Addr() net.Addr { return nil }
-
-func TestNetServerNilAddr(t *testing.T) {
-	const addr = "127.0.0.1:8080"
-	got := NetServer(addr, listener{})
-	expected := nc.Host(addr)
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-func newTCPListener() (net.Listener, error) {
-	return net.Listen("tcp4", "127.0.0.1:0")
-}
-
-func TestNetServerTCP(t *testing.T) {
-	ln, err := newTCPListener()
-	require.NoError(t, err)
-	defer func() { require.NoError(t, ln.Close()) }()
-
-	host, pStr, err := net.SplitHostPort(ln.Addr().String())
-	require.NoError(t, err)
-	port, err := strconv.Atoi(pStr)
-	require.NoError(t, err)
-
-	got := NetServer("example.com:8080", ln)
-	expected := []attribute.KeyValue{
-		nc.HostName("example.com"),
-		nc.HostPort(8080),
-		nc.NetTransportTCP,
-		nc.NetSockFamilyKey.String("inet"),
-		nc.NetSockHostAddrKey.String(host),
-		nc.NetSockHostPortKey.Int(port),
-	}
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
 func TestNetHost(t *testing.T) {
 	testAddrs(t, []addrTest{
 		{address: "", expected: nil},
@@ -122,103 +72,6 @@ func TestNetHostName(t *testing.T) {
 func TestNetHostPort(t *testing.T) {
 	expected := attribute.Key("net.host.port").Int(port)
 	assert.Equal(t, expected, nc.HostPort(port))
-}
-
-func TestNetClientNilConn(t *testing.T) {
-	const addr = "127.0.0.1:8080"
-	got := NetClient(addr, nil)
-	expected := nc.Peer(addr)
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-type conn struct{ net.Conn }
-
-func (conn) LocalAddr() net.Addr  { return nil }
-func (conn) RemoteAddr() net.Addr { return nil }
-
-func TestNetClientNilAddr(t *testing.T) {
-	const addr = "127.0.0.1:8080"
-	got := NetClient(addr, conn{})
-	expected := nc.Peer(addr)
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-func newTCPConn() (net.Conn, net.Listener, error) {
-	ln, err := newTCPListener()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	conn, err := net.Dial("tcp4", ln.Addr().String())
-	if err != nil {
-		_ = ln.Close()
-		return nil, nil, err
-	}
-
-	return conn, ln, nil
-}
-
-func TestNetClientTCP(t *testing.T) {
-	conn, ln, err := newTCPConn()
-	require.NoError(t, err)
-	defer func() { require.NoError(t, ln.Close()) }()
-	defer func() { require.NoError(t, conn.Close()) }()
-
-	lHost, pStr, err := net.SplitHostPort(conn.LocalAddr().String())
-	require.NoError(t, err)
-	lPort, err := strconv.Atoi(pStr)
-	require.NoError(t, err)
-
-	rHost, pStr, err := net.SplitHostPort(conn.RemoteAddr().String())
-	require.NoError(t, err)
-	rPort, err := strconv.Atoi(pStr)
-	require.NoError(t, err)
-
-	got := NetClient("example.com:8080", conn)
-	expected := []attribute.KeyValue{
-		nc.PeerName("example.com"),
-		nc.PeerPort(8080),
-		nc.NetTransportTCP,
-		nc.NetSockFamilyKey.String("inet"),
-		nc.NetSockPeerAddrKey.String(rHost),
-		nc.NetSockPeerPortKey.Int(rPort),
-		nc.NetSockHostAddrKey.String(lHost),
-		nc.NetSockHostPortKey.Int(lPort),
-	}
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-type remoteOnlyConn struct{ net.Conn }
-
-func (remoteOnlyConn) LocalAddr() net.Addr { return nil }
-
-func TestNetClientTCPNilLocal(t *testing.T) {
-	conn, ln, err := newTCPConn()
-	require.NoError(t, err)
-	defer func() { require.NoError(t, ln.Close()) }()
-	defer func() { require.NoError(t, conn.Close()) }()
-
-	conn = remoteOnlyConn{conn}
-
-	rHost, pStr, err := net.SplitHostPort(conn.RemoteAddr().String())
-	require.NoError(t, err)
-	rPort, err := strconv.Atoi(pStr)
-	require.NoError(t, err)
-
-	got := NetClient("example.com:8080", conn)
-	expected := []attribute.KeyValue{
-		nc.PeerName("example.com"),
-		nc.PeerPort(8080),
-		nc.NetTransportTCP,
-		nc.NetSockFamilyKey.String("inet"),
-		nc.NetSockPeerAddrKey.String(rHost),
-		nc.NetSockPeerPortKey.Int(rPort),
-	}
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
 }
 
 func TestNetPeer(t *testing.T) {

--- a/instrumentation/github.com/labstack/echo/otelecho/internal/semconvutil/httpconv.go
+++ b/instrumentation/github.com/labstack/echo/otelecho/internal/semconvutil/httpconv.go
@@ -114,36 +114,6 @@ func HTTPServerStatus(code int) (codes.Code, string) {
 	return hc.ServerStatus(code)
 }
 
-// HTTPRequestHeader returns the contents of h as attributes.
-//
-// Instrumentation should require an explicit configuration of which headers to
-// captured and then prune what they pass here. Including all headers can be a
-// security risk - explicit configuration helps avoid leaking sensitive
-// information.
-//
-// The User-Agent header is already captured in the http.user_agent attribute
-// from ClientRequest and ServerRequest. Instrumentation may provide an option
-// to capture that header here even though it is not recommended. Otherwise,
-// instrumentation should filter that out of what is passed.
-func HTTPRequestHeader(h http.Header) []attribute.KeyValue {
-	return hc.RequestHeader(h)
-}
-
-// HTTPResponseHeader returns the contents of h as attributes.
-//
-// Instrumentation should require an explicit configuration of which headers to
-// captured and then prune what they pass here. Including all headers can be a
-// security risk - explicit configuration helps avoid leaking sensitive
-// information.
-//
-// The User-Agent header is already captured in the http.user_agent attribute
-// from ClientRequest and ServerRequest. Instrumentation may provide an option
-// to capture that header here even though it is not recommended. Otherwise,
-// instrumentation should filter that out of what is passed.
-func HTTPResponseHeader(h http.Header) []attribute.KeyValue {
-	return hc.ResponseHeader(h)
-}
-
 // httpConv are the HTTP semantic convention attributes defined for a version
 // of the OpenTelemetry specification.
 type httpConv struct {
@@ -549,31 +519,6 @@ func firstHostPort(source ...string) (host string, port int) {
 		}
 	}
 	return
-}
-
-// RequestHeader returns the contents of h as OpenTelemetry attributes.
-func (c *httpConv) RequestHeader(h http.Header) []attribute.KeyValue {
-	return c.header("http.request.header", h)
-}
-
-// ResponseHeader returns the contents of h as OpenTelemetry attributes.
-func (c *httpConv) ResponseHeader(h http.Header) []attribute.KeyValue {
-	return c.header("http.response.header", h)
-}
-
-func (c *httpConv) header(prefix string, h http.Header) []attribute.KeyValue {
-	key := func(k string) attribute.Key {
-		k = strings.ToLower(k)
-		k = strings.ReplaceAll(k, "-", "_")
-		k = fmt.Sprintf("%s.%s", prefix, k)
-		return attribute.Key(k)
-	}
-
-	attrs := make([]attribute.KeyValue, 0, len(h))
-	for k, v := range h {
-		attrs = append(attrs, key(k).StringSlice(v))
-	}
-	return attrs
 }
 
 // ClientStatus returns a span status code and message for an HTTP status code

--- a/instrumentation/github.com/labstack/echo/otelecho/internal/semconvutil/httpconv_test.go
+++ b/instrumentation/github.com/labstack/echo/otelecho/internal/semconvutil/httpconv_test.go
@@ -290,32 +290,6 @@ func TestFirstHostPort(t *testing.T) {
 	}
 }
 
-func TestHTTPRequestHeader(t *testing.T) {
-	ips := []string{"127.0.0.5", "127.0.0.9"}
-	user := []string{"alice"}
-	h := http.Header{"ips": ips, "user": user}
-
-	got := HTTPRequestHeader(h)
-	assert.Equal(t, 2, cap(got), "slice capacity")
-	assert.ElementsMatch(t, []attribute.KeyValue{
-		attribute.StringSlice("http.request.header.ips", ips),
-		attribute.StringSlice("http.request.header.user", user),
-	}, got)
-}
-
-func TestHTTPReponseHeader(t *testing.T) {
-	ips := []string{"127.0.0.5", "127.0.0.9"}
-	user := []string{"alice"}
-	h := http.Header{"ips": ips, "user": user}
-
-	got := HTTPResponseHeader(h)
-	assert.Equal(t, 2, cap(got), "slice capacity")
-	assert.ElementsMatch(t, []attribute.KeyValue{
-		attribute.StringSlice("http.response.header.ips", ips),
-		attribute.StringSlice("http.response.header.user", user),
-	}, got)
-}
-
 func TestHTTPClientStatus(t *testing.T) {
 	tests := []struct {
 		code int

--- a/instrumentation/github.com/labstack/echo/otelecho/internal/semconvutil/netconv.go
+++ b/instrumentation/github.com/labstack/echo/otelecho/internal/semconvutil/netconv.go
@@ -32,24 +32,6 @@ func NetTransport(network string) attribute.KeyValue {
 	return nc.Transport(network)
 }
 
-// NetClient returns trace attributes for a client network connection to address.
-// See net.Dial for information about acceptable address values, address should
-// be the same as the one used to create conn. If conn is nil, only network
-// peer attributes will be returned that describe address. Otherwise, the
-// socket level information about conn will also be included.
-func NetClient(address string, conn net.Conn) []attribute.KeyValue {
-	return nc.Client(address, conn)
-}
-
-// NetServer returns trace attributes for a network listener listening at address.
-// See net.Listen for information about acceptable address values, address
-// should be the same as the one used to create ln. If ln is nil, only network
-// host attributes will be returned that describe address. Otherwise, the
-// socket level information about ln will also be included.
-func NetServer(address string, ln net.Listener) []attribute.KeyValue {
-	return nc.Server(address, ln)
-}
-
 // netConv are the network semantic convention attributes defined for a version
 // of the OpenTelemetry specification.
 type netConv struct {
@@ -125,137 +107,12 @@ func (c *netConv) Host(address string) []attribute.KeyValue {
 	return attrs
 }
 
-// Server returns attributes for a network listener listening at address. See
-// net.Listen for information about acceptable address values, address should
-// be the same as the one used to create ln. If ln is nil, only network host
-// attributes will be returned that describe address. Otherwise, the socket
-// level information about ln will also be included.
-func (c *netConv) Server(address string, ln net.Listener) []attribute.KeyValue {
-	if ln == nil {
-		return c.Host(address)
-	}
-
-	lAddr := ln.Addr()
-	if lAddr == nil {
-		return c.Host(address)
-	}
-
-	hostName, hostPort := splitHostPort(address)
-	sockHostAddr, sockHostPort := splitHostPort(lAddr.String())
-	network := lAddr.Network()
-	sockFamily := family(network, sockHostAddr)
-
-	n := nonZeroStr(hostName, network, sockHostAddr, sockFamily)
-	n += positiveInt(hostPort, sockHostPort)
-	attr := make([]attribute.KeyValue, 0, n)
-	if hostName != "" {
-		attr = append(attr, c.HostName(hostName))
-		if hostPort > 0 {
-			// Only if net.host.name is set should net.host.port be.
-			attr = append(attr, c.HostPort(hostPort))
-		}
-	}
-	if network != "" {
-		attr = append(attr, c.Transport(network))
-	}
-	if sockFamily != "" {
-		attr = append(attr, c.NetSockFamilyKey.String(sockFamily))
-	}
-	if sockHostAddr != "" {
-		attr = append(attr, c.NetSockHostAddrKey.String(sockHostAddr))
-		if sockHostPort > 0 {
-			// Only if net.sock.host.addr is set should net.sock.host.port be.
-			attr = append(attr, c.NetSockHostPortKey.Int(sockHostPort))
-		}
-	}
-	return attr
-}
-
 func (c *netConv) HostName(name string) attribute.KeyValue {
 	return c.NetHostNameKey.String(name)
 }
 
 func (c *netConv) HostPort(port int) attribute.KeyValue {
 	return c.NetHostPortKey.Int(port)
-}
-
-// Client returns attributes for a client network connection to address. See
-// net.Dial for information about acceptable address values, address should be
-// the same as the one used to create conn. If conn is nil, only network peer
-// attributes will be returned that describe address. Otherwise, the socket
-// level information about conn will also be included.
-func (c *netConv) Client(address string, conn net.Conn) []attribute.KeyValue {
-	if conn == nil {
-		return c.Peer(address)
-	}
-
-	lAddr, rAddr := conn.LocalAddr(), conn.RemoteAddr()
-
-	var network string
-	switch {
-	case lAddr != nil:
-		network = lAddr.Network()
-	case rAddr != nil:
-		network = rAddr.Network()
-	default:
-		return c.Peer(address)
-	}
-
-	peerName, peerPort := splitHostPort(address)
-	var (
-		sockFamily   string
-		sockPeerAddr string
-		sockPeerPort int
-		sockHostAddr string
-		sockHostPort int
-	)
-
-	if lAddr != nil {
-		sockHostAddr, sockHostPort = splitHostPort(lAddr.String())
-	}
-
-	if rAddr != nil {
-		sockPeerAddr, sockPeerPort = splitHostPort(rAddr.String())
-	}
-
-	switch {
-	case sockHostAddr != "":
-		sockFamily = family(network, sockHostAddr)
-	case sockPeerAddr != "":
-		sockFamily = family(network, sockPeerAddr)
-	}
-
-	n := nonZeroStr(peerName, network, sockPeerAddr, sockHostAddr, sockFamily)
-	n += positiveInt(peerPort, sockPeerPort, sockHostPort)
-	attr := make([]attribute.KeyValue, 0, n)
-	if peerName != "" {
-		attr = append(attr, c.PeerName(peerName))
-		if peerPort > 0 {
-			// Only if net.peer.name is set should net.peer.port be.
-			attr = append(attr, c.PeerPort(peerPort))
-		}
-	}
-	if network != "" {
-		attr = append(attr, c.Transport(network))
-	}
-	if sockFamily != "" {
-		attr = append(attr, c.NetSockFamilyKey.String(sockFamily))
-	}
-	if sockPeerAddr != "" {
-		attr = append(attr, c.NetSockPeerAddrKey.String(sockPeerAddr))
-		if sockPeerPort > 0 {
-			// Only if net.sock.peer.addr is set should net.sock.peer.port be.
-			attr = append(attr, c.NetSockPeerPortKey.Int(sockPeerPort))
-		}
-	}
-	if sockHostAddr != "" {
-		attr = append(attr, c.NetSockHostAddrKey.String(sockHostAddr))
-		if sockHostPort > 0 {
-			// Only if net.sock.host.addr is set should net.sock.host.port be.
-			attr = append(attr, c.NetSockHostPortKey.Int(sockHostPort))
-		}
-	}
-	return attr
 }
 
 func family(network, address string) string {
@@ -271,26 +128,6 @@ func family(network, address string) string {
 		}
 	}
 	return ""
-}
-
-func nonZeroStr(strs ...string) int {
-	var n int
-	for _, str := range strs {
-		if str != "" {
-			n++
-		}
-	}
-	return n
-}
-
-func positiveInt(ints ...int) int {
-	var n int
-	for _, i := range ints {
-		if i > 0 {
-			n++
-		}
-	}
-	return n
 }
 
 // Peer returns attributes for a network peer address.

--- a/instrumentation/github.com/labstack/echo/otelecho/internal/semconvutil/netconv_test.go
+++ b/instrumentation/github.com/labstack/echo/otelecho/internal/semconvutil/netconv_test.go
@@ -17,12 +17,9 @@
 package semconvutil
 
 import (
-	"net"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel/attribute"
 )
@@ -54,53 +51,6 @@ func TestNetTransport(t *testing.T) {
 	}
 }
 
-func TestNetServerNilListener(t *testing.T) {
-	const addr = "127.0.0.1:8080"
-	got := NetServer(addr, nil)
-	expected := nc.Host(addr)
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-type listener struct{ net.Listener }
-
-func (listener) Addr() net.Addr { return nil }
-
-func TestNetServerNilAddr(t *testing.T) {
-	const addr = "127.0.0.1:8080"
-	got := NetServer(addr, listener{})
-	expected := nc.Host(addr)
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-func newTCPListener() (net.Listener, error) {
-	return net.Listen("tcp4", "127.0.0.1:0")
-}
-
-func TestNetServerTCP(t *testing.T) {
-	ln, err := newTCPListener()
-	require.NoError(t, err)
-	defer func() { require.NoError(t, ln.Close()) }()
-
-	host, pStr, err := net.SplitHostPort(ln.Addr().String())
-	require.NoError(t, err)
-	port, err := strconv.Atoi(pStr)
-	require.NoError(t, err)
-
-	got := NetServer("example.com:8080", ln)
-	expected := []attribute.KeyValue{
-		nc.HostName("example.com"),
-		nc.HostPort(8080),
-		nc.NetTransportTCP,
-		nc.NetSockFamilyKey.String("inet"),
-		nc.NetSockHostAddrKey.String(host),
-		nc.NetSockHostPortKey.Int(port),
-	}
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
 func TestNetHost(t *testing.T) {
 	testAddrs(t, []addrTest{
 		{address: "", expected: nil},
@@ -122,103 +72,6 @@ func TestNetHostName(t *testing.T) {
 func TestNetHostPort(t *testing.T) {
 	expected := attribute.Key("net.host.port").Int(port)
 	assert.Equal(t, expected, nc.HostPort(port))
-}
-
-func TestNetClientNilConn(t *testing.T) {
-	const addr = "127.0.0.1:8080"
-	got := NetClient(addr, nil)
-	expected := nc.Peer(addr)
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-type conn struct{ net.Conn }
-
-func (conn) LocalAddr() net.Addr  { return nil }
-func (conn) RemoteAddr() net.Addr { return nil }
-
-func TestNetClientNilAddr(t *testing.T) {
-	const addr = "127.0.0.1:8080"
-	got := NetClient(addr, conn{})
-	expected := nc.Peer(addr)
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-func newTCPConn() (net.Conn, net.Listener, error) {
-	ln, err := newTCPListener()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	conn, err := net.Dial("tcp4", ln.Addr().String())
-	if err != nil {
-		_ = ln.Close()
-		return nil, nil, err
-	}
-
-	return conn, ln, nil
-}
-
-func TestNetClientTCP(t *testing.T) {
-	conn, ln, err := newTCPConn()
-	require.NoError(t, err)
-	defer func() { require.NoError(t, ln.Close()) }()
-	defer func() { require.NoError(t, conn.Close()) }()
-
-	lHost, pStr, err := net.SplitHostPort(conn.LocalAddr().String())
-	require.NoError(t, err)
-	lPort, err := strconv.Atoi(pStr)
-	require.NoError(t, err)
-
-	rHost, pStr, err := net.SplitHostPort(conn.RemoteAddr().String())
-	require.NoError(t, err)
-	rPort, err := strconv.Atoi(pStr)
-	require.NoError(t, err)
-
-	got := NetClient("example.com:8080", conn)
-	expected := []attribute.KeyValue{
-		nc.PeerName("example.com"),
-		nc.PeerPort(8080),
-		nc.NetTransportTCP,
-		nc.NetSockFamilyKey.String("inet"),
-		nc.NetSockPeerAddrKey.String(rHost),
-		nc.NetSockPeerPortKey.Int(rPort),
-		nc.NetSockHostAddrKey.String(lHost),
-		nc.NetSockHostPortKey.Int(lPort),
-	}
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-type remoteOnlyConn struct{ net.Conn }
-
-func (remoteOnlyConn) LocalAddr() net.Addr { return nil }
-
-func TestNetClientTCPNilLocal(t *testing.T) {
-	conn, ln, err := newTCPConn()
-	require.NoError(t, err)
-	defer func() { require.NoError(t, ln.Close()) }()
-	defer func() { require.NoError(t, conn.Close()) }()
-
-	conn = remoteOnlyConn{conn}
-
-	rHost, pStr, err := net.SplitHostPort(conn.RemoteAddr().String())
-	require.NoError(t, err)
-	rPort, err := strconv.Atoi(pStr)
-	require.NoError(t, err)
-
-	got := NetClient("example.com:8080", conn)
-	expected := []attribute.KeyValue{
-		nc.PeerName("example.com"),
-		nc.PeerPort(8080),
-		nc.NetTransportTCP,
-		nc.NetSockFamilyKey.String("inet"),
-		nc.NetSockPeerAddrKey.String(rHost),
-		nc.NetSockPeerPortKey.Int(rPort),
-	}
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
 }
 
 func TestNetPeer(t *testing.T) {

--- a/instrumentation/gopkg.in/macaron.v1/otelmacaron/internal/semconvutil/httpconv.go
+++ b/instrumentation/gopkg.in/macaron.v1/otelmacaron/internal/semconvutil/httpconv.go
@@ -114,36 +114,6 @@ func HTTPServerStatus(code int) (codes.Code, string) {
 	return hc.ServerStatus(code)
 }
 
-// HTTPRequestHeader returns the contents of h as attributes.
-//
-// Instrumentation should require an explicit configuration of which headers to
-// captured and then prune what they pass here. Including all headers can be a
-// security risk - explicit configuration helps avoid leaking sensitive
-// information.
-//
-// The User-Agent header is already captured in the http.user_agent attribute
-// from ClientRequest and ServerRequest. Instrumentation may provide an option
-// to capture that header here even though it is not recommended. Otherwise,
-// instrumentation should filter that out of what is passed.
-func HTTPRequestHeader(h http.Header) []attribute.KeyValue {
-	return hc.RequestHeader(h)
-}
-
-// HTTPResponseHeader returns the contents of h as attributes.
-//
-// Instrumentation should require an explicit configuration of which headers to
-// captured and then prune what they pass here. Including all headers can be a
-// security risk - explicit configuration helps avoid leaking sensitive
-// information.
-//
-// The User-Agent header is already captured in the http.user_agent attribute
-// from ClientRequest and ServerRequest. Instrumentation may provide an option
-// to capture that header here even though it is not recommended. Otherwise,
-// instrumentation should filter that out of what is passed.
-func HTTPResponseHeader(h http.Header) []attribute.KeyValue {
-	return hc.ResponseHeader(h)
-}
-
 // httpConv are the HTTP semantic convention attributes defined for a version
 // of the OpenTelemetry specification.
 type httpConv struct {
@@ -549,31 +519,6 @@ func firstHostPort(source ...string) (host string, port int) {
 		}
 	}
 	return
-}
-
-// RequestHeader returns the contents of h as OpenTelemetry attributes.
-func (c *httpConv) RequestHeader(h http.Header) []attribute.KeyValue {
-	return c.header("http.request.header", h)
-}
-
-// ResponseHeader returns the contents of h as OpenTelemetry attributes.
-func (c *httpConv) ResponseHeader(h http.Header) []attribute.KeyValue {
-	return c.header("http.response.header", h)
-}
-
-func (c *httpConv) header(prefix string, h http.Header) []attribute.KeyValue {
-	key := func(k string) attribute.Key {
-		k = strings.ToLower(k)
-		k = strings.ReplaceAll(k, "-", "_")
-		k = fmt.Sprintf("%s.%s", prefix, k)
-		return attribute.Key(k)
-	}
-
-	attrs := make([]attribute.KeyValue, 0, len(h))
-	for k, v := range h {
-		attrs = append(attrs, key(k).StringSlice(v))
-	}
-	return attrs
 }
 
 // ClientStatus returns a span status code and message for an HTTP status code

--- a/instrumentation/gopkg.in/macaron.v1/otelmacaron/internal/semconvutil/httpconv_test.go
+++ b/instrumentation/gopkg.in/macaron.v1/otelmacaron/internal/semconvutil/httpconv_test.go
@@ -290,32 +290,6 @@ func TestFirstHostPort(t *testing.T) {
 	}
 }
 
-func TestHTTPRequestHeader(t *testing.T) {
-	ips := []string{"127.0.0.5", "127.0.0.9"}
-	user := []string{"alice"}
-	h := http.Header{"ips": ips, "user": user}
-
-	got := HTTPRequestHeader(h)
-	assert.Equal(t, 2, cap(got), "slice capacity")
-	assert.ElementsMatch(t, []attribute.KeyValue{
-		attribute.StringSlice("http.request.header.ips", ips),
-		attribute.StringSlice("http.request.header.user", user),
-	}, got)
-}
-
-func TestHTTPReponseHeader(t *testing.T) {
-	ips := []string{"127.0.0.5", "127.0.0.9"}
-	user := []string{"alice"}
-	h := http.Header{"ips": ips, "user": user}
-
-	got := HTTPResponseHeader(h)
-	assert.Equal(t, 2, cap(got), "slice capacity")
-	assert.ElementsMatch(t, []attribute.KeyValue{
-		attribute.StringSlice("http.response.header.ips", ips),
-		attribute.StringSlice("http.response.header.user", user),
-	}, got)
-}
-
 func TestHTTPClientStatus(t *testing.T) {
 	tests := []struct {
 		code int

--- a/instrumentation/gopkg.in/macaron.v1/otelmacaron/internal/semconvutil/netconv.go
+++ b/instrumentation/gopkg.in/macaron.v1/otelmacaron/internal/semconvutil/netconv.go
@@ -32,24 +32,6 @@ func NetTransport(network string) attribute.KeyValue {
 	return nc.Transport(network)
 }
 
-// NetClient returns trace attributes for a client network connection to address.
-// See net.Dial for information about acceptable address values, address should
-// be the same as the one used to create conn. If conn is nil, only network
-// peer attributes will be returned that describe address. Otherwise, the
-// socket level information about conn will also be included.
-func NetClient(address string, conn net.Conn) []attribute.KeyValue {
-	return nc.Client(address, conn)
-}
-
-// NetServer returns trace attributes for a network listener listening at address.
-// See net.Listen for information about acceptable address values, address
-// should be the same as the one used to create ln. If ln is nil, only network
-// host attributes will be returned that describe address. Otherwise, the
-// socket level information about ln will also be included.
-func NetServer(address string, ln net.Listener) []attribute.KeyValue {
-	return nc.Server(address, ln)
-}
-
 // netConv are the network semantic convention attributes defined for a version
 // of the OpenTelemetry specification.
 type netConv struct {
@@ -125,137 +107,12 @@ func (c *netConv) Host(address string) []attribute.KeyValue {
 	return attrs
 }
 
-// Server returns attributes for a network listener listening at address. See
-// net.Listen for information about acceptable address values, address should
-// be the same as the one used to create ln. If ln is nil, only network host
-// attributes will be returned that describe address. Otherwise, the socket
-// level information about ln will also be included.
-func (c *netConv) Server(address string, ln net.Listener) []attribute.KeyValue {
-	if ln == nil {
-		return c.Host(address)
-	}
-
-	lAddr := ln.Addr()
-	if lAddr == nil {
-		return c.Host(address)
-	}
-
-	hostName, hostPort := splitHostPort(address)
-	sockHostAddr, sockHostPort := splitHostPort(lAddr.String())
-	network := lAddr.Network()
-	sockFamily := family(network, sockHostAddr)
-
-	n := nonZeroStr(hostName, network, sockHostAddr, sockFamily)
-	n += positiveInt(hostPort, sockHostPort)
-	attr := make([]attribute.KeyValue, 0, n)
-	if hostName != "" {
-		attr = append(attr, c.HostName(hostName))
-		if hostPort > 0 {
-			// Only if net.host.name is set should net.host.port be.
-			attr = append(attr, c.HostPort(hostPort))
-		}
-	}
-	if network != "" {
-		attr = append(attr, c.Transport(network))
-	}
-	if sockFamily != "" {
-		attr = append(attr, c.NetSockFamilyKey.String(sockFamily))
-	}
-	if sockHostAddr != "" {
-		attr = append(attr, c.NetSockHostAddrKey.String(sockHostAddr))
-		if sockHostPort > 0 {
-			// Only if net.sock.host.addr is set should net.sock.host.port be.
-			attr = append(attr, c.NetSockHostPortKey.Int(sockHostPort))
-		}
-	}
-	return attr
-}
-
 func (c *netConv) HostName(name string) attribute.KeyValue {
 	return c.NetHostNameKey.String(name)
 }
 
 func (c *netConv) HostPort(port int) attribute.KeyValue {
 	return c.NetHostPortKey.Int(port)
-}
-
-// Client returns attributes for a client network connection to address. See
-// net.Dial for information about acceptable address values, address should be
-// the same as the one used to create conn. If conn is nil, only network peer
-// attributes will be returned that describe address. Otherwise, the socket
-// level information about conn will also be included.
-func (c *netConv) Client(address string, conn net.Conn) []attribute.KeyValue {
-	if conn == nil {
-		return c.Peer(address)
-	}
-
-	lAddr, rAddr := conn.LocalAddr(), conn.RemoteAddr()
-
-	var network string
-	switch {
-	case lAddr != nil:
-		network = lAddr.Network()
-	case rAddr != nil:
-		network = rAddr.Network()
-	default:
-		return c.Peer(address)
-	}
-
-	peerName, peerPort := splitHostPort(address)
-	var (
-		sockFamily   string
-		sockPeerAddr string
-		sockPeerPort int
-		sockHostAddr string
-		sockHostPort int
-	)
-
-	if lAddr != nil {
-		sockHostAddr, sockHostPort = splitHostPort(lAddr.String())
-	}
-
-	if rAddr != nil {
-		sockPeerAddr, sockPeerPort = splitHostPort(rAddr.String())
-	}
-
-	switch {
-	case sockHostAddr != "":
-		sockFamily = family(network, sockHostAddr)
-	case sockPeerAddr != "":
-		sockFamily = family(network, sockPeerAddr)
-	}
-
-	n := nonZeroStr(peerName, network, sockPeerAddr, sockHostAddr, sockFamily)
-	n += positiveInt(peerPort, sockPeerPort, sockHostPort)
-	attr := make([]attribute.KeyValue, 0, n)
-	if peerName != "" {
-		attr = append(attr, c.PeerName(peerName))
-		if peerPort > 0 {
-			// Only if net.peer.name is set should net.peer.port be.
-			attr = append(attr, c.PeerPort(peerPort))
-		}
-	}
-	if network != "" {
-		attr = append(attr, c.Transport(network))
-	}
-	if sockFamily != "" {
-		attr = append(attr, c.NetSockFamilyKey.String(sockFamily))
-	}
-	if sockPeerAddr != "" {
-		attr = append(attr, c.NetSockPeerAddrKey.String(sockPeerAddr))
-		if sockPeerPort > 0 {
-			// Only if net.sock.peer.addr is set should net.sock.peer.port be.
-			attr = append(attr, c.NetSockPeerPortKey.Int(sockPeerPort))
-		}
-	}
-	if sockHostAddr != "" {
-		attr = append(attr, c.NetSockHostAddrKey.String(sockHostAddr))
-		if sockHostPort > 0 {
-			// Only if net.sock.host.addr is set should net.sock.host.port be.
-			attr = append(attr, c.NetSockHostPortKey.Int(sockHostPort))
-		}
-	}
-	return attr
 }
 
 func family(network, address string) string {
@@ -271,26 +128,6 @@ func family(network, address string) string {
 		}
 	}
 	return ""
-}
-
-func nonZeroStr(strs ...string) int {
-	var n int
-	for _, str := range strs {
-		if str != "" {
-			n++
-		}
-	}
-	return n
-}
-
-func positiveInt(ints ...int) int {
-	var n int
-	for _, i := range ints {
-		if i > 0 {
-			n++
-		}
-	}
-	return n
 }
 
 // Peer returns attributes for a network peer address.

--- a/instrumentation/gopkg.in/macaron.v1/otelmacaron/internal/semconvutil/netconv_test.go
+++ b/instrumentation/gopkg.in/macaron.v1/otelmacaron/internal/semconvutil/netconv_test.go
@@ -17,12 +17,9 @@
 package semconvutil
 
 import (
-	"net"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel/attribute"
 )
@@ -54,53 +51,6 @@ func TestNetTransport(t *testing.T) {
 	}
 }
 
-func TestNetServerNilListener(t *testing.T) {
-	const addr = "127.0.0.1:8080"
-	got := NetServer(addr, nil)
-	expected := nc.Host(addr)
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-type listener struct{ net.Listener }
-
-func (listener) Addr() net.Addr { return nil }
-
-func TestNetServerNilAddr(t *testing.T) {
-	const addr = "127.0.0.1:8080"
-	got := NetServer(addr, listener{})
-	expected := nc.Host(addr)
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-func newTCPListener() (net.Listener, error) {
-	return net.Listen("tcp4", "127.0.0.1:0")
-}
-
-func TestNetServerTCP(t *testing.T) {
-	ln, err := newTCPListener()
-	require.NoError(t, err)
-	defer func() { require.NoError(t, ln.Close()) }()
-
-	host, pStr, err := net.SplitHostPort(ln.Addr().String())
-	require.NoError(t, err)
-	port, err := strconv.Atoi(pStr)
-	require.NoError(t, err)
-
-	got := NetServer("example.com:8080", ln)
-	expected := []attribute.KeyValue{
-		nc.HostName("example.com"),
-		nc.HostPort(8080),
-		nc.NetTransportTCP,
-		nc.NetSockFamilyKey.String("inet"),
-		nc.NetSockHostAddrKey.String(host),
-		nc.NetSockHostPortKey.Int(port),
-	}
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
 func TestNetHost(t *testing.T) {
 	testAddrs(t, []addrTest{
 		{address: "", expected: nil},
@@ -122,103 +72,6 @@ func TestNetHostName(t *testing.T) {
 func TestNetHostPort(t *testing.T) {
 	expected := attribute.Key("net.host.port").Int(port)
 	assert.Equal(t, expected, nc.HostPort(port))
-}
-
-func TestNetClientNilConn(t *testing.T) {
-	const addr = "127.0.0.1:8080"
-	got := NetClient(addr, nil)
-	expected := nc.Peer(addr)
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-type conn struct{ net.Conn }
-
-func (conn) LocalAddr() net.Addr  { return nil }
-func (conn) RemoteAddr() net.Addr { return nil }
-
-func TestNetClientNilAddr(t *testing.T) {
-	const addr = "127.0.0.1:8080"
-	got := NetClient(addr, conn{})
-	expected := nc.Peer(addr)
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-func newTCPConn() (net.Conn, net.Listener, error) {
-	ln, err := newTCPListener()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	conn, err := net.Dial("tcp4", ln.Addr().String())
-	if err != nil {
-		_ = ln.Close()
-		return nil, nil, err
-	}
-
-	return conn, ln, nil
-}
-
-func TestNetClientTCP(t *testing.T) {
-	conn, ln, err := newTCPConn()
-	require.NoError(t, err)
-	defer func() { require.NoError(t, ln.Close()) }()
-	defer func() { require.NoError(t, conn.Close()) }()
-
-	lHost, pStr, err := net.SplitHostPort(conn.LocalAddr().String())
-	require.NoError(t, err)
-	lPort, err := strconv.Atoi(pStr)
-	require.NoError(t, err)
-
-	rHost, pStr, err := net.SplitHostPort(conn.RemoteAddr().String())
-	require.NoError(t, err)
-	rPort, err := strconv.Atoi(pStr)
-	require.NoError(t, err)
-
-	got := NetClient("example.com:8080", conn)
-	expected := []attribute.KeyValue{
-		nc.PeerName("example.com"),
-		nc.PeerPort(8080),
-		nc.NetTransportTCP,
-		nc.NetSockFamilyKey.String("inet"),
-		nc.NetSockPeerAddrKey.String(rHost),
-		nc.NetSockPeerPortKey.Int(rPort),
-		nc.NetSockHostAddrKey.String(lHost),
-		nc.NetSockHostPortKey.Int(lPort),
-	}
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-type remoteOnlyConn struct{ net.Conn }
-
-func (remoteOnlyConn) LocalAddr() net.Addr { return nil }
-
-func TestNetClientTCPNilLocal(t *testing.T) {
-	conn, ln, err := newTCPConn()
-	require.NoError(t, err)
-	defer func() { require.NoError(t, ln.Close()) }()
-	defer func() { require.NoError(t, conn.Close()) }()
-
-	conn = remoteOnlyConn{conn}
-
-	rHost, pStr, err := net.SplitHostPort(conn.RemoteAddr().String())
-	require.NoError(t, err)
-	rPort, err := strconv.Atoi(pStr)
-	require.NoError(t, err)
-
-	got := NetClient("example.com:8080", conn)
-	expected := []attribute.KeyValue{
-		nc.PeerName("example.com"),
-		nc.PeerPort(8080),
-		nc.NetTransportTCP,
-		nc.NetSockFamilyKey.String("inet"),
-		nc.NetSockPeerAddrKey.String(rHost),
-		nc.NetSockPeerPortKey.Int(rPort),
-	}
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
 }
 
 func TestNetPeer(t *testing.T) {

--- a/instrumentation/net/http/httptrace/otelhttptrace/internal/semconvutil/httpconv.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/internal/semconvutil/httpconv.go
@@ -114,36 +114,6 @@ func HTTPServerStatus(code int) (codes.Code, string) {
 	return hc.ServerStatus(code)
 }
 
-// HTTPRequestHeader returns the contents of h as attributes.
-//
-// Instrumentation should require an explicit configuration of which headers to
-// captured and then prune what they pass here. Including all headers can be a
-// security risk - explicit configuration helps avoid leaking sensitive
-// information.
-//
-// The User-Agent header is already captured in the http.user_agent attribute
-// from ClientRequest and ServerRequest. Instrumentation may provide an option
-// to capture that header here even though it is not recommended. Otherwise,
-// instrumentation should filter that out of what is passed.
-func HTTPRequestHeader(h http.Header) []attribute.KeyValue {
-	return hc.RequestHeader(h)
-}
-
-// HTTPResponseHeader returns the contents of h as attributes.
-//
-// Instrumentation should require an explicit configuration of which headers to
-// captured and then prune what they pass here. Including all headers can be a
-// security risk - explicit configuration helps avoid leaking sensitive
-// information.
-//
-// The User-Agent header is already captured in the http.user_agent attribute
-// from ClientRequest and ServerRequest. Instrumentation may provide an option
-// to capture that header here even though it is not recommended. Otherwise,
-// instrumentation should filter that out of what is passed.
-func HTTPResponseHeader(h http.Header) []attribute.KeyValue {
-	return hc.ResponseHeader(h)
-}
-
 // httpConv are the HTTP semantic convention attributes defined for a version
 // of the OpenTelemetry specification.
 type httpConv struct {
@@ -549,31 +519,6 @@ func firstHostPort(source ...string) (host string, port int) {
 		}
 	}
 	return
-}
-
-// RequestHeader returns the contents of h as OpenTelemetry attributes.
-func (c *httpConv) RequestHeader(h http.Header) []attribute.KeyValue {
-	return c.header("http.request.header", h)
-}
-
-// ResponseHeader returns the contents of h as OpenTelemetry attributes.
-func (c *httpConv) ResponseHeader(h http.Header) []attribute.KeyValue {
-	return c.header("http.response.header", h)
-}
-
-func (c *httpConv) header(prefix string, h http.Header) []attribute.KeyValue {
-	key := func(k string) attribute.Key {
-		k = strings.ToLower(k)
-		k = strings.ReplaceAll(k, "-", "_")
-		k = fmt.Sprintf("%s.%s", prefix, k)
-		return attribute.Key(k)
-	}
-
-	attrs := make([]attribute.KeyValue, 0, len(h))
-	for k, v := range h {
-		attrs = append(attrs, key(k).StringSlice(v))
-	}
-	return attrs
 }
 
 // ClientStatus returns a span status code and message for an HTTP status code

--- a/instrumentation/net/http/httptrace/otelhttptrace/internal/semconvutil/httpconv_test.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/internal/semconvutil/httpconv_test.go
@@ -290,32 +290,6 @@ func TestFirstHostPort(t *testing.T) {
 	}
 }
 
-func TestHTTPRequestHeader(t *testing.T) {
-	ips := []string{"127.0.0.5", "127.0.0.9"}
-	user := []string{"alice"}
-	h := http.Header{"ips": ips, "user": user}
-
-	got := HTTPRequestHeader(h)
-	assert.Equal(t, 2, cap(got), "slice capacity")
-	assert.ElementsMatch(t, []attribute.KeyValue{
-		attribute.StringSlice("http.request.header.ips", ips),
-		attribute.StringSlice("http.request.header.user", user),
-	}, got)
-}
-
-func TestHTTPReponseHeader(t *testing.T) {
-	ips := []string{"127.0.0.5", "127.0.0.9"}
-	user := []string{"alice"}
-	h := http.Header{"ips": ips, "user": user}
-
-	got := HTTPResponseHeader(h)
-	assert.Equal(t, 2, cap(got), "slice capacity")
-	assert.ElementsMatch(t, []attribute.KeyValue{
-		attribute.StringSlice("http.response.header.ips", ips),
-		attribute.StringSlice("http.response.header.user", user),
-	}, got)
-}
-
 func TestHTTPClientStatus(t *testing.T) {
 	tests := []struct {
 		code int

--- a/instrumentation/net/http/httptrace/otelhttptrace/internal/semconvutil/netconv.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/internal/semconvutil/netconv.go
@@ -32,24 +32,6 @@ func NetTransport(network string) attribute.KeyValue {
 	return nc.Transport(network)
 }
 
-// NetClient returns trace attributes for a client network connection to address.
-// See net.Dial for information about acceptable address values, address should
-// be the same as the one used to create conn. If conn is nil, only network
-// peer attributes will be returned that describe address. Otherwise, the
-// socket level information about conn will also be included.
-func NetClient(address string, conn net.Conn) []attribute.KeyValue {
-	return nc.Client(address, conn)
-}
-
-// NetServer returns trace attributes for a network listener listening at address.
-// See net.Listen for information about acceptable address values, address
-// should be the same as the one used to create ln. If ln is nil, only network
-// host attributes will be returned that describe address. Otherwise, the
-// socket level information about ln will also be included.
-func NetServer(address string, ln net.Listener) []attribute.KeyValue {
-	return nc.Server(address, ln)
-}
-
 // netConv are the network semantic convention attributes defined for a version
 // of the OpenTelemetry specification.
 type netConv struct {
@@ -125,137 +107,12 @@ func (c *netConv) Host(address string) []attribute.KeyValue {
 	return attrs
 }
 
-// Server returns attributes for a network listener listening at address. See
-// net.Listen for information about acceptable address values, address should
-// be the same as the one used to create ln. If ln is nil, only network host
-// attributes will be returned that describe address. Otherwise, the socket
-// level information about ln will also be included.
-func (c *netConv) Server(address string, ln net.Listener) []attribute.KeyValue {
-	if ln == nil {
-		return c.Host(address)
-	}
-
-	lAddr := ln.Addr()
-	if lAddr == nil {
-		return c.Host(address)
-	}
-
-	hostName, hostPort := splitHostPort(address)
-	sockHostAddr, sockHostPort := splitHostPort(lAddr.String())
-	network := lAddr.Network()
-	sockFamily := family(network, sockHostAddr)
-
-	n := nonZeroStr(hostName, network, sockHostAddr, sockFamily)
-	n += positiveInt(hostPort, sockHostPort)
-	attr := make([]attribute.KeyValue, 0, n)
-	if hostName != "" {
-		attr = append(attr, c.HostName(hostName))
-		if hostPort > 0 {
-			// Only if net.host.name is set should net.host.port be.
-			attr = append(attr, c.HostPort(hostPort))
-		}
-	}
-	if network != "" {
-		attr = append(attr, c.Transport(network))
-	}
-	if sockFamily != "" {
-		attr = append(attr, c.NetSockFamilyKey.String(sockFamily))
-	}
-	if sockHostAddr != "" {
-		attr = append(attr, c.NetSockHostAddrKey.String(sockHostAddr))
-		if sockHostPort > 0 {
-			// Only if net.sock.host.addr is set should net.sock.host.port be.
-			attr = append(attr, c.NetSockHostPortKey.Int(sockHostPort))
-		}
-	}
-	return attr
-}
-
 func (c *netConv) HostName(name string) attribute.KeyValue {
 	return c.NetHostNameKey.String(name)
 }
 
 func (c *netConv) HostPort(port int) attribute.KeyValue {
 	return c.NetHostPortKey.Int(port)
-}
-
-// Client returns attributes for a client network connection to address. See
-// net.Dial for information about acceptable address values, address should be
-// the same as the one used to create conn. If conn is nil, only network peer
-// attributes will be returned that describe address. Otherwise, the socket
-// level information about conn will also be included.
-func (c *netConv) Client(address string, conn net.Conn) []attribute.KeyValue {
-	if conn == nil {
-		return c.Peer(address)
-	}
-
-	lAddr, rAddr := conn.LocalAddr(), conn.RemoteAddr()
-
-	var network string
-	switch {
-	case lAddr != nil:
-		network = lAddr.Network()
-	case rAddr != nil:
-		network = rAddr.Network()
-	default:
-		return c.Peer(address)
-	}
-
-	peerName, peerPort := splitHostPort(address)
-	var (
-		sockFamily   string
-		sockPeerAddr string
-		sockPeerPort int
-		sockHostAddr string
-		sockHostPort int
-	)
-
-	if lAddr != nil {
-		sockHostAddr, sockHostPort = splitHostPort(lAddr.String())
-	}
-
-	if rAddr != nil {
-		sockPeerAddr, sockPeerPort = splitHostPort(rAddr.String())
-	}
-
-	switch {
-	case sockHostAddr != "":
-		sockFamily = family(network, sockHostAddr)
-	case sockPeerAddr != "":
-		sockFamily = family(network, sockPeerAddr)
-	}
-
-	n := nonZeroStr(peerName, network, sockPeerAddr, sockHostAddr, sockFamily)
-	n += positiveInt(peerPort, sockPeerPort, sockHostPort)
-	attr := make([]attribute.KeyValue, 0, n)
-	if peerName != "" {
-		attr = append(attr, c.PeerName(peerName))
-		if peerPort > 0 {
-			// Only if net.peer.name is set should net.peer.port be.
-			attr = append(attr, c.PeerPort(peerPort))
-		}
-	}
-	if network != "" {
-		attr = append(attr, c.Transport(network))
-	}
-	if sockFamily != "" {
-		attr = append(attr, c.NetSockFamilyKey.String(sockFamily))
-	}
-	if sockPeerAddr != "" {
-		attr = append(attr, c.NetSockPeerAddrKey.String(sockPeerAddr))
-		if sockPeerPort > 0 {
-			// Only if net.sock.peer.addr is set should net.sock.peer.port be.
-			attr = append(attr, c.NetSockPeerPortKey.Int(sockPeerPort))
-		}
-	}
-	if sockHostAddr != "" {
-		attr = append(attr, c.NetSockHostAddrKey.String(sockHostAddr))
-		if sockHostPort > 0 {
-			// Only if net.sock.host.addr is set should net.sock.host.port be.
-			attr = append(attr, c.NetSockHostPortKey.Int(sockHostPort))
-		}
-	}
-	return attr
 }
 
 func family(network, address string) string {
@@ -271,26 +128,6 @@ func family(network, address string) string {
 		}
 	}
 	return ""
-}
-
-func nonZeroStr(strs ...string) int {
-	var n int
-	for _, str := range strs {
-		if str != "" {
-			n++
-		}
-	}
-	return n
-}
-
-func positiveInt(ints ...int) int {
-	var n int
-	for _, i := range ints {
-		if i > 0 {
-			n++
-		}
-	}
-	return n
 }
 
 // Peer returns attributes for a network peer address.

--- a/instrumentation/net/http/httptrace/otelhttptrace/internal/semconvutil/netconv_test.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/internal/semconvutil/netconv_test.go
@@ -17,12 +17,9 @@
 package semconvutil
 
 import (
-	"net"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel/attribute"
 )
@@ -54,53 +51,6 @@ func TestNetTransport(t *testing.T) {
 	}
 }
 
-func TestNetServerNilListener(t *testing.T) {
-	const addr = "127.0.0.1:8080"
-	got := NetServer(addr, nil)
-	expected := nc.Host(addr)
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-type listener struct{ net.Listener }
-
-func (listener) Addr() net.Addr { return nil }
-
-func TestNetServerNilAddr(t *testing.T) {
-	const addr = "127.0.0.1:8080"
-	got := NetServer(addr, listener{})
-	expected := nc.Host(addr)
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-func newTCPListener() (net.Listener, error) {
-	return net.Listen("tcp4", "127.0.0.1:0")
-}
-
-func TestNetServerTCP(t *testing.T) {
-	ln, err := newTCPListener()
-	require.NoError(t, err)
-	defer func() { require.NoError(t, ln.Close()) }()
-
-	host, pStr, err := net.SplitHostPort(ln.Addr().String())
-	require.NoError(t, err)
-	port, err := strconv.Atoi(pStr)
-	require.NoError(t, err)
-
-	got := NetServer("example.com:8080", ln)
-	expected := []attribute.KeyValue{
-		nc.HostName("example.com"),
-		nc.HostPort(8080),
-		nc.NetTransportTCP,
-		nc.NetSockFamilyKey.String("inet"),
-		nc.NetSockHostAddrKey.String(host),
-		nc.NetSockHostPortKey.Int(port),
-	}
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
 func TestNetHost(t *testing.T) {
 	testAddrs(t, []addrTest{
 		{address: "", expected: nil},
@@ -122,103 +72,6 @@ func TestNetHostName(t *testing.T) {
 func TestNetHostPort(t *testing.T) {
 	expected := attribute.Key("net.host.port").Int(port)
 	assert.Equal(t, expected, nc.HostPort(port))
-}
-
-func TestNetClientNilConn(t *testing.T) {
-	const addr = "127.0.0.1:8080"
-	got := NetClient(addr, nil)
-	expected := nc.Peer(addr)
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-type conn struct{ net.Conn }
-
-func (conn) LocalAddr() net.Addr  { return nil }
-func (conn) RemoteAddr() net.Addr { return nil }
-
-func TestNetClientNilAddr(t *testing.T) {
-	const addr = "127.0.0.1:8080"
-	got := NetClient(addr, conn{})
-	expected := nc.Peer(addr)
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-func newTCPConn() (net.Conn, net.Listener, error) {
-	ln, err := newTCPListener()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	conn, err := net.Dial("tcp4", ln.Addr().String())
-	if err != nil {
-		_ = ln.Close()
-		return nil, nil, err
-	}
-
-	return conn, ln, nil
-}
-
-func TestNetClientTCP(t *testing.T) {
-	conn, ln, err := newTCPConn()
-	require.NoError(t, err)
-	defer func() { require.NoError(t, ln.Close()) }()
-	defer func() { require.NoError(t, conn.Close()) }()
-
-	lHost, pStr, err := net.SplitHostPort(conn.LocalAddr().String())
-	require.NoError(t, err)
-	lPort, err := strconv.Atoi(pStr)
-	require.NoError(t, err)
-
-	rHost, pStr, err := net.SplitHostPort(conn.RemoteAddr().String())
-	require.NoError(t, err)
-	rPort, err := strconv.Atoi(pStr)
-	require.NoError(t, err)
-
-	got := NetClient("example.com:8080", conn)
-	expected := []attribute.KeyValue{
-		nc.PeerName("example.com"),
-		nc.PeerPort(8080),
-		nc.NetTransportTCP,
-		nc.NetSockFamilyKey.String("inet"),
-		nc.NetSockPeerAddrKey.String(rHost),
-		nc.NetSockPeerPortKey.Int(rPort),
-		nc.NetSockHostAddrKey.String(lHost),
-		nc.NetSockHostPortKey.Int(lPort),
-	}
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-type remoteOnlyConn struct{ net.Conn }
-
-func (remoteOnlyConn) LocalAddr() net.Addr { return nil }
-
-func TestNetClientTCPNilLocal(t *testing.T) {
-	conn, ln, err := newTCPConn()
-	require.NoError(t, err)
-	defer func() { require.NoError(t, ln.Close()) }()
-	defer func() { require.NoError(t, conn.Close()) }()
-
-	conn = remoteOnlyConn{conn}
-
-	rHost, pStr, err := net.SplitHostPort(conn.RemoteAddr().String())
-	require.NoError(t, err)
-	rPort, err := strconv.Atoi(pStr)
-	require.NoError(t, err)
-
-	got := NetClient("example.com:8080", conn)
-	expected := []attribute.KeyValue{
-		nc.PeerName("example.com"),
-		nc.PeerPort(8080),
-		nc.NetTransportTCP,
-		nc.NetSockFamilyKey.String("inet"),
-		nc.NetSockPeerAddrKey.String(rHost),
-		nc.NetSockPeerPortKey.Int(rPort),
-	}
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
 }
 
 func TestNetPeer(t *testing.T) {

--- a/instrumentation/net/http/otelhttp/internal/semconvutil/httpconv.go
+++ b/instrumentation/net/http/otelhttp/internal/semconvutil/httpconv.go
@@ -114,36 +114,6 @@ func HTTPServerStatus(code int) (codes.Code, string) {
 	return hc.ServerStatus(code)
 }
 
-// HTTPRequestHeader returns the contents of h as attributes.
-//
-// Instrumentation should require an explicit configuration of which headers to
-// captured and then prune what they pass here. Including all headers can be a
-// security risk - explicit configuration helps avoid leaking sensitive
-// information.
-//
-// The User-Agent header is already captured in the http.user_agent attribute
-// from ClientRequest and ServerRequest. Instrumentation may provide an option
-// to capture that header here even though it is not recommended. Otherwise,
-// instrumentation should filter that out of what is passed.
-func HTTPRequestHeader(h http.Header) []attribute.KeyValue {
-	return hc.RequestHeader(h)
-}
-
-// HTTPResponseHeader returns the contents of h as attributes.
-//
-// Instrumentation should require an explicit configuration of which headers to
-// captured and then prune what they pass here. Including all headers can be a
-// security risk - explicit configuration helps avoid leaking sensitive
-// information.
-//
-// The User-Agent header is already captured in the http.user_agent attribute
-// from ClientRequest and ServerRequest. Instrumentation may provide an option
-// to capture that header here even though it is not recommended. Otherwise,
-// instrumentation should filter that out of what is passed.
-func HTTPResponseHeader(h http.Header) []attribute.KeyValue {
-	return hc.ResponseHeader(h)
-}
-
 // httpConv are the HTTP semantic convention attributes defined for a version
 // of the OpenTelemetry specification.
 type httpConv struct {
@@ -549,31 +519,6 @@ func firstHostPort(source ...string) (host string, port int) {
 		}
 	}
 	return
-}
-
-// RequestHeader returns the contents of h as OpenTelemetry attributes.
-func (c *httpConv) RequestHeader(h http.Header) []attribute.KeyValue {
-	return c.header("http.request.header", h)
-}
-
-// ResponseHeader returns the contents of h as OpenTelemetry attributes.
-func (c *httpConv) ResponseHeader(h http.Header) []attribute.KeyValue {
-	return c.header("http.response.header", h)
-}
-
-func (c *httpConv) header(prefix string, h http.Header) []attribute.KeyValue {
-	key := func(k string) attribute.Key {
-		k = strings.ToLower(k)
-		k = strings.ReplaceAll(k, "-", "_")
-		k = fmt.Sprintf("%s.%s", prefix, k)
-		return attribute.Key(k)
-	}
-
-	attrs := make([]attribute.KeyValue, 0, len(h))
-	for k, v := range h {
-		attrs = append(attrs, key(k).StringSlice(v))
-	}
-	return attrs
 }
 
 // ClientStatus returns a span status code and message for an HTTP status code

--- a/instrumentation/net/http/otelhttp/internal/semconvutil/httpconv_test.go
+++ b/instrumentation/net/http/otelhttp/internal/semconvutil/httpconv_test.go
@@ -290,32 +290,6 @@ func TestFirstHostPort(t *testing.T) {
 	}
 }
 
-func TestHTTPRequestHeader(t *testing.T) {
-	ips := []string{"127.0.0.5", "127.0.0.9"}
-	user := []string{"alice"}
-	h := http.Header{"ips": ips, "user": user}
-
-	got := HTTPRequestHeader(h)
-	assert.Equal(t, 2, cap(got), "slice capacity")
-	assert.ElementsMatch(t, []attribute.KeyValue{
-		attribute.StringSlice("http.request.header.ips", ips),
-		attribute.StringSlice("http.request.header.user", user),
-	}, got)
-}
-
-func TestHTTPReponseHeader(t *testing.T) {
-	ips := []string{"127.0.0.5", "127.0.0.9"}
-	user := []string{"alice"}
-	h := http.Header{"ips": ips, "user": user}
-
-	got := HTTPResponseHeader(h)
-	assert.Equal(t, 2, cap(got), "slice capacity")
-	assert.ElementsMatch(t, []attribute.KeyValue{
-		attribute.StringSlice("http.response.header.ips", ips),
-		attribute.StringSlice("http.response.header.user", user),
-	}, got)
-}
-
 func TestHTTPClientStatus(t *testing.T) {
 	tests := []struct {
 		code int

--- a/instrumentation/net/http/otelhttp/internal/semconvutil/netconv.go
+++ b/instrumentation/net/http/otelhttp/internal/semconvutil/netconv.go
@@ -32,24 +32,6 @@ func NetTransport(network string) attribute.KeyValue {
 	return nc.Transport(network)
 }
 
-// NetClient returns trace attributes for a client network connection to address.
-// See net.Dial for information about acceptable address values, address should
-// be the same as the one used to create conn. If conn is nil, only network
-// peer attributes will be returned that describe address. Otherwise, the
-// socket level information about conn will also be included.
-func NetClient(address string, conn net.Conn) []attribute.KeyValue {
-	return nc.Client(address, conn)
-}
-
-// NetServer returns trace attributes for a network listener listening at address.
-// See net.Listen for information about acceptable address values, address
-// should be the same as the one used to create ln. If ln is nil, only network
-// host attributes will be returned that describe address. Otherwise, the
-// socket level information about ln will also be included.
-func NetServer(address string, ln net.Listener) []attribute.KeyValue {
-	return nc.Server(address, ln)
-}
-
 // netConv are the network semantic convention attributes defined for a version
 // of the OpenTelemetry specification.
 type netConv struct {
@@ -125,137 +107,12 @@ func (c *netConv) Host(address string) []attribute.KeyValue {
 	return attrs
 }
 
-// Server returns attributes for a network listener listening at address. See
-// net.Listen for information about acceptable address values, address should
-// be the same as the one used to create ln. If ln is nil, only network host
-// attributes will be returned that describe address. Otherwise, the socket
-// level information about ln will also be included.
-func (c *netConv) Server(address string, ln net.Listener) []attribute.KeyValue {
-	if ln == nil {
-		return c.Host(address)
-	}
-
-	lAddr := ln.Addr()
-	if lAddr == nil {
-		return c.Host(address)
-	}
-
-	hostName, hostPort := splitHostPort(address)
-	sockHostAddr, sockHostPort := splitHostPort(lAddr.String())
-	network := lAddr.Network()
-	sockFamily := family(network, sockHostAddr)
-
-	n := nonZeroStr(hostName, network, sockHostAddr, sockFamily)
-	n += positiveInt(hostPort, sockHostPort)
-	attr := make([]attribute.KeyValue, 0, n)
-	if hostName != "" {
-		attr = append(attr, c.HostName(hostName))
-		if hostPort > 0 {
-			// Only if net.host.name is set should net.host.port be.
-			attr = append(attr, c.HostPort(hostPort))
-		}
-	}
-	if network != "" {
-		attr = append(attr, c.Transport(network))
-	}
-	if sockFamily != "" {
-		attr = append(attr, c.NetSockFamilyKey.String(sockFamily))
-	}
-	if sockHostAddr != "" {
-		attr = append(attr, c.NetSockHostAddrKey.String(sockHostAddr))
-		if sockHostPort > 0 {
-			// Only if net.sock.host.addr is set should net.sock.host.port be.
-			attr = append(attr, c.NetSockHostPortKey.Int(sockHostPort))
-		}
-	}
-	return attr
-}
-
 func (c *netConv) HostName(name string) attribute.KeyValue {
 	return c.NetHostNameKey.String(name)
 }
 
 func (c *netConv) HostPort(port int) attribute.KeyValue {
 	return c.NetHostPortKey.Int(port)
-}
-
-// Client returns attributes for a client network connection to address. See
-// net.Dial for information about acceptable address values, address should be
-// the same as the one used to create conn. If conn is nil, only network peer
-// attributes will be returned that describe address. Otherwise, the socket
-// level information about conn will also be included.
-func (c *netConv) Client(address string, conn net.Conn) []attribute.KeyValue {
-	if conn == nil {
-		return c.Peer(address)
-	}
-
-	lAddr, rAddr := conn.LocalAddr(), conn.RemoteAddr()
-
-	var network string
-	switch {
-	case lAddr != nil:
-		network = lAddr.Network()
-	case rAddr != nil:
-		network = rAddr.Network()
-	default:
-		return c.Peer(address)
-	}
-
-	peerName, peerPort := splitHostPort(address)
-	var (
-		sockFamily   string
-		sockPeerAddr string
-		sockPeerPort int
-		sockHostAddr string
-		sockHostPort int
-	)
-
-	if lAddr != nil {
-		sockHostAddr, sockHostPort = splitHostPort(lAddr.String())
-	}
-
-	if rAddr != nil {
-		sockPeerAddr, sockPeerPort = splitHostPort(rAddr.String())
-	}
-
-	switch {
-	case sockHostAddr != "":
-		sockFamily = family(network, sockHostAddr)
-	case sockPeerAddr != "":
-		sockFamily = family(network, sockPeerAddr)
-	}
-
-	n := nonZeroStr(peerName, network, sockPeerAddr, sockHostAddr, sockFamily)
-	n += positiveInt(peerPort, sockPeerPort, sockHostPort)
-	attr := make([]attribute.KeyValue, 0, n)
-	if peerName != "" {
-		attr = append(attr, c.PeerName(peerName))
-		if peerPort > 0 {
-			// Only if net.peer.name is set should net.peer.port be.
-			attr = append(attr, c.PeerPort(peerPort))
-		}
-	}
-	if network != "" {
-		attr = append(attr, c.Transport(network))
-	}
-	if sockFamily != "" {
-		attr = append(attr, c.NetSockFamilyKey.String(sockFamily))
-	}
-	if sockPeerAddr != "" {
-		attr = append(attr, c.NetSockPeerAddrKey.String(sockPeerAddr))
-		if sockPeerPort > 0 {
-			// Only if net.sock.peer.addr is set should net.sock.peer.port be.
-			attr = append(attr, c.NetSockPeerPortKey.Int(sockPeerPort))
-		}
-	}
-	if sockHostAddr != "" {
-		attr = append(attr, c.NetSockHostAddrKey.String(sockHostAddr))
-		if sockHostPort > 0 {
-			// Only if net.sock.host.addr is set should net.sock.host.port be.
-			attr = append(attr, c.NetSockHostPortKey.Int(sockHostPort))
-		}
-	}
-	return attr
 }
 
 func family(network, address string) string {
@@ -271,26 +128,6 @@ func family(network, address string) string {
 		}
 	}
 	return ""
-}
-
-func nonZeroStr(strs ...string) int {
-	var n int
-	for _, str := range strs {
-		if str != "" {
-			n++
-		}
-	}
-	return n
-}
-
-func positiveInt(ints ...int) int {
-	var n int
-	for _, i := range ints {
-		if i > 0 {
-			n++
-		}
-	}
-	return n
 }
 
 // Peer returns attributes for a network peer address.

--- a/instrumentation/net/http/otelhttp/internal/semconvutil/netconv_test.go
+++ b/instrumentation/net/http/otelhttp/internal/semconvutil/netconv_test.go
@@ -17,12 +17,9 @@
 package semconvutil
 
 import (
-	"net"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel/attribute"
 )
@@ -54,53 +51,6 @@ func TestNetTransport(t *testing.T) {
 	}
 }
 
-func TestNetServerNilListener(t *testing.T) {
-	const addr = "127.0.0.1:8080"
-	got := NetServer(addr, nil)
-	expected := nc.Host(addr)
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-type listener struct{ net.Listener }
-
-func (listener) Addr() net.Addr { return nil }
-
-func TestNetServerNilAddr(t *testing.T) {
-	const addr = "127.0.0.1:8080"
-	got := NetServer(addr, listener{})
-	expected := nc.Host(addr)
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-func newTCPListener() (net.Listener, error) {
-	return net.Listen("tcp4", "127.0.0.1:0")
-}
-
-func TestNetServerTCP(t *testing.T) {
-	ln, err := newTCPListener()
-	require.NoError(t, err)
-	defer func() { require.NoError(t, ln.Close()) }()
-
-	host, pStr, err := net.SplitHostPort(ln.Addr().String())
-	require.NoError(t, err)
-	port, err := strconv.Atoi(pStr)
-	require.NoError(t, err)
-
-	got := NetServer("example.com:8080", ln)
-	expected := []attribute.KeyValue{
-		nc.HostName("example.com"),
-		nc.HostPort(8080),
-		nc.NetTransportTCP,
-		nc.NetSockFamilyKey.String("inet"),
-		nc.NetSockHostAddrKey.String(host),
-		nc.NetSockHostPortKey.Int(port),
-	}
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
 func TestNetHost(t *testing.T) {
 	testAddrs(t, []addrTest{
 		{address: "", expected: nil},
@@ -122,103 +72,6 @@ func TestNetHostName(t *testing.T) {
 func TestNetHostPort(t *testing.T) {
 	expected := attribute.Key("net.host.port").Int(port)
 	assert.Equal(t, expected, nc.HostPort(port))
-}
-
-func TestNetClientNilConn(t *testing.T) {
-	const addr = "127.0.0.1:8080"
-	got := NetClient(addr, nil)
-	expected := nc.Peer(addr)
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-type conn struct{ net.Conn }
-
-func (conn) LocalAddr() net.Addr  { return nil }
-func (conn) RemoteAddr() net.Addr { return nil }
-
-func TestNetClientNilAddr(t *testing.T) {
-	const addr = "127.0.0.1:8080"
-	got := NetClient(addr, conn{})
-	expected := nc.Peer(addr)
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-func newTCPConn() (net.Conn, net.Listener, error) {
-	ln, err := newTCPListener()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	conn, err := net.Dial("tcp4", ln.Addr().String())
-	if err != nil {
-		_ = ln.Close()
-		return nil, nil, err
-	}
-
-	return conn, ln, nil
-}
-
-func TestNetClientTCP(t *testing.T) {
-	conn, ln, err := newTCPConn()
-	require.NoError(t, err)
-	defer func() { require.NoError(t, ln.Close()) }()
-	defer func() { require.NoError(t, conn.Close()) }()
-
-	lHost, pStr, err := net.SplitHostPort(conn.LocalAddr().String())
-	require.NoError(t, err)
-	lPort, err := strconv.Atoi(pStr)
-	require.NoError(t, err)
-
-	rHost, pStr, err := net.SplitHostPort(conn.RemoteAddr().String())
-	require.NoError(t, err)
-	rPort, err := strconv.Atoi(pStr)
-	require.NoError(t, err)
-
-	got := NetClient("example.com:8080", conn)
-	expected := []attribute.KeyValue{
-		nc.PeerName("example.com"),
-		nc.PeerPort(8080),
-		nc.NetTransportTCP,
-		nc.NetSockFamilyKey.String("inet"),
-		nc.NetSockPeerAddrKey.String(rHost),
-		nc.NetSockPeerPortKey.Int(rPort),
-		nc.NetSockHostAddrKey.String(lHost),
-		nc.NetSockHostPortKey.Int(lPort),
-	}
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-type remoteOnlyConn struct{ net.Conn }
-
-func (remoteOnlyConn) LocalAddr() net.Addr { return nil }
-
-func TestNetClientTCPNilLocal(t *testing.T) {
-	conn, ln, err := newTCPConn()
-	require.NoError(t, err)
-	defer func() { require.NoError(t, ln.Close()) }()
-	defer func() { require.NoError(t, conn.Close()) }()
-
-	conn = remoteOnlyConn{conn}
-
-	rHost, pStr, err := net.SplitHostPort(conn.RemoteAddr().String())
-	require.NoError(t, err)
-	rPort, err := strconv.Atoi(pStr)
-	require.NoError(t, err)
-
-	got := NetClient("example.com:8080", conn)
-	expected := []attribute.KeyValue{
-		nc.PeerName("example.com"),
-		nc.PeerPort(8080),
-		nc.NetTransportTCP,
-		nc.NetSockFamilyKey.String("inet"),
-		nc.NetSockPeerAddrKey.String(rHost),
-		nc.NetSockPeerPortKey.Int(rPort),
-	}
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
 }
 
 func TestNetPeer(t *testing.T) {

--- a/internal/shared/semconvutil/httpconv.go.tmpl
+++ b/internal/shared/semconvutil/httpconv.go.tmpl
@@ -114,36 +114,6 @@ func HTTPServerStatus(code int) (codes.Code, string) {
 	return hc.ServerStatus(code)
 }
 
-// HTTPRequestHeader returns the contents of h as attributes.
-//
-// Instrumentation should require an explicit configuration of which headers to
-// captured and then prune what they pass here. Including all headers can be a
-// security risk - explicit configuration helps avoid leaking sensitive
-// information.
-//
-// The User-Agent header is already captured in the http.user_agent attribute
-// from ClientRequest and ServerRequest. Instrumentation may provide an option
-// to capture that header here even though it is not recommended. Otherwise,
-// instrumentation should filter that out of what is passed.
-func HTTPRequestHeader(h http.Header) []attribute.KeyValue {
-	return hc.RequestHeader(h)
-}
-
-// HTTPResponseHeader returns the contents of h as attributes.
-//
-// Instrumentation should require an explicit configuration of which headers to
-// captured and then prune what they pass here. Including all headers can be a
-// security risk - explicit configuration helps avoid leaking sensitive
-// information.
-//
-// The User-Agent header is already captured in the http.user_agent attribute
-// from ClientRequest and ServerRequest. Instrumentation may provide an option
-// to capture that header here even though it is not recommended. Otherwise,
-// instrumentation should filter that out of what is passed.
-func HTTPResponseHeader(h http.Header) []attribute.KeyValue {
-	return hc.ResponseHeader(h)
-}
-
 // httpConv are the HTTP semantic convention attributes defined for a version
 // of the OpenTelemetry specification.
 type httpConv struct {
@@ -549,31 +519,6 @@ func firstHostPort(source ...string) (host string, port int) {
 		}
 	}
 	return
-}
-
-// RequestHeader returns the contents of h as OpenTelemetry attributes.
-func (c *httpConv) RequestHeader(h http.Header) []attribute.KeyValue {
-	return c.header("http.request.header", h)
-}
-
-// ResponseHeader returns the contents of h as OpenTelemetry attributes.
-func (c *httpConv) ResponseHeader(h http.Header) []attribute.KeyValue {
-	return c.header("http.response.header", h)
-}
-
-func (c *httpConv) header(prefix string, h http.Header) []attribute.KeyValue {
-	key := func(k string) attribute.Key {
-		k = strings.ToLower(k)
-		k = strings.ReplaceAll(k, "-", "_")
-		k = fmt.Sprintf("%s.%s", prefix, k)
-		return attribute.Key(k)
-	}
-
-	attrs := make([]attribute.KeyValue, 0, len(h))
-	for k, v := range h {
-		attrs = append(attrs, key(k).StringSlice(v))
-	}
-	return attrs
 }
 
 // ClientStatus returns a span status code and message for an HTTP status code

--- a/internal/shared/semconvutil/httpconv_test.go.tmpl
+++ b/internal/shared/semconvutil/httpconv_test.go.tmpl
@@ -290,32 +290,6 @@ func TestFirstHostPort(t *testing.T) {
 	}
 }
 
-func TestHTTPRequestHeader(t *testing.T) {
-	ips := []string{"127.0.0.5", "127.0.0.9"}
-	user := []string{"alice"}
-	h := http.Header{"ips": ips, "user": user}
-
-	got := HTTPRequestHeader(h)
-	assert.Equal(t, 2, cap(got), "slice capacity")
-	assert.ElementsMatch(t, []attribute.KeyValue{
-		attribute.StringSlice("http.request.header.ips", ips),
-		attribute.StringSlice("http.request.header.user", user),
-	}, got)
-}
-
-func TestHTTPReponseHeader(t *testing.T) {
-	ips := []string{"127.0.0.5", "127.0.0.9"}
-	user := []string{"alice"}
-	h := http.Header{"ips": ips, "user": user}
-
-	got := HTTPResponseHeader(h)
-	assert.Equal(t, 2, cap(got), "slice capacity")
-	assert.ElementsMatch(t, []attribute.KeyValue{
-		attribute.StringSlice("http.response.header.ips", ips),
-		attribute.StringSlice("http.response.header.user", user),
-	}, got)
-}
-
 func TestHTTPClientStatus(t *testing.T) {
 	tests := []struct {
 		code int

--- a/internal/shared/semconvutil/netconv.go.tmpl
+++ b/internal/shared/semconvutil/netconv.go.tmpl
@@ -32,24 +32,6 @@ func NetTransport(network string) attribute.KeyValue {
 	return nc.Transport(network)
 }
 
-// NetClient returns trace attributes for a client network connection to address.
-// See net.Dial for information about acceptable address values, address should
-// be the same as the one used to create conn. If conn is nil, only network
-// peer attributes will be returned that describe address. Otherwise, the
-// socket level information about conn will also be included.
-func NetClient(address string, conn net.Conn) []attribute.KeyValue {
-	return nc.Client(address, conn)
-}
-
-// NetServer returns trace attributes for a network listener listening at address.
-// See net.Listen for information about acceptable address values, address
-// should be the same as the one used to create ln. If ln is nil, only network
-// host attributes will be returned that describe address. Otherwise, the
-// socket level information about ln will also be included.
-func NetServer(address string, ln net.Listener) []attribute.KeyValue {
-	return nc.Server(address, ln)
-}
-
 // netConv are the network semantic convention attributes defined for a version
 // of the OpenTelemetry specification.
 type netConv struct {
@@ -125,137 +107,12 @@ func (c *netConv) Host(address string) []attribute.KeyValue {
 	return attrs
 }
 
-// Server returns attributes for a network listener listening at address. See
-// net.Listen for information about acceptable address values, address should
-// be the same as the one used to create ln. If ln is nil, only network host
-// attributes will be returned that describe address. Otherwise, the socket
-// level information about ln will also be included.
-func (c *netConv) Server(address string, ln net.Listener) []attribute.KeyValue {
-	if ln == nil {
-		return c.Host(address)
-	}
-
-	lAddr := ln.Addr()
-	if lAddr == nil {
-		return c.Host(address)
-	}
-
-	hostName, hostPort := splitHostPort(address)
-	sockHostAddr, sockHostPort := splitHostPort(lAddr.String())
-	network := lAddr.Network()
-	sockFamily := family(network, sockHostAddr)
-
-	n := nonZeroStr(hostName, network, sockHostAddr, sockFamily)
-	n += positiveInt(hostPort, sockHostPort)
-	attr := make([]attribute.KeyValue, 0, n)
-	if hostName != "" {
-		attr = append(attr, c.HostName(hostName))
-		if hostPort > 0 {
-			// Only if net.host.name is set should net.host.port be.
-			attr = append(attr, c.HostPort(hostPort))
-		}
-	}
-	if network != "" {
-		attr = append(attr, c.Transport(network))
-	}
-	if sockFamily != "" {
-		attr = append(attr, c.NetSockFamilyKey.String(sockFamily))
-	}
-	if sockHostAddr != "" {
-		attr = append(attr, c.NetSockHostAddrKey.String(sockHostAddr))
-		if sockHostPort > 0 {
-			// Only if net.sock.host.addr is set should net.sock.host.port be.
-			attr = append(attr, c.NetSockHostPortKey.Int(sockHostPort))
-		}
-	}
-	return attr
-}
-
 func (c *netConv) HostName(name string) attribute.KeyValue {
 	return c.NetHostNameKey.String(name)
 }
 
 func (c *netConv) HostPort(port int) attribute.KeyValue {
 	return c.NetHostPortKey.Int(port)
-}
-
-// Client returns attributes for a client network connection to address. See
-// net.Dial for information about acceptable address values, address should be
-// the same as the one used to create conn. If conn is nil, only network peer
-// attributes will be returned that describe address. Otherwise, the socket
-// level information about conn will also be included.
-func (c *netConv) Client(address string, conn net.Conn) []attribute.KeyValue {
-	if conn == nil {
-		return c.Peer(address)
-	}
-
-	lAddr, rAddr := conn.LocalAddr(), conn.RemoteAddr()
-
-	var network string
-	switch {
-	case lAddr != nil:
-		network = lAddr.Network()
-	case rAddr != nil:
-		network = rAddr.Network()
-	default:
-		return c.Peer(address)
-	}
-
-	peerName, peerPort := splitHostPort(address)
-	var (
-		sockFamily   string
-		sockPeerAddr string
-		sockPeerPort int
-		sockHostAddr string
-		sockHostPort int
-	)
-
-	if lAddr != nil {
-		sockHostAddr, sockHostPort = splitHostPort(lAddr.String())
-	}
-
-	if rAddr != nil {
-		sockPeerAddr, sockPeerPort = splitHostPort(rAddr.String())
-	}
-
-	switch {
-	case sockHostAddr != "":
-		sockFamily = family(network, sockHostAddr)
-	case sockPeerAddr != "":
-		sockFamily = family(network, sockPeerAddr)
-	}
-
-	n := nonZeroStr(peerName, network, sockPeerAddr, sockHostAddr, sockFamily)
-	n += positiveInt(peerPort, sockPeerPort, sockHostPort)
-	attr := make([]attribute.KeyValue, 0, n)
-	if peerName != "" {
-		attr = append(attr, c.PeerName(peerName))
-		if peerPort > 0 {
-			// Only if net.peer.name is set should net.peer.port be.
-			attr = append(attr, c.PeerPort(peerPort))
-		}
-	}
-	if network != "" {
-		attr = append(attr, c.Transport(network))
-	}
-	if sockFamily != "" {
-		attr = append(attr, c.NetSockFamilyKey.String(sockFamily))
-	}
-	if sockPeerAddr != "" {
-		attr = append(attr, c.NetSockPeerAddrKey.String(sockPeerAddr))
-		if sockPeerPort > 0 {
-			// Only if net.sock.peer.addr is set should net.sock.peer.port be.
-			attr = append(attr, c.NetSockPeerPortKey.Int(sockPeerPort))
-		}
-	}
-	if sockHostAddr != "" {
-		attr = append(attr, c.NetSockHostAddrKey.String(sockHostAddr))
-		if sockHostPort > 0 {
-			// Only if net.sock.host.addr is set should net.sock.host.port be.
-			attr = append(attr, c.NetSockHostPortKey.Int(sockHostPort))
-		}
-	}
-	return attr
 }
 
 func family(network, address string) string {
@@ -271,26 +128,6 @@ func family(network, address string) string {
 		}
 	}
 	return ""
-}
-
-func nonZeroStr(strs ...string) int {
-	var n int
-	for _, str := range strs {
-		if str != "" {
-			n++
-		}
-	}
-	return n
-}
-
-func positiveInt(ints ...int) int {
-	var n int
-	for _, i := range ints {
-		if i > 0 {
-			n++
-		}
-	}
-	return n
 }
 
 // Peer returns attributes for a network peer address.

--- a/internal/shared/semconvutil/netconv_test.go.tmpl
+++ b/internal/shared/semconvutil/netconv_test.go.tmpl
@@ -17,12 +17,9 @@
 package semconvutil
 
 import (
-	"net"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel/attribute"
 )
@@ -54,53 +51,6 @@ func TestNetTransport(t *testing.T) {
 	}
 }
 
-func TestNetServerNilListener(t *testing.T) {
-	const addr = "127.0.0.1:8080"
-	got := NetServer(addr, nil)
-	expected := nc.Host(addr)
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-type listener struct{ net.Listener }
-
-func (listener) Addr() net.Addr { return nil }
-
-func TestNetServerNilAddr(t *testing.T) {
-	const addr = "127.0.0.1:8080"
-	got := NetServer(addr, listener{})
-	expected := nc.Host(addr)
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-func newTCPListener() (net.Listener, error) {
-	return net.Listen("tcp4", "127.0.0.1:0")
-}
-
-func TestNetServerTCP(t *testing.T) {
-	ln, err := newTCPListener()
-	require.NoError(t, err)
-	defer func() { require.NoError(t, ln.Close()) }()
-
-	host, pStr, err := net.SplitHostPort(ln.Addr().String())
-	require.NoError(t, err)
-	port, err := strconv.Atoi(pStr)
-	require.NoError(t, err)
-
-	got := NetServer("example.com:8080", ln)
-	expected := []attribute.KeyValue{
-		nc.HostName("example.com"),
-		nc.HostPort(8080),
-		nc.NetTransportTCP,
-		nc.NetSockFamilyKey.String("inet"),
-		nc.NetSockHostAddrKey.String(host),
-		nc.NetSockHostPortKey.Int(port),
-	}
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
 func TestNetHost(t *testing.T) {
 	testAddrs(t, []addrTest{
 		{address: "", expected: nil},
@@ -122,103 +72,6 @@ func TestNetHostName(t *testing.T) {
 func TestNetHostPort(t *testing.T) {
 	expected := attribute.Key("net.host.port").Int(port)
 	assert.Equal(t, expected, nc.HostPort(port))
-}
-
-func TestNetClientNilConn(t *testing.T) {
-	const addr = "127.0.0.1:8080"
-	got := NetClient(addr, nil)
-	expected := nc.Peer(addr)
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-type conn struct{ net.Conn }
-
-func (conn) LocalAddr() net.Addr  { return nil }
-func (conn) RemoteAddr() net.Addr { return nil }
-
-func TestNetClientNilAddr(t *testing.T) {
-	const addr = "127.0.0.1:8080"
-	got := NetClient(addr, conn{})
-	expected := nc.Peer(addr)
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-func newTCPConn() (net.Conn, net.Listener, error) {
-	ln, err := newTCPListener()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	conn, err := net.Dial("tcp4", ln.Addr().String())
-	if err != nil {
-		_ = ln.Close()
-		return nil, nil, err
-	}
-
-	return conn, ln, nil
-}
-
-func TestNetClientTCP(t *testing.T) {
-	conn, ln, err := newTCPConn()
-	require.NoError(t, err)
-	defer func() { require.NoError(t, ln.Close()) }()
-	defer func() { require.NoError(t, conn.Close()) }()
-
-	lHost, pStr, err := net.SplitHostPort(conn.LocalAddr().String())
-	require.NoError(t, err)
-	lPort, err := strconv.Atoi(pStr)
-	require.NoError(t, err)
-
-	rHost, pStr, err := net.SplitHostPort(conn.RemoteAddr().String())
-	require.NoError(t, err)
-	rPort, err := strconv.Atoi(pStr)
-	require.NoError(t, err)
-
-	got := NetClient("example.com:8080", conn)
-	expected := []attribute.KeyValue{
-		nc.PeerName("example.com"),
-		nc.PeerPort(8080),
-		nc.NetTransportTCP,
-		nc.NetSockFamilyKey.String("inet"),
-		nc.NetSockPeerAddrKey.String(rHost),
-		nc.NetSockPeerPortKey.Int(rPort),
-		nc.NetSockHostAddrKey.String(lHost),
-		nc.NetSockHostPortKey.Int(lPort),
-	}
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
-}
-
-type remoteOnlyConn struct{ net.Conn }
-
-func (remoteOnlyConn) LocalAddr() net.Addr { return nil }
-
-func TestNetClientTCPNilLocal(t *testing.T) {
-	conn, ln, err := newTCPConn()
-	require.NoError(t, err)
-	defer func() { require.NoError(t, ln.Close()) }()
-	defer func() { require.NoError(t, conn.Close()) }()
-
-	conn = remoteOnlyConn{conn}
-
-	rHost, pStr, err := net.SplitHostPort(conn.RemoteAddr().String())
-	require.NoError(t, err)
-	rPort, err := strconv.Atoi(pStr)
-	require.NoError(t, err)
-
-	got := NetClient("example.com:8080", conn)
-	expected := []attribute.KeyValue{
-		nc.PeerName("example.com"),
-		nc.PeerPort(8080),
-		nc.NetTransportTCP,
-		nc.NetSockFamilyKey.String("inet"),
-		nc.NetSockPeerAddrKey.String(rHost),
-		nc.NetSockPeerPortKey.Int(rPort),
-	}
-	assert.Equal(t, cap(expected), cap(got), "slice capacity")
-	assert.ElementsMatch(t, expected, got)
 }
 
 func TestNetPeer(t *testing.T) {


### PR DESCRIPTION
Now that the semconvutil package is templated and internal (not shared), we are free to remove any code that isn't used by any of our telemetry without breaking on update.

This code removes A number of public functions, tests of these functions, and supporting code that are not used by any of our instrumentation.
- `HTTPRequestHeader`
- `HTTPResponseHeader`
- `NetClient`
- `NetServer`