### PR TITLE
Use more efficient `WithAttributeSet()`

### DIFF
--- a/instrumentation/google.golang.org/grpc/otelgrpc/interceptor.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/interceptor.go
@@ -333,7 +333,7 @@ func UnaryServerInterceptor(opts ...Option) grpc.UnaryServerInterceptor {
 		elapsedTime := float64(time.Since(before)) / float64(time.Millisecond)
 
 		metricAttrs = append(metricAttrs, grpcStatusCodeAttr)
-		cfg.rpcDuration.Record(ctx, elapsedTime, metric.WithAttributes(metricAttrs...))
+		cfg.rpcDuration.Record(ctx, elapsedTime, metric.WithAttributeSet(attribute.NewSet(metricAttrs...)))
 
 		return resp, err
 	}

--- a/instrumentation/net/http/otelhttp/transport.go
+++ b/instrumentation/net/http/otelhttp/transport.go
@@ -11,15 +11,14 @@ import (
 	"sync/atomic"
 	"time"
 
-	"go.opentelemetry.io/otel/metric"
-
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/internal/semconvutil"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/propagation"
-	"go.opentelemetry.io/otel/trace"
-
 	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // Transport implements the http.RoundTripper interface and wraps
@@ -170,11 +169,12 @@ func (t *Transport) RoundTrip(r *http.Request) (*http.Response, error) {
 	if res.StatusCode > 0 {
 		metricAttrs = append(metricAttrs, semconv.HTTPStatusCode(res.StatusCode))
 	}
-	o := metric.WithAttributes(metricAttrs...)
-	t.requestBytesCounter.Add(ctx, bw.read.Load(), o)
+	o := metric.WithAttributeSet(attribute.NewSet(metricAttrs...))
+	addOpts := []metric.AddOption{o} // Allocate vararg slice once.
+	t.requestBytesCounter.Add(ctx, bw.read.Load(), addOpts...)
 	// For handling response bytes we leverage a callback when the client reads the http response
 	readRecordFunc := func(n int64) {
-		t.responseBytesCounter.Add(ctx, n, o)
+		t.responseBytesCounter.Add(ctx, n, addOpts...)
 	}
 
 	// traces


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-go/blob/5661ff0ded32cf1b83f1147dae96ca403c198504/metric/instrument.go#L349-L364

Since all the usage places of `WithAttributes()` operate on a locally allocated slice, there is no need to make a defensive copy.