### PR TITLE
Replace WithInstrumentationScope with options and and argument

### DIFF
--- a/bridges/otellogrus/example_test.go
+++ b/bridges/otellogrus/example_test.go
@@ -15,7 +15,7 @@ func Example() {
 	provider := noop.NewLoggerProvider()
 
 	// Create an *otellogrus.Hook and use it in your application.
-	hook := otellogrus.NewHook(otellogrus.WithLoggerProvider(provider))
+	hook := otellogrus.NewHook("my/pkg/name", otellogrus.WithLoggerProvider(provider))
 
 	// Set the newly created hook as a global logrus hook
 	logrus.AddHook(hook)

--- a/bridges/otellogrus/go.mod
+++ b/bridges/otellogrus/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/otel/log v0.2.0-alpha.0.20240517142840-ebd0adee357f
-	go.opentelemetry.io/otel/sdk v1.26.0
 )
 
 require (

--- a/bridges/otellogrus/go.sum
+++ b/bridges/otellogrus/go.sum
@@ -22,8 +22,6 @@ go.opentelemetry.io/otel/log v0.2.0-alpha.0.20240517142840-ebd0adee357f h1:JmJ7s
 go.opentelemetry.io/otel/log v0.2.0-alpha.0.20240517142840-ebd0adee357f/go.mod h1:vbFZc65yq4c4ssvXY43y/nIqkNJLxORrqw0L85P59LA=
 go.opentelemetry.io/otel/metric v1.26.0 h1:7S39CLuY5Jgg9CrnA9HHiEjGMF/X2VHvoXGgSllRz30=
 go.opentelemetry.io/otel/metric v1.26.0/go.mod h1:SY+rHOI4cEawI9a7N1A4nIg/nTQXe1ccCNWYOJUrpX4=
-go.opentelemetry.io/otel/sdk v1.26.0 h1:Y7bumHf5tAiDlRYFmGqetNcLaVUZmh4iYfmGxtmz7F8=
-go.opentelemetry.io/otel/sdk v1.26.0/go.mod h1:0p8MXpqLeJ0pzcszQQN4F0S5FVjBLgypeGSngLsmirs=
 go.opentelemetry.io/otel/trace v1.26.0 h1:1ieeAUb4y0TE26jUFrCIXKpTuVK7uJGN9/Z/2LP5sQA=
 go.opentelemetry.io/otel/trace v1.26.0/go.mod h1:4iDxvGDQuUkHve82hJJ8UqrwswHYsZuWCBllGV2U2y0=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/bridges/otellogrus/hook.go
+++ b/bridges/otellogrus/hook.go
@@ -86,7 +86,7 @@ type optFunc func(config) config
 func (f optFunc) apply(c config) config { return f(c) }
 
 // WithVersion returns an [Option] that configures the version of the
-// [log.Logger] used by a [Handler]. The version should be the version of the
+// [log.Logger] used by a [Hook]. The version should be the version of the
 // package that is being logged.
 func WithVersion(version string) Option {
 	return optFunc(func(c config) config {
@@ -96,7 +96,7 @@ func WithVersion(version string) Option {
 }
 
 // WithSchemaURL returns an [Option] that configures the semantic convention
-// schema URL of the [log.Logger] used by a [Handler]. The schemaURL should be
+// schema URL of the [log.Logger] used by a [Hook]. The schemaURL should be
 // the schema URL for the semantic conventions used in log records.
 func WithSchemaURL(schemaURL string) Option {
 	return optFunc(func(c config) config {

--- a/bridges/otellogrus/version.go
+++ b/bridges/otellogrus/version.go
@@ -1,7 +1,0 @@
-// Copyright The OpenTelemetry Authors
-// SPDX-License-Identifier: Apache-2.0
-
-package otellogrus // import "go.opentelemetry.io/contrib/bridges/otellogrus"
-
-// version is the current release version of otellogrus in use.
-const version = "0.0.1-alpha"


### PR DESCRIPTION
Resolves #5586 

Removes the import of `go.opentelemetry.io/otel/sdk` by replacing `WithInstrumentationScope` with a `name` parameters for both `NewHandler` and `NewLogger` and the added options `WithVersion` and `WithSchemaURL`.