### PR TITLE
Add comment to the safety of the uint8 cast

### DIFF
--- a/samplers/probability/consistent/tracestate.go
+++ b/samplers/probability/consistent/tracestate.go
@@ -198,6 +198,7 @@ func parseNumber(key string, input string, maximum uint8) (uint8, error) {
 	if value > uint64(maximum) {
 		return maximum + 1, parseError(key, strconv.ErrRange)
 	}
+	// `value` is strictly less then the uint8 maximum. This cast is safe.
 	return uint8(value), nil
 }
 


### PR DESCRIPTION
Closes #5666
Closes #5571 
Closes #5626

The conversion referenced in both issues is impossible to overflow. This PR leaves a comment to that effect.