### PR TITLE
otelhttptrace: add TLS info to the "http.tls" span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The `WithSchemaURL` option function in `go.opentelemetry.io/contrib/bridges/otelslog`.
   This option function is used as a replacement of `WithInstrumentationScope` to specify the semantic convention schema URL for the logged records. (#5588)
 - Add support for Cloud Run jobs in `go.opentelemetry.io/contrib/detectors/gcp`. (#5559)
-- Add TLS information to otelhttptrace http.tls attributes, providing information on the cipher and protocol version used, whether the session was resumed, the SHA256 hash of the leaf certificate, "not before"/"not after" dates, and verified certificate chains.
+- Add TLS information from semantic conventions v1.24.0 to `go.opentelemetry.io/contrib/instrumentation/net/http/httptrace`. (#5563)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The `WithSchemaURL` option function in `go.opentelemetry.io/contrib/bridges/otelslog`.
   This option function is used as a replacement of `WithInstrumentationScope` to specify the semantic convention schema URL for the logged records. (#5588)
 - Add support for Cloud Run jobs in `go.opentelemetry.io/contrib/detectors/gcp`. (#5559)
+- Add TLS information to otelhttptrace http.tls attributes, providing information on the cipher and protocol version used, whether the session was resumed, the SHA256 hash of the leaf certificate, "not before"/"not after" dates, and verified certificate chains.
 
 ### Changed
 

--- a/instrumentation/net/http/httptrace/otelhttptrace/clienttrace.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/clienttrace.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -278,7 +279,7 @@ func (ct *clientTracer) span(hook string) trace.Span {
 }
 
 func (ct *clientTracer) getConn(host string) {
-	ct.start("http.getconn", "http.getconn", attribute.Key("net.host.name").String(host))
+	ct.start("http.getconn", "http.getconn", semconv.NetHostName(host))
 }
 
 func (ct *clientTracer) gotConn(info httptrace.GotConnInfo) {
@@ -303,7 +304,7 @@ func (ct *clientTracer) gotFirstResponseByte() {
 }
 
 func (ct *clientTracer) dnsStart(info httptrace.DNSStartInfo) {
-	ct.start("http.dns", "http.dns", attribute.Key("net.host.name").String(info.Host))
+	ct.start("http.dns", "http.dns", semconv.NetHostName(info.Host))
 }
 
 func (ct *clientTracer) dnsDone(info httptrace.DNSDoneInfo) {

--- a/instrumentation/net/http/httptrace/otelhttptrace/clienttrace.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/clienttrace.go
@@ -44,13 +44,13 @@ var (
 //
 // From https://opentelemetry.io/docs/specs/semconv/attributes-registry/tls/ but only present from semconv v1.24.
 var (
-	TLSCipher                 = attribute.Key("tls.cipher")
-	TLSProtocolVersion        = attribute.Key("tls.protocol.version")
-	TLSResumed                = attribute.Key("tls.resumed")
-	TLSServerCertificateChain = attribute.Key("tls.server.certificate_chain")
-	TLSServerHashSha256       = attribute.Key("tls.server.hash.sha256")
-	TLSServerNotAfter         = attribute.Key("tls.server.not_after")
-	TLSServerNotBefore        = attribute.Key("tls.server.not_before")
+	TLSCipherKey                 = attribute.Key("tls.cipher")
+	TLSProtocolVersionKey        = attribute.Key("tls.protocol.version")
+	TLSResumedKey                = attribute.Key("tls.resumed")
+	TLSServerCertificateChainKey = attribute.Key("tls.server.certificate_chain")
+	TLSServerHashSha256Key       = attribute.Key("tls.server.hash.sha256")
+	TLSServerNotAfterKey         = attribute.Key("tls.server.not_after")
+	TLSServerNotBeforeKey        = attribute.Key("tls.server.not_before")
 )
 
 var hookMap = map[string]string{
@@ -336,9 +336,9 @@ func (ct *clientTracer) tlsHandshakeStart() {
 func (ct *clientTracer) tlsHandshakeDone(state tls.ConnectionState, err error) {
 	attrs := make([]attribute.KeyValue, 0, 7)
 	attrs = append(attrs,
-		TLSCipher.String(tls.CipherSuiteName(state.CipherSuite)),
-		TLSProtocolVersion.String(tls.VersionName(state.Version)),
-		TLSResumed.Bool(state.DidResume),
+		TLSCipherKey.String(tls.CipherSuiteName(state.CipherSuite)),
+		TLSProtocolVersionKey.String(tls.VersionName(state.Version)),
+		TLSResumedKey.Bool(state.DidResume),
 	)
 
 	if len(state.PeerCertificates) > 0 {
@@ -349,10 +349,10 @@ func (ct *clientTracer) tlsHandshakeDone(state tls.ConnectionState, err error) {
 
 		leafCert := state.PeerCertificates[0]
 		attrs = append(attrs,
-			TLSServerCertificateChain.StringSlice(certChain),
-			TLSServerHashSha256.String(fmt.Sprintf("%X", sha256.Sum256(leafCert.Raw))),
-			TLSServerNotAfter.String(leafCert.NotAfter.UTC().Format(time.RFC3339)),
-			TLSServerNotBefore.String(leafCert.NotBefore.UTC().Format(time.RFC3339)),
+			TLSServerCertificateChainKey.StringSlice(certChain),
+			TLSServerHashSha256Key.String(fmt.Sprintf("%X", sha256.Sum256(leafCert.Raw))),
+			TLSServerNotAfterKey.String(leafCert.NotAfter.UTC().Format(time.RFC3339)),
+			TLSServerNotBeforeKey.String(leafCert.NotBefore.UTC().Format(time.RFC3339)),
 		)
 	}
 	ct.end("http.tls", err, attrs...)

--- a/instrumentation/net/http/httptrace/otelhttptrace/httptrace.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/httptrace.go
@@ -12,7 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/baggage"
 	"go.opentelemetry.io/otel/propagation"
-	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/instrumentation/net/http/httptrace/otelhttptrace/httptrace.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/httptrace.go
@@ -12,7 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/baggage"
 	"go.opentelemetry.io/otel/propagation"
-	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/instrumentation/net/http/httptrace/otelhttptrace/httptrace_test.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/httptrace_test.go
@@ -17,7 +17,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/baggage"
 	"go.opentelemetry.io/otel/propagation"
-	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
 )

--- a/instrumentation/net/http/httptrace/otelhttptrace/httptrace_test.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/httptrace_test.go
@@ -17,7 +17,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/baggage"
 	"go.opentelemetry.io/otel/propagation"
-	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
 )

--- a/instrumentation/net/http/httptrace/otelhttptrace/httptrace_test.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/httptrace_test.go
@@ -31,7 +31,7 @@ func TestRoundtrip(t *testing.T) {
 	props := otelhttptrace.WithPropagators(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
 
 	// Mock http server
-	ts := httptest.NewTLSServer(
+	ts := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			attrs, corrs, span := otelhttptrace.Extract(r.Context(), r, props)
 
@@ -76,7 +76,7 @@ func TestRoundtrip(t *testing.T) {
 		semconv.NetHostPortKey:              port,
 		semconv.NetProtocolVersionKey:       "1.1",
 		semconv.HTTPMethodKey:               "GET",
-		semconv.HTTPSchemeKey:               "https",
+		semconv.HTTPSchemeKey:               "http",
 		semconv.HTTPTargetKey:               "/",
 		semconv.HTTPRequestContentLengthKey: "3",
 		semconv.NetSockPeerAddrKey:          host,

--- a/instrumentation/net/http/httptrace/otelhttptrace/test/clienttrace_test.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/test/clienttrace_test.go
@@ -186,7 +186,7 @@ func TestHTTPRequestWithClientTrace(t *testing.T) {
 					}
 					attrs = slices.DeleteFunc(attrs, func(a attribute.KeyValue) bool {
 						// Skip keys that are unable to be detected beforehand.
-						if a.Key == otelhttptrace.TLSCipher || a.Key == otelhttptrace.TLSProtocolVersion {
+						if a.Key == otelhttptrace.TLSCipherKey || a.Key == otelhttptrace.TLSProtocolVersionKey {
 							return true
 						}
 						return false

--- a/instrumentation/net/http/httptrace/otelhttptrace/test/clienttrace_test.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/test/clienttrace_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -87,7 +88,6 @@ func TestHTTPRequestWithClientTrace(t *testing.T) {
 			name       string
 			attributes []attribute.KeyValue
 			parent     string
-			onlyTLS    bool
 		}
 
 		testLen := []tc{

--- a/instrumentation/net/http/httptrace/otelhttptrace/test/clienttrace_test.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/test/clienttrace_test.go
@@ -18,12 +18,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 )
 
 func getSpanFromRecorder(sr *tracetest.SpanRecorder, name string) (trace.ReadOnlySpan, bool) {
@@ -169,7 +169,7 @@ func TestHTTPRequestWithClientTrace(t *testing.T) {
 				}
 				attrs = slices.DeleteFunc(attrs, func(a attribute.KeyValue) bool {
 					// Skip keys that are unable to be detected beforehand.
-					if a.Key == semconv.TLSCipherKey || a.Key == semconv.TLSProtocolVersionKey {
+					if a.Key == otelhttptrace.TLSCipher || a.Key == otelhttptrace.TLSProtocolVersion {
 						return true
 					}
 					return false


### PR DESCRIPTION
I noticed that the `http.tls` span was not including any useful information for otelhttptrace, and considering httptrace is supposed to show excess debug information about an HTTP connection, I figured it would be good to add some simple attributes on that span.

When committing, I noticed that the golangci-lint checks were failing because of some deprecated semconv functions, namely `semconv.NetHostName()`, so I fixed them to what those values they set are to eliminate the linter failures. It looks like `net.host.name` has been replaced with `server.address` in semconv, but I didn't want to break existing code -- happy to change them to the new semconv version if requested!