### PR TITLE
Protect against multiple WriteHeader calls

### DIFF
--- a/instrumentation/net/http/otelhttp/internal/request/resp_writer_wrapper.go
+++ b/instrumentation/net/http/otelhttp/internal/request/resp_writer_wrapper.go
@@ -73,11 +73,13 @@ func (w *RespWriterWrapper) WriteHeader(statusCode int) {
 // It does not acquire a lock, and therefore assumes that is being handled by a
 // parent method.
 func (w *RespWriterWrapper) writeHeader(statusCode int) {
+	// Make sure we only write the header once.
 	if !w.wroteHeader {
 		w.wroteHeader = true
 		w.statusCode = statusCode
+
+		w.ResponseWriter.WriteHeader(statusCode)
 	}
-	w.ResponseWriter.WriteHeader(statusCode)
 }
 
 // Flush implements [http.Flusher].


### PR DESCRIPTION
In the RespWriterWrapper there was a logic issue. The instance tracks whether WriteHeader has been called or not, but was still attempting to call it again even when it had already been called.

This updates the internal implementation to recognize if it's already been called and make any additional attempts a no-op. This avoids errors bubbling up for "superfluous response.WriteHeader calls".

Closes: #6112 