### PR TITLE
HTTP Semconv migration Part2 Server - duplicate support

### DIFF
--- a/instrumentation/net/http/otelhttp/internal/semconv/dup.go
+++ b/instrumentation/net/http/otelhttp/internal/semconv/dup.go
@@ -1,0 +1,195 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semconv // import "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/internal/semconv"
+
+import (
+	"io"
+	"net/http"
+	"slices"
+	"strings"
+
+	"go.opentelemetry.io/otel/attribute"
+	semconvOld "go.opentelemetry.io/otel/semconv/v1.20.0"
+	semconvNew "go.opentelemetry.io/otel/semconv/v1.24.0"
+)
+
+type dupHTTPServer struct{}
+
+var _ HTTPServer = dupHTTPServer{}
+
+// TraceRequest returns trace attributes for an HTTP request received by a
+// server.
+//
+// The server must be the primary server name if it is known. For example this
+// would be the ServerName directive
+// (https://httpd.apache.org/docs/2.4/mod/core.html#servername) for an Apache
+// server, and the server_name directive
+// (http://nginx.org/en/docs/http/ngx_http_core_module.html#server_name) for an
+// nginx server. More generically, the primary server name would be the host
+// header value that matches the default virtual host of an HTTP server. It
+// should include the host identifier and if a port is used to route to the
+// server that port identifier should be included as an appropriate port
+// suffix.
+//
+// If the primary server name is not known, server should be an empty string.
+// The req Host will be used to determine the server instead.
+func (d dupHTTPServer) TraceRequest(server string, req *http.Request) []attribute.KeyValue {
+	// old http.target http.scheme net.host.name net.host.port http.scheme net.host.name net.host.port http.method net.sock.peer.addr net.sock.peer.port user_agent.original http.method http.status_code net.protocol.version
+	// new http.request.header server.address server.port network.local.address network.local.port client.address client.port url.path url.query url.scheme user_agent.original server.address server.port url.scheme http.request.method http.response.status_code error.type network.protocol.name network.protocol.version http.request.method_original http.response.header http.request.method network.peer.address network.peer.port network.transport http.request.method http.response.status_code error.type network.protocol.name network.protocol.version
+
+	const MaxAttributes = 24
+	attrs := make([]attribute.KeyValue, MaxAttributes)
+	var host string
+	var p int
+	if server == "" {
+		host, p = splitHostPort(req.Host)
+	} else {
+		// Prioritize the primary server name.
+		host, p = splitHostPort(server)
+		if p < 0 {
+			_, p = splitHostPort(req.Host)
+		}
+	}
+
+	attrs[0] = semconvOld.NetHostName(host)
+	attrs[1] = semconvNew.ServerAddress(host)
+	i := 2
+	if hostPort := requiredHTTPPort(req.TLS != nil, p); hostPort > 0 {
+		attrs[i] = semconvOld.NetHostPort(hostPort)
+		attrs[i+1] = semconvNew.ServerPort(hostPort)
+		i += 2
+	}
+	i += d.method(req.Method, attrs[i:])     // Max 3
+	i += d.scheme(req.TLS != nil, attrs[i:]) // Max 2
+
+	if peer, peerPort := splitHostPort(req.RemoteAddr); peer != "" {
+		// The Go HTTP server sets RemoteAddr to "IP:port", this will not be a
+		// file-path that would be interpreted with a sock family.
+		attrs[i] = semconvOld.NetSockPeerAddr(peer)
+		attrs[i+1] = semconvNew.NetworkPeerAddress(peer)
+		i += 2
+		if peerPort > 0 {
+			attrs[i] = semconvOld.NetSockPeerPort(peerPort)
+			attrs[i+1] = semconvNew.NetworkPeerPort(peerPort)
+			i += 2
+		}
+	}
+
+	if useragent := req.UserAgent(); useragent != "" {
+		// This is the same between v1.20, and v1.24
+		attrs[i] = semconvNew.UserAgentOriginal(useragent)
+		i++
+	}
+
+	if clientIP := serverClientIP(req.Header.Get("X-Forwarded-For")); clientIP != "" {
+		attrs[i] = semconvOld.HTTPClientIP(clientIP)
+		attrs[i+1] = semconvNew.ClientAddress(clientIP)
+		i += 2
+	}
+
+	if req.URL != nil && req.URL.Path != "" {
+		attrs[i] = semconvOld.HTTPTarget(req.URL.Path)
+		attrs[i+1] = semconvNew.URLPath(req.URL.Path)
+		i += 2
+	}
+
+	protoName, protoVersion := netProtocol(req.Proto)
+	if protoName != "" && protoName != "http" {
+		attrs[i] = semconvOld.NetProtocolName(protoName)
+		attrs[i+1] = semconvNew.NetworkProtocolName(protoName)
+		i += 2
+	}
+	if protoVersion != "" {
+		attrs[i] = semconvOld.NetProtocolVersion(protoVersion)
+		attrs[i+1] = semconvNew.NetworkProtocolVersion(protoVersion)
+		i += 2
+	}
+
+	return slices.Clip(attrs[:i])
+}
+
+func (d dupHTTPServer) method(method string, attrs []attribute.KeyValue) int {
+	if method == "" {
+		attrs[0] = semconvOld.HTTPMethod(http.MethodGet)
+		attrs[1] = semconvNew.HTTPRequestMethodGet
+		return 2
+	}
+	attrs[0] = semconvOld.HTTPMethod(method)
+	if attr, ok := methodLookup[method]; ok {
+		attrs[1] = attr
+		return 2
+	}
+
+	if attr, ok := methodLookup[strings.ToUpper(method)]; ok {
+		attrs[1] = attr
+	} else {
+		// If the Original method is not a standard HTTP method fallback to GET
+		attrs[1] = semconvNew.HTTPRequestMethodGet
+	}
+	attrs[2] = semconvNew.HTTPRequestMethodOriginal(method)
+	return 3
+}
+
+func (d dupHTTPServer) scheme(https bool, attrs []attribute.KeyValue) int { // nolint:revive
+	if https {
+		attrs[0] = semconvOld.HTTPSchemeHTTPS
+		attrs[1] = semconvNew.URLScheme("https")
+		return 2
+	}
+	attrs[0] = semconvOld.HTTPSchemeHTTP
+	attrs[1] = semconvNew.URLScheme("http")
+	return 2
+}
+
+// TraceResponse returns trace attributes for telemetry from an HTTP response.
+//
+// If any of the fields in the ResponseTelemetry are not set the attribute will be omitted.
+func (d dupHTTPServer) TraceResponse(resp ResponseTelemetry) []attribute.KeyValue {
+	attributes := []attribute.KeyValue{}
+
+	if resp.ReadBytes > 0 {
+		attributes = append(attributes,
+			semconvOld.HTTPRequestContentLength(resp.ReadBytes),
+			semconvNew.HTTPRequestBodySize(resp.ReadBytes),
+		)
+	}
+	if resp.ReadError != nil && resp.ReadError != io.EOF {
+		// This is not in the semantic conventions, but is historically provided
+		attributes = append(attributes, attribute.String("http.read_error", resp.ReadError.Error()))
+	}
+	if resp.WriteBytes > 0 {
+		attributes = append(attributes,
+			semconvOld.HTTPResponseContentLength(resp.WriteBytes),
+			semconvNew.HTTPResponseBodySize(resp.WriteBytes),
+		)
+	}
+	if resp.WriteError != nil && resp.WriteError != io.EOF {
+		// This is not in the semantic conventions, but is historically provided
+		attributes = append(attributes, attribute.String("http.write_error", resp.WriteError.Error()))
+	}
+	if resp.StatusCode > 0 {
+		attributes = append(attributes,
+			semconvOld.HTTPStatusCode(resp.StatusCode),
+			semconvNew.HTTPResponseStatusCode(resp.StatusCode),
+		)
+	}
+
+	return attributes
+}
+
+// Route returns the attribute for the route.
+func (d dupHTTPServer) Route(route string) attribute.KeyValue {
+	return semconvNew.HTTPRoute(route)
+}

--- a/instrumentation/net/http/otelhttp/internal/semconv/dup.go
+++ b/instrumentation/net/http/otelhttp/internal/semconv/dup.go
@@ -29,7 +29,7 @@ type dupHTTPServer struct{}
 
 var _ HTTPServer = dupHTTPServer{}
 
-// TraceRequest returns trace attributes for an HTTP request received by a
+// RequestTraceAttrs returns trace attributes for an HTTP request received by a
 // server.
 //
 // The server must be the primary server name if it is known. For example this
@@ -45,7 +45,7 @@ var _ HTTPServer = dupHTTPServer{}
 //
 // If the primary server name is not known, server should be an empty string.
 // The req Host will be used to determine the server instead.
-func (d dupHTTPServer) TraceRequest(server string, req *http.Request) []attribute.KeyValue {
+func (d dupHTTPServer) RequestTraceAttrs(server string, req *http.Request) []attribute.KeyValue {
 	// old http.target http.scheme net.host.name net.host.port http.scheme net.host.name net.host.port http.method net.sock.peer.addr net.sock.peer.port user_agent.original http.method http.status_code net.protocol.version
 	// new http.request.header server.address server.port network.local.address network.local.port client.address client.port url.path url.query url.scheme user_agent.original server.address server.port url.scheme http.request.method http.response.status_code error.type network.protocol.name network.protocol.version http.request.method_original http.response.header http.request.method network.peer.address network.peer.port network.transport http.request.method http.response.status_code error.type network.protocol.name network.protocol.version
 
@@ -153,16 +153,16 @@ func (d dupHTTPServer) scheme(https bool, attrs []attribute.KeyValue) int { // n
 	return 2
 }
 
-// TraceResponse returns trace attributes for telemetry from an HTTP response.
+// ResponseTraceAttrs returns trace attributes for telemetry from an HTTP response.
 //
 // If any of the fields in the ResponseTelemetry are not set the attribute will be omitted.
-func (d dupHTTPServer) TraceResponse(resp ResponseTelemetry) []attribute.KeyValue {
+func (d dupHTTPServer) ResponseTraceAttrs(resp ResponseTelemetry) []attribute.KeyValue {
 	attributes := []attribute.KeyValue{}
 
 	if resp.ReadBytes > 0 {
 		attributes = append(attributes,
-			semconvOld.HTTPRequestContentLength(resp.ReadBytes),
-			semconvNew.HTTPRequestBodySize(resp.ReadBytes),
+			semconvOld.HTTPRequestContentLength(int(resp.ReadBytes)),
+			semconvNew.HTTPRequestBodySize(int(resp.ReadBytes)),
 		)
 	}
 	if resp.ReadError != nil && resp.ReadError != io.EOF {
@@ -171,8 +171,8 @@ func (d dupHTTPServer) TraceResponse(resp ResponseTelemetry) []attribute.KeyValu
 	}
 	if resp.WriteBytes > 0 {
 		attributes = append(attributes,
-			semconvOld.HTTPResponseContentLength(resp.WriteBytes),
-			semconvNew.HTTPResponseBodySize(resp.WriteBytes),
+			semconvOld.HTTPResponseContentLength(int(resp.WriteBytes)),
+			semconvNew.HTTPResponseBodySize(int(resp.WriteBytes)),
 		)
 	}
 	if resp.WriteError != nil && resp.WriteError != io.EOF {

--- a/instrumentation/net/http/otelhttp/internal/semconv/dup_test.go
+++ b/instrumentation/net/http/otelhttp/internal/semconv/dup_test.go
@@ -1,0 +1,113 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semconv
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func TestDupTraceRequest(t *testing.T) {
+	t.Setenv("OTEL_HTTP_CLIENT_COMPATIBILITY_MODE", "http/dup")
+	serv := NewHTTPServer()
+	want := func(req testServerReq) []attribute.KeyValue {
+		return []attribute.KeyValue{
+			attribute.String("http.method", "GET"),
+			attribute.String("http.request.method", "GET"),
+			attribute.String("http.scheme", "http"),
+			attribute.String("url.scheme", "http"),
+			attribute.String("net.host.name", req.hostname),
+			attribute.String("server.address", req.hostname),
+			attribute.Int("net.host.port", req.serverPort),
+			attribute.Int("server.port", req.serverPort),
+			attribute.String("net.sock.peer.addr", req.peerAddr),
+			attribute.String("network.peer.address", req.peerAddr),
+			attribute.Int("net.sock.peer.port", req.peerPort),
+			attribute.Int("network.peer.port", req.peerPort),
+			attribute.String("user_agent.original", "Go-http-client/1.1"),
+			attribute.String("http.client_ip", req.clientIP),
+			attribute.String("client.address", req.clientIP),
+			attribute.String("net.protocol.version", "1.1"),
+			attribute.String("network.protocol.version", "1.1"),
+			attribute.String("http.target", "/"),
+			attribute.String("url.path", "/"),
+		}
+	}
+	testTraceRequest(t, serv, want)
+}
+
+func TestDupMethod(t *testing.T) {
+	testCases := []struct {
+		method string
+		n      int
+		want   []attribute.KeyValue
+	}{
+		{
+			method: http.MethodPost,
+			n:      2,
+			want: []attribute.KeyValue{
+				attribute.String("http.method", "POST"),
+				attribute.String("http.request.method", "POST"),
+			},
+		},
+		{
+			method: "Put",
+			n:      3,
+			want: []attribute.KeyValue{
+				attribute.String("http.method", "Put"),
+				attribute.String("http.request.method", "PUT"),
+				attribute.String("http.request.method_original", "Put"),
+			},
+		},
+		{
+			method: "Unknown",
+			n:      3,
+			want: []attribute.KeyValue{
+				attribute.String("http.method", "Unknown"),
+				attribute.String("http.request.method", "GET"),
+				attribute.String("http.request.method_original", "Unknown"),
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.method, func(t *testing.T) {
+			attrs := make([]attribute.KeyValue, 5)
+			n := dupHTTPServer{}.method(tt.method, attrs[1:])
+			require.Equal(t, tt.n, n, "Length doesn't match")
+			require.ElementsMatch(t, tt.want, attrs[1:n+1])
+		})
+	}
+}
+
+func TestDupTraceResponse(t *testing.T) {
+	t.Setenv("OTEL_HTTP_CLIENT_COMPATIBILITY_MODE", "http/dup")
+	serv := NewHTTPServer()
+	want := []attribute.KeyValue{
+		attribute.Int("http.request_content_length", 701),
+		attribute.Int("http.request.body.size", 701),
+		attribute.String("http.read_error", "read error"),
+		attribute.Int("http.response_content_length", 802),
+		attribute.Int("http.response.body.size", 802),
+		attribute.String("http.write_error", "write error"),
+		attribute.Int("http.status_code", 200),
+		attribute.Int("http.response.status_code", 200),
+	}
+	testTraceResponse(t, serv, want)
+}

--- a/instrumentation/net/http/otelhttp/internal/semconv/env.go
+++ b/instrumentation/net/http/otelhttp/internal/semconv/env.go
@@ -6,6 +6,8 @@ package semconv // import "go.opentelemetry.io/contrib/instrumentation/net/http/
 import (
 	"fmt"
 	"net/http"
+	"os"
+	"strings"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -52,7 +54,13 @@ type HTTPServer interface {
 func NewHTTPServer() HTTPServer {
 	// TODO (#5331): Detect version based on environment variable OTEL_HTTP_CLIENT_COMPATIBILITY_MODE.
 	// TODO (#5331): Add warning of use of a deprecated version of Semantic Versions.
-	return oldHTTPServer{}
+	env := strings.ToLower(os.Getenv("OTEL_HTTP_CLIENT_COMPATIBILITY_MODE"))
+	switch env {
+	case "http/dup":
+		return dupHTTPServer{}
+	default:
+		return oldHTTPServer{}
+	}
 }
 
 // ServerStatus returns a span status code and message for an HTTP status code

--- a/instrumentation/net/http/otelhttp/internal/semconv/util.go
+++ b/instrumentation/net/http/otelhttp/internal/semconv/util.go
@@ -5,8 +5,12 @@ package semconv // import "go.opentelemetry.io/contrib/instrumentation/net/http/
 
 import (
 	"net"
+	"net/http"
 	"strconv"
 	"strings"
+
+	"go.opentelemetry.io/otel/attribute"
+	semconvNew "go.opentelemetry.io/otel/semconv/v1.24.0"
 )
 
 // splitHostPort splits a network address hostport of the form "host",
@@ -46,4 +50,42 @@ func splitHostPort(hostport string) (host string, port int) {
 		return
 	}
 	return host, int(p)
+}
+
+func requiredHTTPPort(https bool, port int) int { // nolint:revive
+	if https {
+		if port > 0 && port != 443 {
+			return port
+		}
+	} else {
+		if port > 0 && port != 80 {
+			return port
+		}
+	}
+	return -1
+}
+
+func serverClientIP(xForwardedFor string) string {
+	if idx := strings.Index(xForwardedFor, ","); idx >= 0 {
+		xForwardedFor = xForwardedFor[:idx]
+	}
+	return xForwardedFor
+}
+
+func netProtocol(proto string) (name string, version string) {
+	name, version, _ = strings.Cut(proto, "/")
+	name = strings.ToLower(name)
+	return name, version
+}
+
+var methodLookup = map[string]attribute.KeyValue{
+	http.MethodConnect: semconvNew.HTTPRequestMethodConnect,
+	http.MethodDelete:  semconvNew.HTTPRequestMethodDelete,
+	http.MethodGet:     semconvNew.HTTPRequestMethodGet,
+	http.MethodHead:    semconvNew.HTTPRequestMethodHead,
+	http.MethodOptions: semconvNew.HTTPRequestMethodOptions,
+	http.MethodPatch:   semconvNew.HTTPRequestMethodPatch,
+	http.MethodPost:    semconvNew.HTTPRequestMethodPost,
+	http.MethodPut:     semconvNew.HTTPRequestMethodPut,
+	http.MethodTrace:   semconvNew.HTTPRequestMethodTrace,
 }


### PR DESCRIPTION
This change adds the duplicate attribute producer to the semconv of otlehttp. 

The full PR is https://github.com/open-telemetry/opentelemetry-go-contrib/pull/5092
Part of https://github.com/open-telemetry/opentelemetry-go-contrib/issues/5331