### PR TITLE
Add alpha release of otelslog to next release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Add the new `go.opentelemetry.io/contrib/instrgen` package to provide auto-generated source code instrumentation. (#3068, #3108)
-- The `go.opentelemetry.io/contrib/bridge/otelslog` module.
+- The `go.opentelemetry.io/contrib/bridges/otelslog` module.
   This module provides an OpenTelemetry logging bridge for "log/slog". (#5335)
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Add the new `go.opentelemetry.io/contrib/instrgen` package to provide auto-generated source code instrumentation. (#3068, #3108)
+- The `go.opentelemetry.io/contrib/bridge/otelslog` module.
+  This module provides an OpenTelemetry logging bridge for "log/slog". (#5335)
 
 ### Removed
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -74,8 +74,11 @@ module-sets:
     version: v0.4.0
     modules:
       - go.opentelemetry.io/contrib/config
+  experimental-bridge:
+    version: v0.0.1
+    modules:
+      - go.opentelemetry.io/contrib/bridges/slog
 excluded-modules:
-  - go.opentelemetry.io/contrib/bridges/slog
   - go.opentelemetry.io/contrib/instrgen
   - go.opentelemetry.io/contrib/instrgen/driver
   - go.opentelemetry.io/contrib/instrgen/testdata/interface

--- a/versions.yaml
+++ b/versions.yaml
@@ -77,7 +77,7 @@ module-sets:
   experimental-bridge:
     version: v0.0.1
     modules:
-      - go.opentelemetry.io/contrib/bridges/slog
+      - go.opentelemetry.io/contrib/bridges/otelslog
 excluded-modules:
   - go.opentelemetry.io/contrib/instrgen
   - go.opentelemetry.io/contrib/instrgen/driver


### PR DESCRIPTION
Closes #5138 

Add the new `otelslog` package as a new modset "experimental-bridge" to be release next at version `0.0.1`.