### PR TITLE
Fix: Silently failing of sampling rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Custom attributes targeting metrics recorded by the `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp` are not ignored anymore. (#5129)
 - Use `c.FullPath()` method to set `http.route` attribute in `go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin`. (#5734)
 - The double setup in `go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace/example` that caused duplicate traces. (#5564)
-- Added status code check in `getSamplingRules` method to ensure only successful responses with status 200 are processed in `go.opentelemetry.io/contrib/samplers/aws/xray/internal/client.go`.
+- Added status code check in `getSamplingRules` method to ensure only successful responses with status 200 are processed in `go.opentelemetry.io/contrib/samplers/aws/xray/internal/client.go`. (#5795)
 
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Custom attributes targeting metrics recorded by the `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp` are not ignored anymore. (#5129)
 - Use `c.FullPath()` method to set `http.route` attribute in `go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin`. (#5734)
 - The double setup in `go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace/example` that caused duplicate traces. (#5564)
+- Added status code check in `getSamplingRules` method to ensure only successful responses with status 200 are processed in `go.opentelemetry.io/contrib/samplers/aws/xray/internal/client.go`.
+
 
 ### Deprecated
 

--- a/samplers/aws/xray/internal/client.go
+++ b/samplers/aws/xray/internal/client.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 )
@@ -139,6 +140,12 @@ func (c *xrayClient) getSamplingRules(ctx context.Context) (*getSamplingRulesOut
 	}
 	defer output.Body.Close()
 
+	// Check for a successful status code
+	if output.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(output.Body)
+		return nil, fmt.Errorf("xray client: received non-200 response: %d %s", output.StatusCode, string(body))
+	}
+
 	var samplingRulesOutput *getSamplingRulesOutput
 	if err := json.NewDecoder(output.Body).Decode(&samplingRulesOutput); err != nil {
 		return nil, fmt.Errorf("xray client: unable to unmarshal the response body: %w", err)
@@ -169,6 +176,12 @@ func (c *xrayClient) getSamplingTargets(ctx context.Context, s []*samplingStatis
 		return nil, fmt.Errorf("xray client: unable to retrieve sampling settings: %w", err)
 	}
 	defer output.Body.Close()
+
+	// Check for a successful status code
+	if output.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(output.Body)
+		return nil, fmt.Errorf("xray client: received non-200 response: %d %s", output.StatusCode, string(body))
+	}
 
 	var samplingTargetsOutput *getSamplingTargetsOutput
 	if err := json.NewDecoder(output.Body).Decode(&samplingTargetsOutput); err != nil {


### PR DESCRIPTION
## Added status code in checking the getSamplingRules function. Added unit test for it.

## Fixes #5717 

## Description 
 `getSamplingRules` method in the AWS X-Ray sampler did not check the HTTP response status code, potentially leading to incorrect handling of non-200 responses.

- Added a check for the HTTP response status code in the getSamplingRules method.
- If the status code is not 200, the method now returns an error instead of proceeding to unmarshal the response body.
- Included test for this status code check.
