### PR TITLE
[WIP] Logger support in otelhttp

### DIFF
--- a/instrumentation/net/http/otelhttp/config.go
+++ b/instrumentation/net/http/otelhttp/config.go
@@ -5,6 +5,7 @@ package otelhttp // import "go.opentelemetry.io/contrib/instrumentation/net/http
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"net/http/httptrace"
 
@@ -21,6 +22,7 @@ const ScopeName = "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
 // and http.Transport types.
 type config struct {
 	ServerName        string
+	Logger            *slog.Logger
 	Tracer            trace.Tracer
 	Meter             metric.Meter
 	Propagators       propagation.TextMapPropagator
@@ -192,5 +194,12 @@ func WithClientTrace(f func(context.Context) *httptrace.ClientTrace) Option {
 func WithServerName(server string) Option {
 	return optionFunc(func(c *config) {
 		c.ServerName = server
+	})
+}
+
+// WithLogHandler returns an Option that configures the structured log Handler.
+func WithLogger(logger *slog.Logger) Option {
+	return optionFunc(func(c *config) {
+		c.Logger = logger
 	})
 }


### PR DESCRIPTION
### Problem Statement

The otelhttp middleware is an ideal place to log HTTP transactions, because important data are available, such as:

* HTTP status code
* Elapsed Time
* Bytes read and written

Now that the minimal Go version is 1.21, in which the package log/slog is part of the standard library,
a standard API is available to generate structured log records.

OpenTelemetry loggers can be used with the log/slog API via go.opentelemetry.io/contrib/bridges/otelslog.

### Proposed Solution

The middleware can optionally be configured with a *slog.Logger:
```
    mware := otelhttp.NewMiddleware(operation, otelhttp.WithLogger(logger))
```
If a Logger has been configured, a log record will be emitted with the same attributes as the Span:
```
{
  "time": "2024-04-05T15:42:16.926178547-07:00",
  "level": "INFO",
  "msg": "operation",
  "http.method": "GET",
  "http.scheme": "http",
  "net.host.name": "tonio.attlocal.net",
  "net.host.port": 8080,
  "net.protocol.name": "http",
  "net.protocol.version": "1.1",
  "http.status_code": 200, 
  "http.wrote_bytes": 3954,
  "http.server.duration": 4.426442,
}
```
