### PR TITLE
Create a new metric `process.runtime.uptime` and deprecate `runtime.uptime` metric  in `instrumentation/runtime/runtime.go`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add the new `go.opentelemetry.io/contrib/instrgen` package to provide auto-generated source code instrumentation. (#3068, #3108)
 
 ### Changed
-- Changed `runtime.uptime` from an asynchronous counter to an asynchronous gauge
+- Changed `runtime.uptime` from an asynchronous counter to an asynchronous gauge (#1341)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Add the new `go.opentelemetry.io/contrib/instrgen` package to provide auto-generated source code instrumentation. (#3068, #3108)
+- Add a new metric `process.runtime.uptime` that uses an asynchronous gauge function (#5293, #5294) 
 
-### Changed
-- Changed `runtime.uptime` from an asynchronous counter to an asynchronous gauge (#1341)
+### Deprecated
+
+- The `runtime.uptime` metric in `instrumentation/runtime/runtime.go` is deprecated(#5293, #5294)
+
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Add the new `go.opentelemetry.io/contrib/instrgen` package to provide auto-generated source code instrumentation. (#3068, #3108)
 
+### Changed
+- Changed `runtime.uptime` from an asynchronous counter to an asynchronous gauge
+
 ### Removed
 
 - Drop support for [Go 1.20]. (#5163)

--- a/instrumentation/runtime/runtime.go
+++ b/instrumentation/runtime/runtime.go
@@ -108,7 +108,7 @@ func Start(opts ...Option) error {
 
 func (r *runtime) register() error {
 	startTime := time.Now()
-	uptime, err := r.meter.Int64ObservableCounter(
+	uptime, err := r.meter.Int64ObservableGauge(
 		"runtime.uptime",
 		metric.WithUnit("ms"),
 		metric.WithDescription("Milliseconds since application was initialized"),

--- a/instrumentation/runtime/runtime.go
+++ b/instrumentation/runtime/runtime.go
@@ -108,8 +108,18 @@ func Start(opts ...Option) error {
 
 func (r *runtime) register() error {
 	startTime := time.Now()
-	uptime, err := r.meter.Int64ObservableGauge(
+	// DEPRECATED: This metric is deprecated in favor of processUptime
+	uptime, err := r.meter.Int64ObservableCounter(
 		"runtime.uptime",
+		metric.WithUnit("ms"),
+		metric.WithDescription("Milliseconds since application was initialized"),
+	)
+	if err != nil {
+		return err
+	}
+
+	processUptime, err := r.meter.Int64ObservableGauge(
+		"process.runtime.uptime",
 		metric.WithUnit("ms"),
 		metric.WithDescription("Milliseconds since application was initialized"),
 	)
@@ -136,10 +146,12 @@ func (r *runtime) register() error {
 	_, err = r.meter.RegisterCallback(
 		func(ctx context.Context, o metric.Observer) error {
 			o.ObserveInt64(uptime, time.Since(startTime).Milliseconds())
+			o.ObserveInt64(processUptime, time.Since(startTime).Milliseconds())
 			o.ObserveInt64(goroutines, int64(goruntime.NumGoroutine()))
 			o.ObserveInt64(cgoCalls, goruntime.NumCgoCall())
 			return nil
 		},
+		processUptime,
 		uptime,
 		goroutines,
 		cgoCalls,


### PR DESCRIPTION
Created a new metric `process.runtime.uptime` and deprecated `runtime.uptime` metric  in `instrumentation/runtime/runtime.go` (#5293, #5294)

process.runtime.uptime is now an asynchronous gauge function