### PR TITLE
[chore]: enable go-require rule from testifylint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -250,5 +250,4 @@ linters-settings:
       - expected-actual
       - float-compare
       - formatter
-      - go-require
       - require-error

--- a/exporters/autoexport/registry_test.go
+++ b/exporters/autoexport/registry_test.go
@@ -49,7 +49,7 @@ func TestRegistryIsConcurrentSafe(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		require.ErrorIs(t, r.store(exporterName, factory("stdout")), errDuplicateRegistration)
+		assert.ErrorIs(t, r.store(exporterName, factory("stdout")), errDuplicateRegistration)
 	}()
 
 	wg.Add(1)

--- a/instrumentation/google.golang.org/grpc/otelgrpc/test/grpc_stats_handler_test.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/test/grpc_stats_handler_test.go
@@ -1509,12 +1509,12 @@ func TestStatsHandlerConcurrentSafeContextCancellation(t *testing.T) {
 				}
 				err := stream.Send(req)
 				if errors.Is(err, io.EOF) { // possible due to context cancellation
-					require.ErrorIs(t, ctx.Err(), context.Canceled)
+					assert.ErrorIs(t, ctx.Err(), context.Canceled)
 				} else {
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}
 			}
-			require.NoError(t, stream.CloseSend())
+			assert.NoError(t, stream.CloseSend())
 		}()
 
 		wg.Add(1)
@@ -1529,7 +1529,7 @@ func TestStatsHandlerConcurrentSafeContextCancellation(t *testing.T) {
 				if status.Code(err) == codes.Canceled {
 					return
 				}
-				require.NoError(t, err)
+				assert.NoError(t, err)
 			}
 		}()
 

--- a/instrumentation/net/http/otelhttp/test/handler_test.go
+++ b/instrumentation/net/http/otelhttp/test/handler_test.go
@@ -314,7 +314,7 @@ func TestHandlerRequestWithTraceContext(t *testing.T) {
 	h := otelhttp.NewHandler(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			_, err := w.Write([]byte("hello world"))
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		}), "test_handler")
 
 	r, err := http.NewRequest(http.MethodGet, "http://localhost/", nil)

--- a/instrumentation/net/http/otelhttp/test/transport_test.go
+++ b/instrumentation/net/http/otelhttp/test/transport_test.go
@@ -144,7 +144,7 @@ func TestTransportRequestWithTraceContext(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, err := w.Write(content)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}))
 	defer ts.Close()
 
@@ -190,7 +190,7 @@ func TestWithHTTPTrace(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, err := w.Write(content)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}))
 	defer ts.Close()
 

--- a/instrumentation/net/http/otelhttp/transport_test.go
+++ b/instrumentation/net/http/otelhttp/transport_test.go
@@ -382,12 +382,12 @@ func TestTransportProtocolSwitch(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		conn, buf, err := w.(http.Hijacker).Hijack()
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
 		_, err = buf.Write(response)
-		require.NoError(t, err)
-		require.NoError(t, buf.Flush())
-		require.NoError(t, conn.Close())
+		assert.NoError(t, err)
+		assert.NoError(t, buf.Flush())
+		assert.NoError(t, conn.Close())
 	}))
 	defer ts.Close()
 

--- a/samplers/aws/xray/internal/client_test.go
+++ b/samplers/aws/xray/internal/client_test.go
@@ -17,7 +17,7 @@ import (
 func createTestClient(t *testing.T, body []byte) *xrayClient {
 	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
 		_, err := res.Write(body)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}))
 	t.Cleanup(testServer.Close)
 

--- a/samplers/aws/xray/internal/manifest_test.go
+++ b/samplers/aws/xray/internal/manifest_test.go
@@ -1625,7 +1625,7 @@ func TestUpdatingRulesAndTargetsWhileMatchingConcurrentSafe(t *testing.T) {
 			manifest := m.deepCopy()
 
 			err := manifest.updateReservoir(createSamplingTargetDocument("r1", 0, 0.05, 10, 13000000))
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			time.Sleep(time.Millisecond)
 
 			m.mu.Lock()
@@ -1827,7 +1827,7 @@ func TestUpdatingSamplingStatisticsWhenSamplingConcurrentSafe(t *testing.T) {
 			manifest := m.deepCopy()
 
 			_, err := manifest.snapshots()
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
 			m.mu.Lock()
 			m.Rules = manifest.Rules

--- a/samplers/aws/xray/internal/rule_test.go
+++ b/samplers/aws/xray/internal/rule_test.go
@@ -634,7 +634,7 @@ func TestUpdatingRulesAndTargetsWhileSamplingConcurrentSafe(t *testing.T) {
 			manifest := m.deepCopy()
 
 			err := manifest.updateReservoir(&st)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			time.Sleep(time.Millisecond)
 
 			m.mu.Lock()


### PR DESCRIPTION
#### Description

Testifylint is a linter that provides best practices with the use of testify.

This PR enables [go-require](https://github.com/Antonboom/testifylint?tab=readme-ov-file#go-require) rule from [testifylint](https://github.com/Antonboom/testifylint)