### PR TITLE
Fix bug where an empty exemplar was added to counters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add the new `go.opentelemetry.io/contrib/instrgen` package to provide auto-generated source code instrumentation. (#3068, #3108)
 - `NewSDK` in `go.opentelemetry.io/contrib/config` now returns a configured SDK with a valid `MeterProvider`. (#4804)
 
+### Fixed
+
+- Fix bug where an empty exemplar was added to counters in `go.opentelemetry.io/contrib/bridges/prometheus`. (#5395)
+- Fix bug where the last histogram bucket was missing in `go.opentelemetry.io/contrib/bridges/prometheus`. (#5395)
+
 ## [1.25.0/0.50.0/0.19.0/0.5.0/0.0.1] - 2024-04-05
 
 ### Added

--- a/bridges/prometheus/producer_test.go
+++ b/bridges/prometheus/producer_test.go
@@ -218,7 +218,7 @@ func TestProduce(t *testing.T) {
 								{
 									Count:        1,
 									Sum:          578.3,
-									Bounds:       prometheus.DefBuckets,
+									Bounds:       []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
 									BucketCounts: []uint64{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 									Attributes:   attribute.NewSet(attribute.String("foo", "bar")),
 									Exemplars:    []metricdata.Exemplar[float64]{},
@@ -262,7 +262,7 @@ func TestProduce(t *testing.T) {
 								{
 									Count:        1,
 									Sum:          578.3,
-									Bounds:       prometheus.DefBuckets,
+									Bounds:       []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
 									BucketCounts: []uint64{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 									Attributes:   attribute.NewSet(attribute.String("foo", "bar")),
 									Exemplars: []metricdata.Exemplar[float64]{


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go-contrib/issues/5383

I also found out that the +Inf bucket is only _sometimes_ added to the proto format: https://github.com/prometheus/client_golang/blob/d038ab96c0c7b9cd217a39072febd610bcdf1fd8/prometheus/metric.go#L189

That meant we were dropping the highest histogram bucket if users were not using exemplars.

@gouthamve 