### PR TITLE
Don't write headers on `Write` if they were already written

### DIFF
--- a/instrumentation/net/http/otelhttp/internal/request/resp_writer_wrapper.go
+++ b/instrumentation/net/http/otelhttp/internal/request/resp_writer_wrapper.go
@@ -44,7 +44,9 @@ func (w *RespWriterWrapper) Write(p []byte) (int, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	w.writeHeader(http.StatusOK)
+	if !w.wroteHeader {
+		w.writeHeader(http.StatusOK)
+	}
 
 	n, err := w.ResponseWriter.Write(p)
 	n1 := int64(n)

--- a/instrumentation/net/http/otelhttp/test/handler_test.go
+++ b/instrumentation/net/http/otelhttp/test/handler_test.go
@@ -250,6 +250,21 @@ func TestHandlerPropagateWriteHeaderCalls(t *testing.T) {
 			},
 			expectHeadersWritten: []int{http.StatusInternalServerError, http.StatusOK},
 		},
+		{
+			name: "When writing the header indirectly through body write",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte("hello"))
+			},
+			expectHeadersWritten: []int{http.StatusOK},
+		},
+		{
+			name: "With a header already written when writing the body",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte("hello"))
+			},
+			expectHeadersWritten: []int{http.StatusBadRequest},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
The change in #5916 introduced a regression, as we don't check whether the header was written before writing it in `Write()`.
We need to only write if the header wasn't written yet.

Fixes #6053.