### PR TITLE
chore: update jaeger remote sampler example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
-- Updated jaeger version in `go.opentelemetry.io/contrib/samplers/jaegerremote/example` example. (#4892)
+- Updated otel-collector from `otel/openteleemtry-collector` to `otel/opentelemetry-collector-contrib` in `go.opentelemetry.io/contrib/samplers/jaegerremote/example` example. (#4892)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add client metric support to `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp`. (#4707)
 - Add peer attributes to spans recorded by `NewClientHandler`, `NewServerHandler` in `go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc`. (#4873)
 
+### Changed
+
+- Updated jaeger version in `go.opentelemetry.io/contrib/samplers/jaegerremote/example` example. (#4892)
+
 ### Deprecated
 
 - The `RequestCount`, `RequestContentLength`, `ResponseContentLength`, `ServerLatency` constants in `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp` are deprecated. (#4707)

--- a/samplers/jaegerremote/example/docker-compose.yaml
+++ b/samplers/jaegerremote/example/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3"
 services:
 
   otel-collector:
-    image: otel/opentelemetry-collector:latest
+    image: otel/opentelemetry-collector-contrib:latest
     command: [ "--config=/etc/otel-collector.yaml" ]
     volumes:
       - ./otel-collector.yaml:/etc/otel-collector.yaml

--- a/samplers/jaegerremote/example/go.mod
+++ b/samplers/jaegerremote/example/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/davecgh/go-spew v1.1.1
+	github.com/go-logr/stdr v1.2.2
 	go.opentelemetry.io/contrib/samplers/jaegerremote v0.16.0
 	go.opentelemetry.io/otel v1.22.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.22.0
@@ -12,7 +13,6 @@ require (
 
 require (
 	github.com/go-logr/logr v1.4.1 // indirect
-	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	go.opentelemetry.io/otel/metric v1.22.0 // indirect
 	go.opentelemetry.io/otel/trace v1.22.0 // indirect

--- a/samplers/jaegerremote/example/main.go
+++ b/samplers/jaegerremote/example/main.go
@@ -33,7 +33,7 @@ func main() {
 	// Optional: an implementation of logr.Logger used for demo purposes to catch potential error logs
 	logger := stdr.NewWithOptions(stdlog.New(os.Stderr, "", stdlog.LstdFlags), stdr.Options{LogCaller: stdr.All})
 
-	samplingRefreshInterval := 1 * time.Minute
+	samplingRefreshInterval := 10 * time.Second
 	jaegerRemoteSampler := jaegerremote.New(
 		"foo",
 		jaegerremote.WithSamplingServerURL("http://localhost:5778/sampling"),

--- a/samplers/jaegerremote/example/otel-collector.yaml
+++ b/samplers/jaegerremote/example/otel-collector.yaml
@@ -1,17 +1,25 @@
 receivers:
-  jaeger:
+  otlp:
     protocols:
       grpc:
-    remote_sampling:
-      host_endpoint: "0.0.0.0:5778" # default port
-      insecure: true
-      strategy_file: "/etc/strategies.json"
+      http:
+
+processors:
+  batch:
 
 exporters:
-  logging:
+  debug:
+
+extensions:
+  jaegerremotesampling:
+    source:
+      reload_interval: 30s
+      file: "/etc/strategies.json"
 
 service:
+  extensions: [jaegerremotesampling]
   pipelines:
     traces:
-      receivers: [ jaeger ]
-      exporters: [ logging ]
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]


### PR DESCRIPTION
chore: update jaeger remote sampler example using the latest otelcol-contrib extension

Previously, the example was outdated and not working properly. This commit updates the example provided using otelcol-contrib jaegerremotesampling extension.