### PR TITLE
Don't write headers twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Drop support for [Go 1.21]. (#6046, #6047)
 
+### Fixes
+
+- Superfluous `response.WriteHeader` call in `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp`. (#6054)
+
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->
 

--- a/instrumentation/net/http/otelhttp/internal/request/resp_writer_wrapper.go
+++ b/instrumentation/net/http/otelhttp/internal/request/resp_writer_wrapper.go
@@ -74,8 +74,8 @@ func (w *RespWriterWrapper) writeHeader(statusCode int) {
 	if !w.wroteHeader {
 		w.wroteHeader = true
 		w.statusCode = statusCode
+		w.ResponseWriter.WriteHeader(statusCode)
 	}
-	w.ResponseWriter.WriteHeader(statusCode)
 }
 
 // Flush implements [http.Flusher].


### PR DESCRIPTION
The change in https://github.com/open-telemetry/opentelemetry-go-contrib/pull/5916 introduced a regression, as we check for `wroteHeader`, but then always write anyway.
We need to only write if the header wasn't written yet.

Fixes #6053.