### PR TITLE
[chore] Fix renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,11 +21,6 @@
       "matchManagers": ["gomod"],
       "matchDepTypes": ["indirect"],
       "enabled": false
-    },
-    {
-      "matchManagers": ["pip"],
-      "packageNames": ["codespell"],
-      "enabled": true
     }
   ]
 }


### PR DESCRIPTION
The current config is invalid and because of it renovate jobs are failing.

> Repository problems
> These problems occurred while renovating this repository.
> 
> Source: renovate.json
> 
> Reason: The renovate configuration file contains some invalid settings

We do not need settings for pip. See: https://github.com/open-telemetry/opentelemetry-go/pull/5447