### PR TITLE
otelgrpc: histogram buckets

### DIFF
--- a/instrumentation/google.golang.org/grpc/otelgrpc/config.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/config.go
@@ -39,6 +39,12 @@ type config struct {
 	tracer trace.Tracer
 	meter  metric.Meter
 
+	rpcDurationAdditionalOptions        []metric.Float64HistogramOption
+	rpcRequestSizeAdditionalOptions     []metric.Int64HistogramOption
+	rpcResponseSizeAdditionalOptions    []metric.Int64HistogramOption
+	rpcRequestsPerRPCAdditionalOptions  []metric.Int64HistogramOption
+	rpcResponsesPerRPCAdditionalOptions []metric.Int64HistogramOption
+
 	rpcDuration        metric.Float64Histogram
 	rpcRequestSize     metric.Int64Histogram
 	rpcResponseSize    metric.Int64Histogram
@@ -75,8 +81,11 @@ func newConfig(opts []Option, role string) *config {
 
 	var err error
 	c.rpcDuration, err = c.meter.Float64Histogram("rpc."+role+".duration",
-		metric.WithDescription("Measures the duration of inbound RPC."),
-		metric.WithUnit("ms"))
+		append([]metric.Float64HistogramOption{
+			metric.WithDescription("Measures the duration of inbound RPC."),
+			metric.WithUnit("ms"),
+		}, c.rpcDurationAdditionalOptions...)...,
+	)
 	if err != nil {
 		otel.Handle(err)
 		if c.rpcDuration == nil {
@@ -85,8 +94,10 @@ func newConfig(opts []Option, role string) *config {
 	}
 
 	c.rpcRequestSize, err = c.meter.Int64Histogram("rpc."+role+".request.size",
-		metric.WithDescription("Measures size of RPC request messages (uncompressed)."),
-		metric.WithUnit("By"))
+		append([]metric.Int64HistogramOption{
+			metric.WithDescription("Measures size of RPC request messages (uncompressed)."),
+			metric.WithUnit("By"),
+		}, c.rpcRequestSizeAdditionalOptions...)...)
 	if err != nil {
 		otel.Handle(err)
 		if c.rpcRequestSize == nil {
@@ -95,8 +106,10 @@ func newConfig(opts []Option, role string) *config {
 	}
 
 	c.rpcResponseSize, err = c.meter.Int64Histogram("rpc."+role+".response.size",
-		metric.WithDescription("Measures size of RPC response messages (uncompressed)."),
-		metric.WithUnit("By"))
+		append([]metric.Int64HistogramOption{
+			metric.WithDescription("Measures size of RPC response messages (uncompressed)."),
+			metric.WithUnit("By"),
+		}, c.rpcResponseSizeAdditionalOptions...)...)
 	if err != nil {
 		otel.Handle(err)
 		if c.rpcResponseSize == nil {
@@ -105,8 +118,10 @@ func newConfig(opts []Option, role string) *config {
 	}
 
 	c.rpcRequestsPerRPC, err = c.meter.Int64Histogram("rpc."+role+".requests_per_rpc",
-		metric.WithDescription("Measures the number of messages received per RPC. Should be 1 for all non-streaming RPCs."),
-		metric.WithUnit("{count}"))
+		append([]metric.Int64HistogramOption{
+			metric.WithDescription("Measures the number of messages received per RPC. Should be 1 for all non-streaming RPCs."),
+			metric.WithUnit("{count}"),
+		}, c.rpcRequestsPerRPCAdditionalOptions...)...)
 	if err != nil {
 		otel.Handle(err)
 		if c.rpcRequestsPerRPC == nil {
@@ -115,8 +130,10 @@ func newConfig(opts []Option, role string) *config {
 	}
 
 	c.rpcResponsesPerRPC, err = c.meter.Int64Histogram("rpc."+role+".responses_per_rpc",
-		metric.WithDescription("Measures the number of messages received per RPC. Should be 1 for all non-streaming RPCs."),
-		metric.WithUnit("{count}"))
+		append([]metric.Int64HistogramOption{
+			metric.WithDescription("Measures the number of messages received per RPC. Should be 1 for all non-streaming RPCs."),
+			metric.WithUnit("{count}"),
+		}, c.rpcResponsesPerRPCAdditionalOptions...)...)
 	if err != nil {
 		otel.Handle(err)
 		if c.rpcResponsesPerRPC == nil {
@@ -231,4 +248,64 @@ func (o spanStartOption) apply(c *config) {
 // trace.SpanOptions, which are applied to each new span.
 func WithSpanOptions(opts ...trace.SpanStartOption) Option {
 	return spanStartOption{opts}
+}
+
+// WithRPCDurationBucketBoundaries configures the
+// RPC duration histogram bucket boundaries.
+func WithRPCDurationBucketBoundaries(boundaries []float64) Option {
+	return rpcDurationBucketBoundaries(boundaries)
+}
+
+type rpcDurationBucketBoundaries []float64
+
+func (o rpcDurationBucketBoundaries) apply(c *config) {
+	c.rpcDurationAdditionalOptions = append(c.rpcDurationAdditionalOptions, metric.WithExplicitBucketBoundaries(o...))
+}
+
+// WithRPCRequestSizeBucketBoundaries configures the
+// RPC request size histogram bucket boundaries.
+func WithRPCRequestSizeBucketBoundaries(boundaries []float64) Option {
+	return rpcRequestSizeBucketBoundaries(boundaries)
+}
+
+type rpcRequestSizeBucketBoundaries []float64
+
+func (o rpcRequestSizeBucketBoundaries) apply(c *config) {
+	c.rpcRequestSizeAdditionalOptions = append(c.rpcRequestSizeAdditionalOptions, metric.WithExplicitBucketBoundaries(o...))
+}
+
+// WithRPCResponseSizeBucketBoundaries configures the
+// RPC response size histogram bucket boundaries.
+func WithRPCResponseSizeBucketBoundaries(boundaries []float64) Option {
+	return rpcResponseSizeBucketBoundaries(boundaries)
+}
+
+type rpcResponseSizeBucketBoundaries []float64
+
+func (o rpcResponseSizeBucketBoundaries) apply(c *config) {
+	c.rpcResponseSizeAdditionalOptions = append(c.rpcResponseSizeAdditionalOptions, metric.WithExplicitBucketBoundaries(o...))
+}
+
+// WithRPCRequestsPerRPCBucketBoundaries configures the
+// RPC requests per RPC histogram bucket boundaries.
+func WithRPCRequestsPerRPCBucketBoundaries(boundaries []float64) Option {
+	return rpcRequestsPerRPCBucketBoundaries(boundaries)
+}
+
+type rpcRequestsPerRPCBucketBoundaries []float64
+
+func (o rpcRequestsPerRPCBucketBoundaries) apply(c *config) {
+	c.rpcRequestsPerRPCAdditionalOptions = append(c.rpcRequestsPerRPCAdditionalOptions, metric.WithExplicitBucketBoundaries(o...))
+}
+
+// WithRPCResponsesPerRPCBucketBoundaries configures the
+// RPC responses per RPC histogram bucket boundaries.
+func WithRPCResponsesPerRPCBucketBoundaries(boundaries []float64) Option {
+	return rpcResponsesPerRPCBucketBoundaries(boundaries)
+}
+
+type rpcResponsesPerRPCBucketBoundaries []float64
+
+func (o rpcResponsesPerRPCBucketBoundaries) apply(c *config) {
+	c.rpcResponsesPerRPCAdditionalOptions = append(c.rpcResponsesPerRPCAdditionalOptions, metric.WithExplicitBucketBoundaries(o...))
 }


### PR DESCRIPTION
This allows package clients to explicitly specify bucket boundaries.