### PR TITLE
Upgrade Go versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
   # backwards compatibility with the previous two minor releases and we
   # explicitly test our code for these versions so keeping this at prior
   # versions does not add value.
-  DEFAULT_GO_VERSION: "~1.22.4"
+  DEFAULT_GO_VERSION: "~1.22.5"
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -101,7 +101,7 @@ jobs:
   compatibility-test:
     strategy:
       matrix:
-        go-version: ["~1.22.4", "~1.21.11"]
+        go-version: ["~1.22.4", "~1.21.12"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         # GitHub Actions does not support arm* architectures on default
         # runners. It is possible to accomplish this with a self-hosted runner


### PR DESCRIPTION
Address https://pkg.go.dev/vuln/GO-2024-2963 which is blocking things: https://github.com/open-telemetry/opentelemetry-go-contrib/actions/runs/9767710483/job/26963575194?pr=5838