### PR TITLE
[chore]: enable compares and negative-positive rules from testifylint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -247,10 +247,8 @@ linters-settings:
   testifylint:
     enable-all: true
     disable:
-      - compares
       - expected-actual
       - float-compare
       - formatter
       - go-require
-      - negative-positive
       - require-error

--- a/instrumentation/runtime/runtime_test.go
+++ b/instrumentation/runtime/runtime_test.go
@@ -182,7 +182,7 @@ func assertNonZeroValues(t *testing.T, sm metricdata.ScopeMetrics) {
 		switch a := m.Data.(type) {
 		case metricdata.Sum[int64]:
 			for _, dp := range a.DataPoints {
-				assert.True(t, dp.Value > 0, fmt.Sprintf("Metric %q should have a non-zero value for point with attributes %+v", m.Name, dp.Attributes))
+				assert.Positive(t, dp.Value, fmt.Sprintf("Metric %q should have a non-zero value for point with attributes %+v", m.Name, dp.Attributes))
 			}
 		default:
 			t.Fatalf("unexpected data type %v", a)

--- a/propagators/b3/b3_propagator_test.go
+++ b/propagators/b3/b3_propagator_test.go
@@ -301,7 +301,7 @@ func TestB3EncodingOperations(t *testing.T) {
 	for i, e := range encodings {
 		for j := i + 1; j < i+len(encodings); j++ {
 			o := encodings[j%len(encodings)]
-			assert.False(t, e == o, "%v == %v", e, o)
+			assert.NotEqual(t, e, o, "%v == %v", e, o)
 		}
 	}
 


### PR DESCRIPTION
#### Description

Testifylint is a linter that provides best practices with the use of testify.

This PR enables [compares](https://github.com/Antonboom/testifylint?tab=readme-ov-file#compares) and [negative-positive](https://github.com/Antonboom/testifylint?tab=readme-ov-file#negative-positive) rules from [testifylint](https://github.com/Antonboom/testifylint)