### PR TITLE
otelzap: add testable example and package documentation

### DIFF
--- a/bridges/otelzap/README.md
+++ b/bridges/otelzap/README.md
@@ -1,0 +1,3 @@
+# OpenTelemetry Zap Log Bridge
+
+[![Go Reference](https://pkg.go.dev/badge/go.opentelemetry.io/contrib/bridges/otelzap.svg)](https://pkg.go.dev/go.opentelemetry.io/contrib/bridges/otelzap)

--- a/bridges/otelzap/example_test.go
+++ b/bridges/otelzap/example_test.go
@@ -1,0 +1,44 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otelzap_test
+
+import (
+	"os"
+
+	"go.opentelemetry.io/contrib/bridges/otelzap"
+	"go.opentelemetry.io/otel/log/noop"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func Example() {
+	// Use a working LoggerProvider implementation instead e.g. use go.opentelemetry.io/otel/sdk/log.
+	provider := noop.NewLoggerProvider()
+
+	// Initialize a zap logger with the otelzap bridge core.
+	// This method actually doesn't log anything on your STDOUT, as everything
+	// is shipped to a configured otel endpoint.
+	logger := zap.New(otelzap.NewCore("my/pkg/name", otelzap.WithLoggerProvider(provider)))
+
+	// You can now use your logger in your code.
+	logger.Info("something really cool")
+}
+
+func Example_multiple() {
+	// Use a working LoggerProvider implementation instead e.g. use go.opentelemetry.io/otel/sdk/log.
+	provider := noop.NewLoggerProvider()
+
+	// If you want to log also on stdout, you can initialize a new zap.Core
+	// that has multiple outputs using the method zap.NewTee(). With the following code,
+	// logs will be written to stdout and also exported to the OTEL endpoint through the bridge.
+	core := zapcore.NewTee(
+		zapcore.NewCore(zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()), zapcore.AddSync(os.Stdout), zapcore.InfoLevel),
+		otelzap.NewCore("my/pkg/name", otelzap.WithLoggerProvider(provider)),
+	)
+	logger := zap.New(core)
+
+	// You can now use your logger in your code.
+	logger.Info("something really cool")
+}


### PR DESCRIPTION
This PR adds a simple example to demonstrate how to use the OpenTelemetry Zap bridge to send logs emitted by Zap to an OTEL endpoint.

Part of #5191. 

@pellared, do we need to write a README also for this module? Or the future package godoc will be sufficient? 

