### PR TITLE
chore: removing unnecessary comments

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -63,8 +63,6 @@ func (s *SDK) Shutdown(ctx context.Context) error {
 }
 
 // NewSDK creates SDK providers based on the configuration model.
-//
-// Caution: The implementation only returns noop providers.
 func NewSDK(opts ...ConfigurationOption) (SDK, error) {
 	o := configOptions{}
 	for _, opt := range opts {
@@ -128,9 +126,6 @@ func WithOpenTelemetryConfiguration(cfg OpenTelemetryConfiguration) Configuratio
 		return c
 	})
 }
-
-// TODO: implement parsing functionality:
-// - https://github.com/open-telemetry/opentelemetry-go-contrib/issues/4412
 
 // ParseYAML parses a YAML configuration file into an OpenTelemetryConfiguration.
 func ParseYAML(file []byte) (*OpenTelemetryConfiguration, error) {


### PR DESCRIPTION
The comment at the top is no longer true, the one at the bottom is no longer applicable as it was decided to wait to support JSON format parsing.