### PR TITLE
Refactor span formatter function to use a html template to generate autoescaped HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Add the new `go.opentelemetry.io/contrib/instrgen` package to provide auto-generated source code instrumentation. (#3068, #3108)
+- Add a new package `go.opentelemetry.io/contrib/zpages/internal` to enable the use of internal.Templates within the parseTemplate function.
+- Refactored the spanRowFormatter function to utilize HTML templates for auto-escaping HTML, ensuring protection against Cross-site Scripting (XSS) vulnerabilities. (#4451)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Add the new `go.opentelemetry.io/contrib/instrgen` package to provide auto-generated source code instrumentation. (#3068, #3108)
-- Add a new package `go.opentelemetry.io/contrib/zpages/internal` to enable the use of internal.Templates within the parseTemplate function.
-- Refactored the spanRowFormatter function to utilize HTML templates for auto-escaping HTML, ensuring protection against Cross-site Scripting (XSS) vulnerabilities. (#4451)
+
+### Fixed
+
+- Improved the spanRowFormatter function by using HTML templates that automatically handle HTML escaping. This change strengthens security against Cross-Site Scripting (XSS) vulnerabilities. (Issue #4451)
 
 ### Removed
 

--- a/zpages/templates.go
+++ b/zpages/templates.go
@@ -61,7 +61,6 @@ func parseTemplate(name string) *template.Template {
 	return template.Must(template.New(name).Funcs(templateFunctions).Parse(string(text)))
 }
 
-//nolint:gosec // G203: The used method does not auto-escape HTML. Tracked under https://github.com/open-telemetry/opentelemetry-go-contrib/issues/4451.
 func spanRowFormatter(r spanRow) template.HTML {
 	if !r.SpanContext.IsValid() {
 		return ""

--- a/zpages/templates.go
+++ b/zpages/templates.go
@@ -73,17 +73,17 @@ func spanRowFormatter(r spanRow) template.HTML {
 	var tpl string
 
 	if r.ParentSpanContext.IsValid() {
-		tpl = fmt.Sprintf(`trace_id: <b style="color:%s">%s</b> span_id: %s parent_span_id: %s`, col, r.SpanContext.TraceID(), r.SpanContext.SpanID(), r.ParentSpanContext.SpanID())
+		tpl = fmt.Sprintf(`trace_id: <b style="color:%s">%s</b> span_id: %s parent_span_id: %s`, col, template.HTMLEscapeString(r.SpanContext.TraceID().String()), template.HTMLEscapeString(r.SpanContext.SpanID().String()), template.HTMLEscapeString(r.ParentSpanContext.SpanID().String()))
 	} else {
-		tpl = fmt.Sprintf(`trace_id: <b style="color:%s">%s</b> span_id: %s `, col, r.SpanContext.TraceID(), r.SpanContext.SpanID())
+		tpl = fmt.Sprintf(`trace_id: <b style="color:%s">%s</b> span_id: %s `, col, template.HTMLEscapeString(r.SpanContext.TraceID().String()), template.HTMLEscapeString(r.SpanContext.SpanID().String()))
 	}
 
 	t := template.Must(template.New("spanRow").Parse(tpl))
 	var buf bytes.Buffer
 	if err := t.Execute(&buf, nil); err != nil {
-		return template.HTML(fmt.Sprintf("Error executing template: %v", err))
+		return template.HTML(template.HTMLEscapeString(fmt.Sprintf("Error executing template: %s", err.Error())))
 	}
-	return template.HTML(buf.String())
+	return template.HTML(template.HTMLEscapeString(buf.String()))
 }
 
 func even(x int) bool {


### PR DESCRIPTION
- Refactored the spanRowFormatter function to utilize HTML templates for auto-escaping HTML, ensuring protection against Cross-site Scripting (XSS) vulnerabilities. under issue#4451. https://github.com/open-telemetry/opentelemetry-go-contrib/issues/4451
