### PR TITLE
Revert toolchain addition to autoexport

### DIFF
--- a/exporters/autoexport/go.mod
+++ b/exporters/autoexport/go.mod
@@ -1,8 +1,6 @@
 module go.opentelemetry.io/contrib/exporters/autoexport
 
-go 1.21.0
-
-toolchain go1.22.4
+go 1.21
 
 require (
 	github.com/prometheus/client_golang v1.19.1


### PR DESCRIPTION
Reverts changes introduced in #5779. Drops the toolchain directive in go.mod. This addition adds project wide issues
(https://github.com/open-telemetry/opentelemetry-go-contrib/actions/runs/9765870369/job/26957555908?pr=5839).

If toolchains are going to be used, they need to be added project wide.