### PR TITLE
exporters/autoexport: add support for signal-specific protocols environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add support to configure views when creating MeterProvider using the config package. (#5654)
 - Add log support for the autoexport package. (#5733)
 - Add support for disabling the old runtime metrics using the `OTEL_GO_X_DEPRECATED_RUNTIME_METRICS=false` environment variable. (#5747)
+- Add support for signal-specific protocols environment variables (`OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`, `OTEL_EXPORTER_OTLP_LOGS_PROTOCOL`, `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL`) for the autoexport package. (#5807)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add support to configure views when creating MeterProvider using the config package. (#5654)
 - Add log support for the autoexport package. (#5733)
 - Add support for disabling the old runtime metrics using the `OTEL_GO_X_DEPRECATED_RUNTIME_METRICS=false` environment variable. (#5747)
-- Add support for signal-specific protocols environment variables (`OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`, `OTEL_EXPORTER_OTLP_LOGS_PROTOCOL`, `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL`) for the autoexport package. (#5807)
+- Add support for signal-specific protocols environment variables (`OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`, `OTEL_EXPORTER_OTLP_LOGS_PROTOCOL`, `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL`) in `go.opentelemetry.io/contrib/exporters/autoexport`. (#5816)
 
 ### Fixed
 

--- a/exporters/autoexport/logs.go
+++ b/exporters/autoexport/logs.go
@@ -12,6 +12,8 @@ import (
 	"go.opentelemetry.io/otel/sdk/log"
 )
 
+const otelExporterOTLPLogsProtoEnvKey = "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL"
+
 // LogOption applies an autoexport configuration option.
 type LogOption = option[log.Exporter]
 
@@ -29,6 +31,9 @@ var logsSignal = newSignal[log.Exporter]("OTEL_LOGS_EXPORTER")
 // supported values:
 //   - "http/protobuf" (default) -  protobuf-encoded data over HTTP connection;
 //     see: [go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp]
+//
+// OTEL_EXPORTER_OTLP_LOGS_PROTOCOL defines OTLP exporter's transport protocol for the logs signal;
+// supported values are the same as OTEL_EXPORTER_OTLP_PROTOCOL.
 //
 // An error is returned if an environment value is set to an unhandled value.
 //
@@ -51,7 +56,12 @@ func RegisterLogExporter(name string, factory func(context.Context) (log.Exporte
 
 func init() {
 	RegisterLogExporter("otlp", func(ctx context.Context) (log.Exporter, error) {
-		proto := os.Getenv(otelExporterOTLPProtoEnvKey)
+		proto := os.Getenv(otelExporterOTLPLogsProtoEnvKey)
+		if proto == "" {
+			proto = os.Getenv(otelExporterOTLPProtoEnvKey)
+		}
+
+		// Fallback to default, http/protobuf.
 		if proto == "" {
 			proto = "http/protobuf"
 		}

--- a/exporters/autoexport/logs_test.go
+++ b/exporters/autoexport/logs_test.go
@@ -60,6 +60,32 @@ func TestLogExporterOTLP(t *testing.T) {
 	}
 }
 
+func TestLogExporterOTLPWithDedicatedProtocol(t *testing.T) {
+	t.Setenv("OTEL_LOGS_EXPORTER", "otlp")
+
+	for _, tc := range []struct {
+		protocol, clientType string
+	}{
+		{"http/protobuf", "atomic.Pointer[go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp.client]"},
+		{"", "atomic.Pointer[go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp.client]"},
+	} {
+		t.Run(fmt.Sprintf("protocol=%q", tc.protocol), func(t *testing.T) {
+			t.Setenv("OTEL_EXPORTER_OTLP_LOGS_PROTOCOL", tc.protocol)
+
+			got, err := NewLogExporter(context.Background())
+			assert.NoError(t, err)
+			t.Cleanup(func() {
+				assert.NoError(t, got.Shutdown(context.Background()))
+			})
+			assert.Implements(t, new(log.Exporter), got)
+
+			// Implementation detail hack. This may break when bumping OTLP exporter modules as it uses unexported API.
+			clientType := reflect.Indirect(reflect.ValueOf(got)).FieldByName("client").Type()
+			assert.Equal(t, tc.clientType, clientType.String())
+		})
+	}
+}
+
 func TestLogExporterOTLPOverInvalidProtocol(t *testing.T) {
 	t.Setenv("OTEL_LOGS_EXPORTER", "otlp")
 	t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "invalid-protocol")

--- a/exporters/autoexport/metrics.go
+++ b/exporters/autoexport/metrics.go
@@ -25,6 +25,8 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric"
 )
 
+const otelExporterOTLPMetricsProtoEnvKey = "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"
+
 // MetricOption applies an autoexport configuration option.
 type MetricOption = option[metric.Reader]
 
@@ -49,6 +51,9 @@ func WithFallbackMetricReader(metricReaderFactory func(ctx context.Context) (met
 //     see: [go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc]
 //   - "http/protobuf" (default) -  protobuf-encoded data over HTTP connection;
 //     see: [go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp]
+//
+// OTEL_EXPORTER_OTLP_METRICS_PROTOCOL defines OTLP exporter's transport protocol for the metrics signal;
+// supported values are the same as OTEL_EXPORTER_OTLP_PROTOCOL.
 //
 // OTEL_EXPORTER_PROMETHEUS_HOST (defaulting to "localhost") and
 // OTEL_EXPORTER_PROMETHEUS_PORT (defaulting to 9464) define the host and port for the
@@ -106,7 +111,12 @@ func init() {
 			readerOpts = append(readerOpts, metric.WithProducer(producer))
 		}
 
-		proto := os.Getenv(otelExporterOTLPProtoEnvKey)
+		proto := os.Getenv(otelExporterOTLPMetricsProtoEnvKey)
+		if proto == "" {
+			proto = os.Getenv(otelExporterOTLPProtoEnvKey)
+		}
+
+		// Fallback to default, http/protobuf.
 		if proto == "" {
 			proto = "http/protobuf"
 		}

--- a/exporters/autoexport/spans.go
+++ b/exporters/autoexport/spans.go
@@ -13,6 +13,8 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace"
 )
 
+const otelExporterOTLPTracesProtoEnvKey = "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"
+
 // SpanOption applies an autoexport configuration option.
 type SpanOption = option[trace.SpanExporter]
 
@@ -42,6 +44,9 @@ func WithFallbackSpanExporter(spanExporterFactory func(ctx context.Context) (tra
 //   - "http/protobuf" (default) -  protobuf-encoded data over HTTP connection;
 //     see: [go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp]
 //
+// OTEL_EXPORTER_OTLP_TRACES_PROTOCOL defines OTLP exporter's transport protocol for the traces signal;
+// supported values are the same as OTEL_EXPORTER_OTLP_PROTOCOL.
+//
 // An error is returned if an environment value is set to an unhandled value.
 //
 // Use [RegisterSpanExporter] to handle more values of OTEL_TRACES_EXPORTER.
@@ -65,7 +70,12 @@ var tracesSignal = newSignal[trace.SpanExporter]("OTEL_TRACES_EXPORTER")
 
 func init() {
 	RegisterSpanExporter("otlp", func(ctx context.Context) (trace.SpanExporter, error) {
-		proto := os.Getenv(otelExporterOTLPProtoEnvKey)
+		proto := os.Getenv(otelExporterOTLPTracesProtoEnvKey)
+		if proto == "" {
+			proto = os.Getenv(otelExporterOTLPProtoEnvKey)
+		}
+
+		// Fallback to default, http/protobuf.
 		if proto == "" {
 			proto = "http/protobuf"
 		}


### PR DESCRIPTION
This PR adds support for signal-specific environment variables to configure the OTLP protocol used with the exporter. 

The following environment variables have been added to configure signal-specific protocols:

- `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`
- `OTEL_EXPORTER_OTLP_LOGS_PROTOCOL`
- `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL`

The package will first attempt to load the protocol for a signal from the corresponding environment variable. If it is not set or is empty, it will try to determine the protocol from `OTEL_EXPORTER_OTLP_PROTOCOL`. If this is also not defined or is empty, it will fall back to `http/protobuf`.

**Note for reviewers**: As you'll see in the code, I use my own [env](https://github.com/thomasgouveia/goutils/tree/main/env) package (MIT License) to facilitate environment variable management. If needed, I can backport the used functions into the code here and remove the dependency. Let me know.

Closes https://github.com/open-telemetry/opentelemetry-go-contrib/issues/5807