### PR TITLE
otelgrpc: update semconv to v1.26.0

### DIFF
--- a/instrumentation/google.golang.org/grpc/otelgrpc/config.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/config.go
@@ -11,7 +11,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/propagation"
-	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/instrumentation/google.golang.org/grpc/otelgrpc/interceptor.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/interceptor.go
@@ -24,7 +24,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
-	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -479,13 +479,13 @@ func peerAttr(addr string) []attribute.KeyValue {
 	var attr []attribute.KeyValue
 	if ip := net.ParseIP(host); ip != nil {
 		attr = []attribute.KeyValue{
-			semconv.NetSockPeerAddr(host),
-			semconv.NetSockPeerPort(port),
+			semconv.NetworkPeerAddress(host),
+			semconv.NetworkPeerPort(port),
 		}
 	} else {
 		attr = []attribute.KeyValue{
-			semconv.NetPeerName(host),
-			semconv.NetPeerPort(port),
+			semconv.NetworkPeerAddress(host),
+			semconv.NetworkPeerPort(port),
 		}
 	}
 

--- a/instrumentation/google.golang.org/grpc/otelgrpc/internal/parse.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/internal/parse.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
 
 // ParseFullMethod returns a span name following the OpenTelemetry semantic

--- a/instrumentation/google.golang.org/grpc/otelgrpc/internal/parse_test.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/internal/parse_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/instrumentation/google.golang.org/grpc/otelgrpc/semconv.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/semconv.go
@@ -5,7 +5,7 @@ package otelgrpc // import "go.opentelemetry.io/contrib/instrumentation/google.g
 
 import (
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
 
 // Semantic conventions for attribute keys for gRPC.

--- a/instrumentation/google.golang.org/grpc/otelgrpc/stats_handler.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/stats_handler.go
@@ -17,7 +17,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
-	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -157,10 +157,10 @@ func (c *config) handleRPC(ctx context.Context, rs stats.RPCStats, isServer bool
 		if c.ReceivedEvent {
 			span.AddEvent("message",
 				trace.WithAttributes(
-					semconv.MessageTypeReceived,
-					semconv.MessageIDKey.Int64(messageId),
-					semconv.MessageCompressedSizeKey.Int(rs.CompressedLength),
-					semconv.MessageUncompressedSizeKey.Int(rs.Length),
+					semconv.MessagingOperationTypeReceive,
+					semconv.MessagingMessageIDKey.Int64(messageId),
+					semconv.RPCMessageCompressedSize(rs.CompressedLength),
+					semconv.RPCMessageUncompressedSize(rs.Length),
 				),
 			)
 		}
@@ -173,10 +173,10 @@ func (c *config) handleRPC(ctx context.Context, rs stats.RPCStats, isServer bool
 		if c.SentEvent {
 			span.AddEvent("message",
 				trace.WithAttributes(
-					semconv.MessageTypeSent,
-					semconv.MessageIDKey.Int64(messageId),
-					semconv.MessageCompressedSizeKey.Int(rs.CompressedLength),
-					semconv.MessageUncompressedSizeKey.Int(rs.Length),
+					semconv.RPCMessageTypeSent,
+					semconv.MessagingMessageIDKey.Int64(messageId),
+					semconv.RPCMessageCompressedSize(rs.CompressedLength),
+					semconv.RPCMessageUncompressedSize(rs.Length),
 				),
 			)
 		}

--- a/instrumentation/google.golang.org/grpc/otelgrpc/test/grpc_stats_handler_test.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/test/grpc_stats_handler_test.go
@@ -29,7 +29,7 @@ import (
 
 	"go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 
 	testpb "google.golang.org/grpc/interop/grpc_testing"
 )

--- a/instrumentation/google.golang.org/grpc/otelgrpc/test/grpc_test.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/test/grpc_test.go
@@ -24,7 +24,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
 	"go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 
 	pb "google.golang.org/grpc/interop/grpc_testing"
 )

--- a/instrumentation/google.golang.org/grpc/otelgrpc/test/interceptor_test.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/test/interceptor_test.go
@@ -21,7 +21,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
 	"go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	oteltrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/stretchr/testify/assert"

--- a/instrumentation/google.golang.org/grpc/otelgrpc/test/stats_handler_test.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/test/stats_handler_test.go
@@ -20,7 +20,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
 	"go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
 
 func TestStatsHandlerHandleRPCServerErrors(t *testing.T) {


### PR DESCRIPTION
Update semconv to v1.26.0 instead of too old of v1.17.0.