### PR TITLE
[chore] Renovate to add Skip Changelog label

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
     "config:recommended"
   ],
   "ignorePaths": [],
+  "labels": ["Skip Changelog"],
   "separateMajorMinor": true,
   "postUpdateOptions" : [
     "gomodTidy"


### PR DESCRIPTION
Use https://docs.renovatebot.com/configuration-options/#labels to add `Skip Changelog` label.