### PR TITLE
Move @hanyuancheung to Emeritus status

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -45,11 +45,11 @@ exporters/autoexport                                                    @open-te
 instrumentation/github.com/aws/aws-lambda-go/otellambda/                @open-telemetry/go-approvers @akats7
 instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/                   @open-telemetry/go-approvers @akats7
 instrumentation/github.com/emicklei/go-restful/otelrestful/             @open-telemetry/go-approvers @dashpole
-instrumentation/github.com/gin-gonic/gin/otelgin/                       @open-telemetry/go-approvers @hanyuancheung
+instrumentation/github.com/gin-gonic/gin/otelgin/                       @open-telemetry/go-approvers
 instrumentation/github.com/gorilla/mux/otelmux/                         @open-telemetry/go-approvers @akats7
 instrumentation/github.com/labstack/echo/otelecho/                      @open-telemetry/go-approvers
 instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/            @open-telemetry/go-approvers
-instrumentation/google.golang.org/grpc/otelgrpc/                        @open-telemetry/go-approvers @dashpole @hanyuancheung
+instrumentation/google.golang.org/grpc/otelgrpc/                        @open-telemetry/go-approvers @dashpole
 instrumentation/gopkg.in/macaron.v1/otelmacaron/                        @open-telemetry/go-approvers
 
 instrumentation/host/                                                   @open-telemetry/go-approvers

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,8 +125,6 @@ See the [public meeting notes](https://docs.google.com/document/d/1E5e7Ld0NuU1iV
 
 Approvers:
 
-- [Chester Cheung](https://github.com/hanyuancheung), Tencent
-
 Maintainers:
 
 - [Damien Mathieu](https://github.com/dmathieu), Elastic
@@ -139,6 +137,7 @@ Emeritus:
 
 - [Aaron Clawson](https://github.com/MadVikingGod), LightStep
 - [Anthony Mirabella](https://github.com/Aneurysm9), Amazon
+- [Chester Cheung](https://github.com/hanyuancheung), Tencent
 - [Evan Torrie](https://github.com/evantorrie), Yahoo
 - [Gustavo Silva Paiva](https://github.com/paivagustavo), LightStep
 - [Josh MacDonald](https://github.com/jmacd), LightStep


### PR DESCRIPTION
@hanyuancheung is no longer able to fulfil the requirements of an [approver](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver). This moves him out of a approver role and into an Emeritus status.

Thank you @hanyuancheung for all the contributions!