### PR TITLE
Set explicit boundaries for internal otlp grpc/http histogram metrics

### DIFF
--- a/instrumentation/google.golang.org/grpc/otelgrpc/config.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/config.go
@@ -86,7 +86,8 @@ func newConfig(opts []Option, role string) *config {
 	var err error
 	c.rpcDuration, err = c.meter.Float64Histogram("rpc."+role+".duration",
 		metric.WithDescription("Measures the duration of inbound RPC."),
-		metric.WithUnit("ms"))
+		metric.WithUnit("ms"),
+		metric.WithExplicitBoundaries([]float64{0, 5, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000, 25000, 50000, 75000, 100000}...))
 	if err != nil {
 		otel.Handle(err)
 		if c.rpcDuration == nil {
@@ -96,7 +97,8 @@ func newConfig(opts []Option, role string) *config {
 
 	c.rpcRequestSize, err = c.meter.Int64Histogram("rpc."+role+".request.size",
 		metric.WithDescription("Measures size of RPC request messages (uncompressed)."),
-		metric.WithUnit("By"))
+		metric.WithUnit("By"),
+		metric.WithExplicitBoundaries([]int64{0, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216}...))
 	if err != nil {
 		otel.Handle(err)
 		if c.rpcRequestSize == nil {
@@ -106,7 +108,8 @@ func newConfig(opts []Option, role string) *config {
 
 	c.rpcResponseSize, err = c.meter.Int64Histogram("rpc."+role+".response.size",
 		metric.WithDescription("Measures size of RPC response messages (uncompressed)."),
-		metric.WithUnit("By"))
+		metric.WithUnit("By"),
+		metric.WithExplicitBoundaries([]int64{0, 256, 512, 1024}...))
 	if err != nil {
 		otel.Handle(err)
 		if c.rpcResponseSize == nil {
@@ -116,7 +119,8 @@ func newConfig(opts []Option, role string) *config {
 
 	c.rpcRequestsPerRPC, err = c.meter.Int64Histogram("rpc."+role+".requests_per_rpc",
 		metric.WithDescription("Measures the number of messages received per RPC. Should be 1 for all non-streaming RPCs."),
-		metric.WithUnit("{count}"))
+		metric.WithUnit("{count}"),
+		metric.WithExplicitBoundaries([]int64{0, 256, 512, 1024}...))
 	if err != nil {
 		otel.Handle(err)
 		if c.rpcRequestsPerRPC == nil {
@@ -126,7 +130,8 @@ func newConfig(opts []Option, role string) *config {
 
 	c.rpcResponsesPerRPC, err = c.meter.Int64Histogram("rpc."+role+".responses_per_rpc",
 		metric.WithDescription("Measures the number of messages received per RPC. Should be 1 for all non-streaming RPCs."),
-		metric.WithUnit("{count}"))
+		metric.WithUnit("{count}"),
+		metric.WithExplicitBoundaries([]int64{0, 256, 512, 1024}...))
 	if err != nil {
 		otel.Handle(err)
 		if c.rpcResponsesPerRPC == nil {

--- a/instrumentation/net/http/otelhttp/handler.go
+++ b/instrumentation/net/http/otelhttp/handler.go
@@ -116,6 +116,7 @@ func (h *middleware) createMeasures() {
 		serverDuration,
 		metric.WithUnit("ms"),
 		metric.WithDescription("Measures the duration of inbound HTTP requests."),
+		metric.WithExplicitBoundaries([]float64{0, 5, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000, 25000, 50000, 75000, 100000}...),
 	)
 	handleErr(err)
 }

--- a/instrumentation/net/http/otelhttp/transport.go
+++ b/instrumentation/net/http/otelhttp/transport.go
@@ -98,6 +98,7 @@ func (t *Transport) createMeasures() {
 		clientDuration,
 		metric.WithUnit("ms"),
 		metric.WithDescription("Measures the duration of outbound HTTP requests."),
+		metric.WithExplicitBoundaries([]float64{0, 5, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000, 25000, 50000, 75000, 100000}...),
 	)
 	handleErr(err)
 }


### PR DESCRIPTION
I found that implicit boundaries of internal grpc metrics are not very useful. For example I was debugging issues with huge RPC requests (>4MB which is default limit on the collector), but histogram max bucket size is only `9.77kiB - +Inf`, so it is not visible how many huge requests I received:
![image](https://github.com/open-telemetry/opentelemetry-go-contrib/assets/1182932/032da77a-58f2-4840-a36e-dd81d2c85f74)
It will be nice to have better explicit boundaries, so I set them. It is opinionated configuration, so someone should review boundaries. I think we need to provide support for huge requests (e.g. max 16MB) and long timeouts (e.g. max 100sec).