### PR TITLE
Add span start end end options to gin configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Add the new `go.opentelemetry.io/contrib/instrgen` package to provide auto-generated source code instrumentation. (#3068, #3108)
+- Add `WithSpanStartOption` and `WithSpanEndOption` to the `go.opentelemetry.io/contrib/github.com/gin-gonic/gin` package to provide options on span start and end. (#5250)
 
 ### Removed
 

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/option.go
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/option.go
@@ -17,6 +17,8 @@ type config struct {
 	Propagators       propagation.TextMapPropagator
 	Filters           []Filter
 	SpanNameFormatter SpanNameFormatter
+	SpanStartOptions  []oteltrace.SpanStartOption
+	SpanEndOptions    []oteltrace.SpanEndOption
 }
 
 // Filter is a predicate used to determine whether a given http.request should
@@ -75,5 +77,21 @@ func WithFilter(f ...Filter) Option {
 func WithSpanNameFormatter(f func(r *http.Request) string) Option {
 	return optionFunc(func(c *config) {
 		c.SpanNameFormatter = f
+	})
+}
+
+// WithSpanStartOption applies options to all the HTTP span created by the
+// instrumentation.
+func WithSpanStartOption(o ...oteltrace.SpanStartOption) Option {
+	return optionFunc(func(c *config) {
+		c.SpanStartOptions = append(c.SpanStartOptions, o...)
+	})
+}
+
+// WithSpanEndOption applies options when ending the HTTP span created by the
+// instrumentation.
+func WithSpanEndOption(o ...oteltrace.SpanEndOption) Option {
+	return optionFunc(func(c *config) {
+		c.SpanEndOptions = append(c.SpanEndOptions, o...)
 	})
 }

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/test/gintrace_test.go
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/test/gintrace_test.go
@@ -25,7 +25,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"go.opentelemetry.io/otel/attribute"
-	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 func init() {
@@ -86,7 +85,7 @@ func TestTrace200(t *testing.T) {
 	require.Len(t, spans, 1)
 	span := spans[0]
 	assert.Equal(t, "/user/:id", span.Name())
-	assert.Equal(t, oteltrace.SpanKindServer, span.SpanKind())
+	assert.Equal(t, trace.SpanKindServer, span.SpanKind())
 	attr := span.Attributes()
 	assert.Contains(t, attr, attribute.String("net.host.name", "foobar"))
 	assert.Contains(t, attr, attribute.Int("http.status_code", http.StatusOK))


### PR DESCRIPTION
This allows setting span start and end options to the gin configuration, so folks can (for example), enable stack traces to recorded errors.