### PR TITLE
Test spanRowFormatter, and mark the gosec issue as a false-positive

### DIFF
--- a/zpages/templates.go
+++ b/zpages/templates.go
@@ -60,7 +60,6 @@ func parseTemplate(name string) *template.Template {
 	return template.Must(template.New(name).Funcs(templateFunctions).Parse(string(text)))
 }
 
-//nolint:gosec // G203: The used method does not auto-escape HTML. Tracked under https://github.com/open-telemetry/opentelemetry-go-contrib/issues/4451.
 func spanRowFormatter(r spanRow) template.HTML {
 	if !r.SpanContext.IsValid() {
 		return ""
@@ -69,10 +68,19 @@ func spanRowFormatter(r spanRow) template.HTML {
 	if r.SpanContext.IsSampled() {
 		col = "blue"
 	}
+
+	tpl := fmt.Sprintf(
+		`trace_id: <b style="color:%s">%s</b> span_id: %s`,
+		col,
+		r.SpanContext.TraceID(),
+		r.SpanContext.SpanID(),
+	)
 	if r.ParentSpanContext.IsValid() {
-		return template.HTML(fmt.Sprintf(`trace_id: <b style="color:%s">%s</b> span_id: %s parent_span_id: %s`, col, r.SpanContext.TraceID(), r.SpanContext.SpanID(), r.ParentSpanContext.SpanID()))
+		tpl += fmt.Sprintf(` parent_span_id: %s`, r.ParentSpanContext.SpanID())
 	}
-	return template.HTML(fmt.Sprintf(`trace_id: <b style="color:%s">%s</b> span_id: %s`, col, r.SpanContext.TraceID(), r.SpanContext.SpanID()))
+
+	//nolint:gosec // G203: HTML is escaped manually, so this lint issue is a false positive.
+	return template.HTML(tpl)
 }
 
 func even(x int) bool {

--- a/zpages/templates.go
+++ b/zpages/templates.go
@@ -79,7 +79,9 @@ func spanRowFormatter(r spanRow) template.HTML {
 		tpl += fmt.Sprintf(` parent_span_id: %s`, r.ParentSpanContext.SpanID())
 	}
 
-	//nolint:gosec // G203: HTML is escaped manually, so this lint issue is a false positive.
+	//nolint:gosec // G203: None of the dynamic attributes (TraceID/SpanID) can
+	// contain characters that need escaping so this lint issue is a false
+	// positive.
 	return template.HTML(tpl)
 }
 

--- a/zpages/templates_test.go
+++ b/zpages/templates_test.go
@@ -1,0 +1,59 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package zpages
+
+import (
+	"html/template"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestSpanRowFormatter(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		row  spanRow
+
+		expectedTemplate template.HTML
+	}{
+		{
+			name: "with an invalid span context",
+			row: spanRow{
+				SpanContext: trace.NewSpanContext(trace.SpanContextConfig{}),
+			},
+			expectedTemplate: "",
+		},
+		{
+			name: "with a valid span context",
+			row: spanRow{
+				SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
+					TraceID: trace.TraceID{2, 3, 4, 5, 6, 7, 8, 9, 2, 3, 4, 5, 6, 7, 8, 9},
+					SpanID:  trace.SpanID{1, 2, 3, 4, 5, 6, 7, 8},
+				}),
+			},
+			expectedTemplate: "trace_id: <b style=\"color:black\">02030405060708090203040506070809</b> span_id: 0102030405060708",
+		},
+		{
+			name: "with a valid parent span context",
+			row: spanRow{
+				SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
+					TraceID: trace.TraceID{2, 3, 4, 5, 6, 7, 8, 9, 2, 3, 4, 5, 6, 7, 8, 9},
+					SpanID:  trace.SpanID{1, 2, 3, 4, 5, 6, 7, 8},
+				}),
+				ParentSpanContext: trace.NewSpanContext(trace.SpanContextConfig{
+					TraceID: trace.TraceID{10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
+					SpanID:  trace.SpanID{10, 11, 12, 13, 14, 15, 16, 18},
+				}),
+			},
+			expectedTemplate: "trace_id: <b style=\"color:black\">02030405060708090203040506070809</b> span_id: 0102030405060708 parent_span_id: 0a0b0c0d0e0f1012",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			r := spanRowFormatter(tt.row)
+			assert.Equal(t, tt.expectedTemplate, r)
+		})
+	}
+}


### PR DESCRIPTION
Closes #4451

As mentioned in the other issue, I am not doing any escaping here.

* The HTML tags we already have there need not to be escaped, so they will be properly rendered in zpages.
* The Trace ID and Span ID are hexadecimal byte arrays. We decode them using [encoding/hex](https://pkg.go.dev/encoding/hex), which can only output `[0-9a-f]`, not any character that HTML should encode.