### PR TITLE
otelgin: Using `c.FullPath()` to set `http.route` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - The superfluous `response.WriteHeader` call in `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp` when the response writer is flushed. (#5634)
 - Custom attributes targeting metrics recorded by the `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp` are not ignored anymore. (#5129)
-
+- Using `c.FullPath()` to set `http.route` attribute in [`otelgin`](go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin)
+- Support pass `routeName` to `SpanNameFormatter` in [`otelgin`](go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin)
 ### Deprecated
 
 - The `go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo` package is deprecated.

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/gintrace.go
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/gintrace.go
@@ -60,6 +60,7 @@ func Middleware(service string, opts ...Option) gin.HandlerFunc {
 		ctx := cfg.Propagators.Extract(savedCtx, propagation.HeaderCarrier(c.Request.Header))
 		opts := []oteltrace.SpanStartOption{
 			oteltrace.WithAttributes(semconvutil.HTTPServerRequest(service, c.Request)...),
+			oteltrace.WithAttributes(semconv.HTTPRoute(c.FullPath())),
 			oteltrace.WithSpanKind(oteltrace.SpanKindServer),
 		}
 		var spanName string
@@ -70,9 +71,6 @@ func Middleware(service string, opts ...Option) gin.HandlerFunc {
 		}
 		if spanName == "" {
 			spanName = fmt.Sprintf("HTTP %s route not found", c.Request.Method)
-		} else {
-			rAttr := semconv.HTTPRoute(spanName)
-			opts = append(opts, oteltrace.WithAttributes(rAttr))
 		}
 		ctx, span := tracer.Start(ctx, spanName, opts...)
 		defer span.End()

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/gintrace.go
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/gintrace.go
@@ -67,7 +67,7 @@ func Middleware(service string, opts ...Option) gin.HandlerFunc {
 		if cfg.SpanNameFormatter == nil {
 			spanName = c.FullPath()
 		} else {
-			spanName = cfg.SpanNameFormatter(c.Request)
+			spanName = cfg.SpanNameFormatter(c.FullPath(), c.Request)
 		}
 		if spanName == "" {
 			spanName = fmt.Sprintf("HTTP %s route not found", c.Request.Method)

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/option.go
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/option.go
@@ -23,8 +23,8 @@ type config struct {
 // be traced. A Filter must return true if the request should be traced.
 type Filter func(*http.Request) bool
 
-// SpanNameFormatter is used to set span name by http.request.
-type SpanNameFormatter func(r *http.Request) string
+// SpanNameFormatter is used to set span name by http.Request.
+type SpanNameFormatter func(routeName string, r *http.Request) string
 
 // Option specifies instrumentation configuration options.
 type Option interface {
@@ -70,9 +70,11 @@ func WithFilter(f ...Filter) Option {
 	})
 }
 
-// WithSpanNameFormatter takes a function that will be called on every
-// request and the returned string will become the Span Name.
-func WithSpanNameFormatter(f func(r *http.Request) string) Option {
+// WithSpanNameFormatter specifies a function to use for generating a custom span
+// name. By default, the route name (path template or regexp) is used. The route
+// name is provided so you can use it in the span name without needing to
+// duplicate the logic for extracting it from the request.
+func WithSpanNameFormatter(f func(routeName string, r *http.Request) string) Option {
 	return optionFunc(func(c *config) {
 		c.SpanNameFormatter = f
 	})


### PR DESCRIPTION
As `spanName` can be custumized with `SpanNameFormatter`, so the `spanName` may not be the same with `http.route`, e.g. the `spanName` can be `GET /users/:id`, but the `http.route` is `/users/:id`, so, using  [`c.FullPath()`](https://github.com/gin-gonic/gin/blob/v1.10.0/context.go#L165-L173) to set `http.route` attribute in `otelgin` 