### PR TITLE
Rename  "runtime.uptime" metric from instrumentation/runtime package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add the new `go.opentelemetry.io/contrib/instrgen` package to provide auto-generated source code instrumentation. (#3068, #3108)
 
 ### Changed
-- Renamed `runtime.uptime` in `/instrumentation/runtime/runtime.go` to `process.runtime.uptime` (#2625)
+- Rename metric `runtime.uptime` in `go.opentelemetry.io/contrib/runtime` to `process.runtime.uptime`. (#5293)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Add the new `go.opentelemetry.io/contrib/instrgen` package to provide auto-generated source code instrumentation. (#3068, #3108)
 
+### Changed
+- Renamed `runtime.uptime` in `/instrumentation/runtime/runtime.go` to `process.runtime.uptime` (#2625)
+
 ### Removed
 
 - Drop support for [Go 1.20]. (#5163)

--- a/instrumentation/runtime/runtime.go
+++ b/instrumentation/runtime/runtime.go
@@ -109,7 +109,7 @@ func Start(opts ...Option) error {
 func (r *runtime) register() error {
 	startTime := time.Now()
 	uptime, err := r.meter.Int64ObservableCounter(
-		"runtime.uptime",
+		"process.runtime.uptime",
 		metric.WithUnit("ms"),
 		metric.WithDescription("Milliseconds since application was initialized"),
 	)


### PR DESCRIPTION
Renamed `runtime.uptime` in `/instrumentation/runtime/runtime.go` to `process.runtime.uptime` (#2625)
