### PR TITLE
config: Add `WithPrometheusRegisterer` config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Add `NewProducer` to `go.opentelemetry.io/contrib/instrumentation/runtime`, which allows collecting the `go.schedule.duration` histogram metric from the Go runtime. (#5991)
-- Add `WithRegistry` to `go.opentelemetry.io/contrib/config` to allow users to configure their own prometheus registry and server.
+- Add `WithRegistry` to `go.opentelemetry.io/contrib/config` to allow users to configure their own prometheus registry and server. (#6091)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Add `NewProducer` to `go.opentelemetry.io/contrib/instrumentation/runtime`, which allows collecting the `go.schedule.duration` histogram metric from the Go runtime. (#5991)
-- Add `WithRegistry` to `go.opentelemetry.io/contrib/config` to allow users to configure their own prometheus registry and server. (#6091)
+- Add `WithPrometheusRegisterer` to `go.opentelemetry.io/contrib/config` to allow users to configure their own prometheus registry and handler. (#6091)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Add `NewProducer` to `go.opentelemetry.io/contrib/instrumentation/runtime`, which allows collecting the `go.schedule.duration` histogram metric from the Go runtime. (#5991)
+- Add `WithRegistry` to `go.opentelemetry.io/contrib/config` to allow users to configure their own prometheus registry and server.
 
 ### Removed
 

--- a/config/config.go
+++ b/config/config.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/log"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
@@ -23,6 +24,7 @@ const (
 type configOptions struct {
 	ctx                 context.Context
 	opentelemetryConfig OpenTelemetryConfiguration
+	prometheusRegistry  *prometheus.Registry
 }
 
 type shutdownFunc func(context.Context) error
@@ -123,6 +125,17 @@ func WithContext(ctx context.Context) ConfigurationOption {
 func WithOpenTelemetryConfiguration(cfg OpenTelemetryConfiguration) ConfigurationOption {
 	return configurationOptionFunc(func(c configOptions) configOptions {
 		c.opentelemetryConfig = cfg
+		return c
+	})
+}
+
+// WithPrometheusRegistry sets a Prometheus registered to be used by
+// any Prometheus exporters configured in this SDK. Note: if this option
+// is set, the caller is expected to initialize their own handler to
+// expose Prometheus metrics.
+func WithPrometheusRegistry(reg *prometheus.Registry) ConfigurationOption {
+	return configurationOptionFunc(func(c configOptions) configOptions {
+		c.prometheusRegistry = reg
 		return c
 	})
 }

--- a/config/config.go
+++ b/config/config.go
@@ -24,7 +24,7 @@ const (
 type configOptions struct {
 	ctx                  context.Context
 	opentelemetryConfig  OpenTelemetryConfiguration
-	prometheusRegisterer *prometheus.Registerer
+	prometheusRegisterer prometheus.Registerer
 }
 
 type shutdownFunc func(context.Context) error
@@ -133,7 +133,7 @@ func WithOpenTelemetryConfiguration(cfg OpenTelemetryConfiguration) Configuratio
 // any Prometheus exporters configured in this SDK. Note: if this option
 // is set, the caller is expected to initialize their own handler to
 // expose Prometheus metrics.
-func WithPrometheusRegisterer(reg *prometheus.Registerer) ConfigurationOption {
+func WithPrometheusRegisterer(reg prometheus.Registerer) ConfigurationOption {
 	return configurationOptionFunc(func(c configOptions) configOptions {
 		c.prometheusRegisterer = reg
 		return c

--- a/config/config.go
+++ b/config/config.go
@@ -22,9 +22,9 @@ const (
 )
 
 type configOptions struct {
-	ctx                 context.Context
-	opentelemetryConfig OpenTelemetryConfiguration
-	prometheusRegistry  *prometheus.Registry
+	ctx                  context.Context
+	opentelemetryConfig  OpenTelemetryConfiguration
+	prometheusRegisterer *prometheus.Registerer
 }
 
 type shutdownFunc func(context.Context) error
@@ -129,13 +129,13 @@ func WithOpenTelemetryConfiguration(cfg OpenTelemetryConfiguration) Configuratio
 	})
 }
 
-// WithPrometheusRegistry sets a Prometheus registered to be used by
+// WithPrometheusRegisterer sets a Prometheus registerer to be used by
 // any Prometheus exporters configured in this SDK. Note: if this option
 // is set, the caller is expected to initialize their own handler to
 // expose Prometheus metrics.
-func WithPrometheusRegistry(reg *prometheus.Registry) ConfigurationOption {
+func WithPrometheusRegisterer(reg *prometheus.Registerer) ConfigurationOption {
 	return configurationOptionFunc(func(c configOptions) configOptions {
-		c.prometheusRegistry = reg
+		c.prometheusRegisterer = reg
 		return c
 	})
 }

--- a/config/metric.go
+++ b/config/metric.go
@@ -251,8 +251,8 @@ func prometheusReader(cfg configOptions, prometheusConfig *Prometheus) (sdkmetri
 	// if a registry is set, the caller is expected
 	// to setup a prometheus server, all that's needed
 	// is to pass the option and return the reader here
-	if cfg.prometheusRegistry != nil {
-		opts = append(opts, otelprom.WithRegisterer(cfg.prometheusRegistry))
+	if cfg.prometheusRegisterer != nil {
+		opts = append(opts, otelprom.WithRegisterer(cfg.prometheusRegisterer))
 		return otelprom.New(opts...)
 	}
 

--- a/config/metric_test.go
+++ b/config/metric_test.go
@@ -480,7 +480,7 @@ func TestReader(t *testing.T) {
 	}
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := metricReader(context.Background(), tt.reader)
+			got, err := metricReader(configOptions{}, tt.reader)
 			require.Equal(t, tt.wantErr, err)
 			if tt.wantReader == nil {
 				require.Nil(t, got)


### PR DESCRIPTION
This is to allow the OTel Collector to configure its own handler for prometheus metrics, allowing it to manage error reporting and shutdown.

I'm opening this PR to get feedback from contributors on whether this approach makes sense or not, will add tests once I get some feedback.