### PR TITLE
otelzap: Implement methods on objectEncoder

### DIFF
--- a/bridges/otelzap/core_test.go
+++ b/bridges/otelzap/core_test.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Copyright (c) 2016-2017 Uber Technologies, Inc.
+
 package otelzap
 
 import (
@@ -93,67 +94,4 @@ func TestConvertLevel(t *testing.T) {
 			t.Errorf("For level %v, expected %v but got %v", test.level, test.expectedSev, result)
 		}
 	}
-}
-
-// Copied from field_test.go. https://github.com/uber-go/zap/blob/b39f8b6b6a44d8371a87610be50cce58eeeaabcb/zapcore/memory_encoder_test.go
-func TestObjectEncoder(t *testing.T) {
-
-	tests := []struct {
-		desc     string
-		f        func(zapcore.ObjectEncoder)
-		expected interface{}
-	}{
-		{
-			desc:     "AddBinary",
-			f:        func(e zapcore.ObjectEncoder) { e.AddBinary("k", []byte("foo")) },
-			expected: []byte("foo"),
-		},
-		{
-			desc:     "AddByteString",
-			f:        func(e zapcore.ObjectEncoder) { e.AddByteString("k", []byte("foo")) },
-			expected: "foo",
-		},
-		{
-			desc:     "AddBool",
-			f:        func(e zapcore.ObjectEncoder) { e.AddBool("k", true) },
-			expected: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.desc, func(t *testing.T) {
-			enc := newObjectEncoder(1)
-			tt.f(enc)
-			require.Len(t, enc.kv, 1)
-			assert.Equal(t, tt.expected, value2Result((enc.kv[0].Value)), "Unexpected encoder output.")
-		})
-	}
-}
-
-func value2Result(v log.Value) any {
-	switch v.Kind() {
-	case log.KindBool:
-		return v.AsBool()
-	case log.KindFloat64:
-		return v.AsFloat64()
-	case log.KindInt64:
-		return v.AsInt64()
-	case log.KindString:
-		return v.AsString()
-	case log.KindBytes:
-		return v.AsBytes()
-	case log.KindSlice:
-		var s []any
-		for _, val := range v.AsSlice() {
-			s = append(s, value2Result(val))
-		}
-		return s
-	case log.KindMap:
-		m := make(map[string]any)
-		for _, val := range v.AsMap() {
-			m[val.Key] = value2Result(val.Value)
-		}
-		return m
-	}
-	return nil
 }

--- a/bridges/otelzap/core_test.go
+++ b/bridges/otelzap/core_test.go
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+// Copyright (c) 2016-2017 Uber Technologies, Inc.
 package otelzap
 
 import (
@@ -92,4 +93,67 @@ func TestConvertLevel(t *testing.T) {
 			t.Errorf("For level %v, expected %v but got %v", test.level, test.expectedSev, result)
 		}
 	}
+}
+
+// Copied from field_test.go. https://github.com/uber-go/zap/blob/b39f8b6b6a44d8371a87610be50cce58eeeaabcb/zapcore/memory_encoder_test.go
+func TestObjectEncoder(t *testing.T) {
+
+	tests := []struct {
+		desc     string
+		f        func(zapcore.ObjectEncoder)
+		expected interface{}
+	}{
+		{
+			desc:     "AddBinary",
+			f:        func(e zapcore.ObjectEncoder) { e.AddBinary("k", []byte("foo")) },
+			expected: []byte("foo"),
+		},
+		{
+			desc:     "AddByteString",
+			f:        func(e zapcore.ObjectEncoder) { e.AddByteString("k", []byte("foo")) },
+			expected: "foo",
+		},
+		{
+			desc:     "AddBool",
+			f:        func(e zapcore.ObjectEncoder) { e.AddBool("k", true) },
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			enc := newObjectEncoder(1)
+			tt.f(enc)
+			require.Len(t, enc.kv, 1)
+			assert.Equal(t, tt.expected, value2Result((enc.kv[0].Value)), "Unexpected encoder output.")
+		})
+	}
+}
+
+func value2Result(v log.Value) any {
+	switch v.Kind() {
+	case log.KindBool:
+		return v.AsBool()
+	case log.KindFloat64:
+		return v.AsFloat64()
+	case log.KindInt64:
+		return v.AsInt64()
+	case log.KindString:
+		return v.AsString()
+	case log.KindBytes:
+		return v.AsBytes()
+	case log.KindSlice:
+		var s []any
+		for _, val := range v.AsSlice() {
+			s = append(s, value2Result(val))
+		}
+		return s
+	case log.KindMap:
+		m := make(map[string]any)
+		for _, val := range v.AsMap() {
+			m[val.Key] = value2Result(val.Value)
+		}
+		return m
+	}
+	return nil
 }

--- a/bridges/otelzap/core_test.go
+++ b/bridges/otelzap/core_test.go
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-// Copyright (c) 2016-2017 Uber Technologies, Inc.
-
 package otelzap
 
 import (

--- a/bridges/otelzap/encoder.go
+++ b/bridges/otelzap/encoder.go
@@ -16,7 +16,7 @@ var _ zapcore.ObjectEncoder = (*objectEncoder)(nil)
 // objectEncoder implements zapcore.ObjectEncoder.
 // It encodes given fields to OTel key-values.
 type objectEncoder struct {
-	kv []log.KeyValue // nolint:unused
+	kv []log.KeyValue
 }
 
 // nolint:unused
@@ -66,27 +66,22 @@ func (m *objectEncoder) AddComplex128(k string, v complex128) {
 
 // AddFloat64 converts float64 to log.Float64.
 func (m *objectEncoder) AddFloat64(k string, v float64) {
-	// TODO
-}
-
-// AddFloat32 converts float32 to log.Float64.
-func (m *objectEncoder) AddFloat32(k string, v float32) {
-	// TODO
+	m.kv = append(m.kv, log.Float64(k, v))
 }
 
 // AddInt64 converts int64 to log.Int64.
 func (m *objectEncoder) AddInt64(k string, v int64) {
-	// TODO
+	m.kv = append(m.kv, log.Int64(k, v))
 }
 
 // AddInt converts int to log.Int.
 func (m *objectEncoder) AddInt(k string, v int) {
-	// TODO
+	m.kv = append(m.kv, log.Int(k, v))
 }
 
 // AddString converts string to log.String.
 func (m *objectEncoder) AddString(k string, v string) {
-	// TODO
+	m.kv = append(m.kv, log.String(k, v))
 }
 
 // TODO.
@@ -105,10 +100,11 @@ func (m *objectEncoder) OpenNamespace(k string) {
 }
 
 // TODO.
+func (m *objectEncoder) AddFloat32(k string, v float32)     { m.AddFloat64(k, float64(v)) }
 func (m *objectEncoder) AddComplex64(k string, v complex64) {}
-func (m *objectEncoder) AddInt32(k string, v int32)         {}
-func (m *objectEncoder) AddInt16(k string, v int16)         {}
-func (m *objectEncoder) AddInt8(k string, v int8)           {}
+func (m *objectEncoder) AddInt32(k string, v int32)         { m.AddInt64(k, int64(v)) }
+func (m *objectEncoder) AddInt16(k string, v int16)         { m.AddInt64(k, int64(v)) }
+func (m *objectEncoder) AddInt8(k string, v int8)           { m.AddInt64(k, int64(v)) }
 func (m *objectEncoder) AddTime(k string, v time.Time)      {}
 func (m *objectEncoder) AddUint(k string, v uint)           {}
 func (m *objectEncoder) AddUint32(k string, v uint32)       {}

--- a/bridges/otelzap/encoder.go
+++ b/bridges/otelzap/encoder.go
@@ -1,0 +1,117 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otelzap // import "go.opentelemetry.io/contrib/bridges/otelzap"
+
+import (
+	"time"
+
+	"go.uber.org/zap/zapcore"
+
+	"go.opentelemetry.io/otel/log"
+)
+
+var _ zapcore.ObjectEncoder = (*objectEncoder)(nil)
+
+// objectEncoder implements zapcore.ObjectEncoder.
+// It encodes given fields to OTel key-values.
+type objectEncoder struct {
+	kv []log.KeyValue // nolint:unused
+}
+
+// nolint:unused
+func newObjectEncoder(len int) *objectEncoder {
+	keyval := make([]log.KeyValue, 0, len)
+
+	return &objectEncoder{
+		kv: keyval,
+	}
+}
+
+// AddArray converts array to log.Slice using ArrayEncoder.
+func (m *objectEncoder) AddArray(key string, v zapcore.ArrayMarshaler) error {
+	// TODO
+	return nil
+}
+
+// AddObject converts object to log.Map using ObjectEncoder.
+func (m *objectEncoder) AddObject(k string, v zapcore.ObjectMarshaler) error {
+	// TODO
+	return nil
+}
+
+// AddBinary converts binary to log.Bytes.
+func (m *objectEncoder) AddBinary(k string, v []byte) {
+	// TODO
+}
+
+// AddByteString converts byte to log.String.
+func (m *objectEncoder) AddByteString(k string, v []byte) {
+	// TODO
+}
+
+// AddBool converts bool to log.Bool.
+func (m *objectEncoder) AddBool(k string, v bool) {
+	// TODO
+}
+
+// AddDuration converts duration to log.Int.
+func (m *objectEncoder) AddDuration(k string, v time.Duration) {
+	// TODO
+}
+
+// TODO.
+func (m *objectEncoder) AddComplex128(k string, v complex128) {
+}
+
+// AddFloat64 converts float64 to log.Float64.
+func (m *objectEncoder) AddFloat64(k string, v float64) {
+	// TODO
+}
+
+// AddFloat32 converts float32 to log.Float64.
+func (m *objectEncoder) AddFloat32(k string, v float32) {
+	// TODO
+}
+
+// AddInt64 converts int64 to log.Int64.
+func (m *objectEncoder) AddInt64(k string, v int64) {
+	// TODO
+}
+
+// AddInt converts int to log.Int.
+func (m *objectEncoder) AddInt(k string, v int) {
+	// TODO
+}
+
+// AddString converts string to log.String.
+func (m *objectEncoder) AddString(k string, v string) {
+	// TODO
+}
+
+// TODO.
+func (m *objectEncoder) AddUint64(k string, v uint64) {
+}
+
+// TODO.
+func (m *objectEncoder) AddReflected(k string, v interface{}) error {
+	return nil
+}
+
+// OpenNamespace opens an isolated namespace where all subsequent fields will
+// be added.
+func (m *objectEncoder) OpenNamespace(k string) {
+	// TODO
+}
+
+// TODO.
+func (m *objectEncoder) AddComplex64(k string, v complex64) {}
+func (m *objectEncoder) AddInt32(k string, v int32)         {}
+func (m *objectEncoder) AddInt16(k string, v int16)         {}
+func (m *objectEncoder) AddInt8(k string, v int8)           {}
+func (m *objectEncoder) AddTime(k string, v time.Time)      {}
+func (m *objectEncoder) AddUint(k string, v uint)           {}
+func (m *objectEncoder) AddUint32(k string, v uint32)       {}
+func (m *objectEncoder) AddUint16(k string, v uint16)       {}
+func (m *objectEncoder) AddUint8(k string, v uint8)         {}
+func (m *objectEncoder) AddUintptr(k string, v uintptr)     {}

--- a/bridges/otelzap/encoder.go
+++ b/bridges/otelzap/encoder.go
@@ -28,58 +28,48 @@ func newObjectEncoder(len int) *objectEncoder {
 	}
 }
 
-// AddArray converts array to log.Slice using ArrayEncoder.
 func (m *objectEncoder) AddArray(key string, v zapcore.ArrayMarshaler) error {
 	// TODO
 	return nil
 }
 
-// AddObject converts object to log.Map using ObjectEncoder.
 func (m *objectEncoder) AddObject(k string, v zapcore.ObjectMarshaler) error {
 	// TODO
 	return nil
 }
 
-// AddBinary converts binary to log.Bytes.
 func (m *objectEncoder) AddBinary(k string, v []byte) {
 	m.kv = append(m.kv, log.Bytes(k, v))
 }
 
-// AddByteString converts byte to log.String.
 func (m *objectEncoder) AddByteString(k string, v []byte) {
 	m.kv = append(m.kv, log.String(k, string(v)))
 }
 
-// AddBool converts bool to log.Bool.
 func (m *objectEncoder) AddBool(k string, v bool) {
 	m.kv = append(m.kv, log.Bool(k, v))
 }
 
-// AddDuration converts duration to log.Int.
 func (m *objectEncoder) AddDuration(k string, v time.Duration) {
 	// TODO
 }
 
-// TODO.
 func (m *objectEncoder) AddComplex128(k string, v complex128) {
+	// TODO.
 }
 
-// AddFloat64 converts float64 to log.Float64.
 func (m *objectEncoder) AddFloat64(k string, v float64) {
 	m.kv = append(m.kv, log.Float64(k, v))
 }
 
-// AddInt64 converts int64 to log.Int64.
 func (m *objectEncoder) AddInt64(k string, v int64) {
 	m.kv = append(m.kv, log.Int64(k, v))
 }
 
-// AddInt converts int to log.Int.
 func (m *objectEncoder) AddInt(k string, v int) {
 	m.kv = append(m.kv, log.Int(k, v))
 }
 
-// AddString converts string to log.String.
 func (m *objectEncoder) AddString(k string, v string) {
 	m.kv = append(m.kv, log.String(k, v))
 }

--- a/bridges/otelzap/encoder.go
+++ b/bridges/otelzap/encoder.go
@@ -42,17 +42,17 @@ func (m *objectEncoder) AddObject(k string, v zapcore.ObjectMarshaler) error {
 
 // AddBinary converts binary to log.Bytes.
 func (m *objectEncoder) AddBinary(k string, v []byte) {
-	// TODO
+	m.kv = append(m.kv, log.Bytes(k, v))
 }
 
 // AddByteString converts byte to log.String.
 func (m *objectEncoder) AddByteString(k string, v []byte) {
-	// TODO
+	m.kv = append(m.kv, log.String(k, string(v)))
 }
 
 // AddBool converts bool to log.Bool.
 func (m *objectEncoder) AddBool(k string, v bool) {
-	// TODO
+	m.kv = append(m.kv, log.Bool(k, v))
 }
 
 // AddDuration converts duration to log.Int.

--- a/bridges/otelzap/encoder.go
+++ b/bridges/otelzap/encoder.go
@@ -99,12 +99,13 @@ func (m *objectEncoder) OpenNamespace(k string) {
 	// TODO
 }
 
+func (m *objectEncoder) AddFloat32(k string, v float32) { m.AddFloat64(k, float64(v)) }
+func (m *objectEncoder) AddInt32(k string, v int32)     { m.AddInt64(k, int64(v)) }
+func (m *objectEncoder) AddInt16(k string, v int16)     { m.AddInt64(k, int64(v)) }
+func (m *objectEncoder) AddInt8(k string, v int8)       { m.AddInt64(k, int64(v)) }
+
 // TODO.
-func (m *objectEncoder) AddFloat32(k string, v float32)     { m.AddFloat64(k, float64(v)) }
 func (m *objectEncoder) AddComplex64(k string, v complex64) {}
-func (m *objectEncoder) AddInt32(k string, v int32)         { m.AddInt64(k, int64(v)) }
-func (m *objectEncoder) AddInt16(k string, v int16)         { m.AddInt64(k, int64(v)) }
-func (m *objectEncoder) AddInt8(k string, v int8)           { m.AddInt64(k, int64(v)) }
 func (m *objectEncoder) AddTime(k string, v time.Time)      {}
 func (m *objectEncoder) AddUint(k string, v uint)           {}
 func (m *objectEncoder) AddUint32(k string, v uint32)       {}

--- a/bridges/otelzap/encoder_test.go
+++ b/bridges/otelzap/encoder_test.go
@@ -1,0 +1,118 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright (c) 2016-2017 Uber Technologies, Inc.
+
+package otelzap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+
+	"go.opentelemetry.io/otel/log"
+)
+
+// Copied from https://github.com/uber-go/zap/blob/b39f8b6b6a44d8371a87610be50cce58eeeaabcb/zapcore/memory_encoder_test.go.
+func TestObjectEncoder(t *testing.T) {
+	tests := []struct {
+		desc     string
+		f        func(zapcore.ObjectEncoder)
+		expected interface{}
+	}{
+		{
+			desc:     "AddBinary",
+			f:        func(e zapcore.ObjectEncoder) { e.AddBinary("k", []byte("foo")) },
+			expected: []byte("foo"),
+		},
+		{
+			desc:     "AddByteString",
+			f:        func(e zapcore.ObjectEncoder) { e.AddByteString("k", []byte("foo")) },
+			expected: "foo",
+		},
+		{
+			desc:     "AddBool",
+			f:        func(e zapcore.ObjectEncoder) { e.AddBool("k", true) },
+			expected: true,
+		},
+		{
+			desc:     "AddFloat64",
+			f:        func(e zapcore.ObjectEncoder) { e.AddFloat64("k", 3.14) },
+			expected: 3.14,
+		},
+		{
+			desc:     "AddFloat32",
+			f:        func(e zapcore.ObjectEncoder) { e.AddFloat32("k", 3.14) },
+			expected: float64(float32(3.14)),
+		},
+		{
+			desc:     "AddInt",
+			f:        func(e zapcore.ObjectEncoder) { e.AddInt("k", 42) },
+			expected: int64(42),
+		},
+		{
+			desc:     "AddInt64",
+			f:        func(e zapcore.ObjectEncoder) { e.AddInt64("k", 42) },
+			expected: int64(42),
+		},
+		{
+			desc:     "AddInt32",
+			f:        func(e zapcore.ObjectEncoder) { e.AddInt32("k", 42) },
+			expected: int64(42),
+		},
+		{
+			desc:     "AddInt16",
+			f:        func(e zapcore.ObjectEncoder) { e.AddInt16("k", 42) },
+			expected: int64(42),
+		},
+		{
+			desc:     "AddInt8",
+			f:        func(e zapcore.ObjectEncoder) { e.AddInt8("k", 42) },
+			expected: int64(42),
+		},
+		{
+			desc:     "AddString",
+			f:        func(e zapcore.ObjectEncoder) { e.AddString("k", "v") },
+			expected: "v",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			enc := newObjectEncoder(1)
+			tt.f(enc)
+			require.Len(t, enc.kv, 1)
+			assert.Equal(t, tt.expected, value2Result((enc.kv[0].Value)), "Unexpected encoder output.")
+		})
+	}
+}
+
+func value2Result(v log.Value) any {
+	switch v.Kind() {
+	case log.KindBool:
+		return v.AsBool()
+	case log.KindFloat64:
+		return v.AsFloat64()
+	case log.KindInt64:
+		return v.AsInt64()
+	case log.KindString:
+		return v.AsString()
+	case log.KindBytes:
+		return v.AsBytes()
+	case log.KindSlice:
+		var s []any
+		for _, val := range v.AsSlice() {
+			s = append(s, value2Result(val))
+		}
+		return s
+	case log.KindMap:
+		m := make(map[string]any)
+		for _, val := range v.AsMap() {
+			m[val.Key] = value2Result(val.Value)
+		}
+		return m
+	}
+	return nil
+}


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-go-contrib/issues/5191

Pre-work https://github.com/open-telemetry/opentelemetry-go-contrib/pull/5279

This PR implements `AddBinary` `AddByteString` and `AddBool` method on `objectEncoder`

P.S will some more methods be accepted in this PR?