### PR TITLE
Add tenv linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,7 @@ linters:
     - misspell
     - revive
     - staticcheck
+    - tenv
     - typecheck
     - unused
 


### PR DESCRIPTION
This is the contrib counterpart of https://github.com/open-telemetry/opentelemetry-go/pull/5524, adding the tenv linter.