### PR TITLE
Add dashpole as a codeowner for otelrestful

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -36,7 +36,7 @@ exporters/autoexport                                                    @open-te
 
 instrumentation/github.com/aws/aws-lambda-go/otellambda/                @open-telemetry/go-approvers
 instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/                   @open-telemetry/go-approvers
-instrumentation/github.com/emicklei/go-restful/otelrestful/             @open-telemetry/go-approvers
+instrumentation/github.com/emicklei/go-restful/otelrestful/             @open-telemetry/go-approvers @dashpole
 instrumentation/github.com/gin-gonic/gin/otelgin/                       @open-telemetry/go-approvers @hanyuancheung
 instrumentation/github.com/gorilla/mux/otelmux/                         @open-telemetry/go-approvers
 instrumentation/github.com/labstack/echo/otelecho/                      @open-telemetry/go-approvers


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go-contrib/issues/5548

Since this is used by kubernetes, i'll step up to own this.