### PR TITLE
[chore] Bump Go versions to ~1.22.3 and ~1.21.10 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
   # backwards compatibility with the previous two minor releases and we
   # explicitly test our code for these versions so keeping this at prior
   # versions does not add value.
-  DEFAULT_GO_VERSION: "~1.22.2"
+  DEFAULT_GO_VERSION: "~1.22.3"
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -91,7 +91,7 @@ jobs:
   compatibility-test:
     strategy:
       matrix:
-        go-version: ["~1.22.2", "~1.21.9"]
+        go-version: ["~1.22.3", "~1.21.10"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         # GitHub Actions does not support arm* architectures on default
         # runners. It is possible to acomplish this with a self-hosted runner

--- a/.github/workflows/create-dependabot-pr.yml
+++ b/.github/workflows/create-dependabot-pr.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: "~1.22.2"
+          go-version: "~1.22.3"
           check-latest: true
           cache-dependency-path: "**/go.sum"
 

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -13,7 +13,7 @@ jobs:
         ref: ${{ github.head_ref }}
     - uses: actions/setup-go@v5
       with:
-        go-version: "~1.22.2"
+        go-version: "~1.22.3"
         check-latest: true
         cache-dependency-path: "**/go.sum"
     - uses: evantorrie/mott-the-tidier@v1-beta

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,8 +2,6 @@ module go.opentelemetry.io/contrib/tools
 
 go 1.22
 
-toolchain go1.22.2
-
 exclude github.com/blizzy78/varnamelen v0.6.1
 
 require (


### PR DESCRIPTION
Fix CI

Similar to https://github.com/open-telemetry/opentelemetry-go/pull/5314