### PR TITLE
[chore]: enable error-nil and nil-compare rules from testifylint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -249,11 +249,9 @@ linters-settings:
     disable:
       - compares
       - error-is-as
-      - error-nil
       - expected-actual
       - float-compare
       - formatter
       - go-require
       - negative-positive
-      - nil-compare
       - require-error

--- a/bridges/prometheus/producer_test.go
+++ b/bridges/prometheus/producer_test.go
@@ -434,7 +434,7 @@ func TestProduce(t *testing.T) {
 			p := NewMetricProducer(WithGatherer(reg))
 			output, err := p.Produce(context.Background())
 			if tt.wantErr == nil {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 			}
 			require.Equal(t, len(output), len(tt.expected))
 			for i := range output {

--- a/detectors/aws/ecs/ecs_test.go
+++ b/detectors/aws/ecs/ecs_test.go
@@ -169,7 +169,7 @@ func TestDetectCannotReadContainerID(t *testing.T) {
 	detector := &resourceDetector{utils: detectorUtils}
 	res, err := detector.Detect(context.Background())
 
-	assert.Equal(t, nil, err)
+	assert.NoError(t, err)
 	assert.Equal(t, expectedResource, res, "Resource returned is incorrect")
 }
 

--- a/detectors/aws/ecs/test/ecs_test.go
+++ b/detectors/aws/ecs/test/ecs_test.go
@@ -79,7 +79,7 @@ func TestDetectV4LaunchTypeEc2(t *testing.T) {
 	detector := ecs.NewResourceDetector()
 	res, err := detector.Detect(context.Background())
 
-	assert.Equal(t, nil, err, "Detector should not fail")
+	assert.NoError(t, err, "Detector should not fail")
 	assert.Equal(t, expectedResource, res, "Resource returned is incorrect")
 }
 
@@ -139,7 +139,7 @@ func TestDetectV4LaunchTypeEc2BadContainerArn(t *testing.T) {
 	detector := ecs.NewResourceDetector()
 	res, err := detector.Detect(context.Background())
 
-	assert.Equal(t, nil, err, "Detector should not fail")
+	assert.NoError(t, err, "Detector should not fail")
 	assert.Equal(t, expectedResource, res, "Resource returned is incorrect")
 }
 
@@ -199,7 +199,7 @@ func TestDetectV4LaunchTypeEc2BadTaskArn(t *testing.T) {
 	detector := ecs.NewResourceDetector()
 	res, err := detector.Detect(context.Background())
 
-	assert.Equal(t, nil, err, "Detector should not fail")
+	assert.NoError(t, err, "Detector should not fail")
 	assert.Equal(t, expectedResource, res, "Resource returned is incorrect")
 }
 
@@ -259,6 +259,6 @@ func TestDetectV4LaunchTypeFargate(t *testing.T) {
 	detector := ecs.NewResourceDetector()
 	res, err := detector.Detect(context.Background())
 
-	assert.Equal(t, nil, err, "Detector should not fail")
+	assert.NoError(t, err, "Detector should not fail")
 	assert.Equal(t, expectedResource, res, "Resource returned is incorrect")
 }

--- a/detectors/aws/lambda/detector_test.go
+++ b/detectors/aws/lambda/detector_test.go
@@ -35,7 +35,7 @@ func TestDetectSuccess(t *testing.T) {
 	detector := resourceDetector{}
 	res, err := detector.Detect(context.Background())
 
-	assert.Nil(t, err, "Detector unexpectedly returned error")
+	assert.NoError(t, err, "Detector unexpectedly returned error")
 	assert.Equal(t, expectedResource, res, "Resource returned is incorrect")
 }
 

--- a/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/test/aws_test.go
+++ b/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/test/aws_test.go
@@ -126,7 +126,7 @@ func TestAppendMiddlewares(t *testing.T) {
 			if c.expectedError == codes.Unset {
 				assert.NoError(t, err)
 			} else {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 			}
 
 			spans := sr.Ended()

--- a/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/test/dynamodbattributes_test.go
+++ b/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/test/dynamodbattributes_test.go
@@ -81,7 +81,7 @@ func TestDynamodbTags(t *testing.T) {
 		if cases.expectedError == codes.Unset {
 			assert.NoError(t, err)
 		} else {
-			assert.NotNil(t, err)
+			assert.Error(t, err)
 		}
 
 		spans := sr.Ended()
@@ -163,7 +163,7 @@ func TestDynamodbTagsCustomSetter(t *testing.T) {
 		if cases.expectedError == codes.Unset {
 			assert.NoError(t, err)
 		} else {
-			assert.NotNil(t, err)
+			assert.Error(t, err)
 		}
 
 		spans := sr.Ended()

--- a/instrumentation/google.golang.org/grpc/otelgrpc/test/interceptor_test.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/test/interceptor_test.go
@@ -581,7 +581,7 @@ func TestStreamClientInterceptorOnUnidirectionalClientServerStream(t *testing.T)
 	// and RecvMsg() calls.
 	_ = streamClient.CloseSend()
 	err := streamClient.RecvMsg(reply)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// wait for span end that is called in separate go routine
 	var span trace.ReadOnlySpan

--- a/samplers/aws/xray/internal/manifest_test.go
+++ b/samplers/aws/xray/internal/manifest_test.go
@@ -211,7 +211,7 @@ func TestMatchAgainstManifestRulesAttributeWildCardMatch(t *testing.T) {
 	require.NoError(t, err)
 
 	// assert that manifest rule r1 is a match
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, *exp, r1)
 }
 


### PR DESCRIPTION
#### Description

Testifylint is a linter that provides best practices with the use of testify.

This PR enables [error-nil](https://github.com/Antonboom/testifylint?tab=readme-ov-file#error-nil) and [nil-compare](https://github.com/Antonboom/testifylint?tab=readme-ov-file#nil-compare) rules from [testifylint](https://github.com/Antonboom/testifylint)