### PR TITLE
Fix panic caused by invalid spanId with b3 propagator

### DIFF
--- a/propagators/b3/b3_propagator.go
+++ b/propagators/b3/b3_propagator.go
@@ -277,6 +277,9 @@ func extractSingle(ctx context.Context, contextHeader string) (context.Context, 
 		}
 		pos += separatorWidth // {traceID}-
 
+		if headerLen < pos+spanIDWidth {
+			return ctx, empty, errInvalidSpanIDValue
+		}
 		scc.SpanID, err = trace.SpanIDFromHex(contextHeader[pos : pos+spanIDWidth])
 		if err != nil {
 			return ctx, empty, errInvalidSpanIDValue

--- a/propagators/b3/b3_propagator_test.go
+++ b/propagators/b3/b3_propagator_test.go
@@ -218,12 +218,22 @@ func TestExtractSingle(t *testing.T) {
 		{"000000000000007b00000000000001c8", trace.SpanContextConfig{}, errInvalidScope, false, false},
 		// Support short trace IDs.
 		{
+			"invalid-000000000000007b",
+			trace.SpanContextConfig{},
+			errInvalidTraceIDValue, false, false,
+		},
+		{
 			"00000000000001c8-000000000000007b",
 			trace.SpanContextConfig{
 				TraceID: trace.TraceID{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x1, 0xc8},
 				SpanID:  spanID,
 			},
 			nil, false, true,
+		},
+		{
+			"000000000000007b00000000000001c8-invalid",
+			trace.SpanContextConfig{},
+			errInvalidSpanIDValue, false, false,
 		},
 		{
 			"000000000000007b00000000000001c8-000000000000007b",


### PR DESCRIPTION
### Background
When using the b3 single propagator, the presence of an invalid spanId in the request can trigger a panic.

### Cause
The panic occurs due to an array index out-of-bounds error when parsing the `SpanID` without proper length checks for invalid spanIds.

### Fix
Added a length check for `SpanID` to prevent this panic by ensuring spanIds are of valid length before processing.