### PR TITLE
Fix logrus severity conversion

### DIFF
--- a/bridges/otellogrus/hook.go
+++ b/bridges/otellogrus/hook.go
@@ -165,8 +165,24 @@ func (h *Hook) convertEntry(e *logrus.Entry) log.Record {
 	record.SetTimestamp(e.Time)
 	record.SetBody(log.StringValue(e.Message))
 
-	const sevOffset = logrus.Level(log.SeverityDebug) - logrus.DebugLevel
-	record.SetSeverity(log.Severity(e.Level + sevOffset))
+	var severity log.Severity
+	switch e.Level {
+	case logrus.PanicLevel:
+		severity = log.SeverityFatal4
+	case logrus.FatalLevel:
+		severity = log.SeverityFatal
+	case logrus.ErrorLevel:
+		severity = log.SeverityError
+	case logrus.WarnLevel:
+		severity = log.SeverityWarn
+	case logrus.InfoLevel:
+		severity = log.SeverityInfo
+	case logrus.DebugLevel:
+		severity = log.SeverityDebug
+	case logrus.TraceLevel:
+		severity = log.SeverityTrace
+	}
+	record.SetSeverity(severity)
 	record.AddAttributes(convertFields(e.Data)...)
 
 	return record

--- a/bridges/otellogrus/hook.go
+++ b/bridges/otellogrus/hook.go
@@ -16,13 +16,15 @@
 //     set.
 //   - Fields are transformed and set as the attributes.
 //
-// The Level is transformed by using the static offset to the OpenTelemetry
+// The Level is transformed to the OpenTelemetry
 // Severity types. For example:
 //
 //   - [logrus.DebugLevel] is transformed to [log.SeverityDebug]
-//   - [logrus.InfoLevel] is transformed to [log.SeverityTrace4]
-//   - [logrus.WarnLevel] is transformed to [log.SeverityTrace3]
-//   - [logrus.ErrorLevel] is transformed to [log.SeverityTrace2]
+//   - [logrus.InfoLevel] is transformed to [log.SeverityInfo]
+//   - [logrus.WarnLevel] is transformed to [log.SeverityWarn]
+//   - [logrus.ErrorLevel] is transformed to [log.SeverityError]
+//   - [logrus.FatalLevel] is transformed to [log.SeverityFatal]
+//   - [logrus.PanicLevel] is transformed to [log.SeverityFatal4]
 //
 // Field values are transformed based on their type into log attributes, or
 // into a string value if there is no matching type.

--- a/bridges/otellogrus/hook_test.go
+++ b/bridges/otellogrus/hook_test.go
@@ -162,7 +162,7 @@ func TestHookFire(t *testing.T) {
 
 			wantRecords: map[string][]log.Record{
 				name: {
-					buildRecord(log.StringValue(""), time.Time{}, 0, nil),
+					buildRecord(log.StringValue(""), time.Time{}, log.SeverityFatal4, nil),
 				},
 			},
 		},
@@ -173,7 +173,7 @@ func TestHookFire(t *testing.T) {
 			},
 			wantRecords: map[string][]log.Record{
 				name: {
-					buildRecord(log.StringValue(""), now, 0, nil),
+					buildRecord(log.StringValue(""), now, log.SeverityFatal4, nil),
 				},
 			},
 		},
@@ -184,7 +184,7 @@ func TestHookFire(t *testing.T) {
 			},
 			wantRecords: map[string][]log.Record{
 				name: {
-					buildRecord(log.StringValue(""), time.Time{}, log.SeverityTrace1, nil),
+					buildRecord(log.StringValue(""), time.Time{}, log.SeverityFatal, nil),
 				},
 			},
 		},
@@ -197,7 +197,7 @@ func TestHookFire(t *testing.T) {
 			},
 			wantRecords: map[string][]log.Record{
 				name: {
-					buildRecord(log.StringValue(""), time.Time{}, 0, []log.KeyValue{
+					buildRecord(log.StringValue(""), time.Time{}, log.SeverityFatal4, []log.KeyValue{
 						log.String("hello", "world"),
 					}),
 				},


### PR DESCRIPTION
Logrus severity transformation is broken right now as all severity levels are counterintuitively transformed to various trace levels.
Logrus has the next levels from 0 (the highest) to 6 (lowest):
```
const (
	// PanicLevel level, highest level of severity. Logs and then calls panic with the
	// message passed to Debug, Info, ...
	PanicLevel Level = iota
	// FatalLevel level. Logs and then calls `logger.Exit(1)`. It will exit even if the
	// logging level is set to Panic.
	FatalLevel
	// ErrorLevel level. Logs. Used for errors that should definitely be noted.
	// Commonly used for hooks to send errors to an error tracking service.
	ErrorLevel
	// WarnLevel level. Non-critical entries that deserve eyes.
	WarnLevel
	// InfoLevel level. General operational entries about what's going on inside the
	// application.
	InfoLevel
	// DebugLevel level. Usually only enabled when debugging. Very verbose logging.
	DebugLevel
	// TraceLevel level. Designates finer-grained informational events than the Debug.
	TraceLevel
)
```
while otel has a huge number of levels from 0 (the lowest) to 24 (the highest):
```
const (
	// SeverityUndefined represents an unset Severity.
	SeverityUndefined Severity = 0 // UNDEFINED

	// A fine-grained debugging log record. Typically disabled in default
	// configurations.
	SeverityTrace1 Severity = 1 // TRACE
	SeverityTrace2 Severity = 2 // TRACE2
	SeverityTrace3 Severity = 3 // TRACE3
	SeverityTrace4 Severity = 4 // TRACE4

	// A debugging log record.
	SeverityDebug1 Severity = 5 // DEBUG
	SeverityDebug2 Severity = 6 // DEBUG2
	SeverityDebug3 Severity = 7 // DEBUG3
	SeverityDebug4 Severity = 8 // DEBUG4

	// An informational log record. Indicates that an event happened.
	SeverityInfo1 Severity = 9  // INFO
	SeverityInfo2 Severity = 10 // INFO2
	SeverityInfo3 Severity = 11 // INFO3
	SeverityInfo4 Severity = 12 // INFO4

	// A warning log record. Not an error but is likely more important than an
	// informational event.
	SeverityWarn1 Severity = 13 // WARN
	SeverityWarn2 Severity = 14 // WARN2
	SeverityWarn3 Severity = 15 // WARN3
	SeverityWarn4 Severity = 16 // WARN4

	// An error log record. Something went wrong.
	SeverityError1 Severity = 17 // ERROR
	SeverityError2 Severity = 18 // ERROR2
	SeverityError3 Severity = 19 // ERROR3
	SeverityError4 Severity = 20 // ERROR4

	// A fatal log record such as application or system crash.
	SeverityFatal1 Severity = 21 // FATAL
	SeverityFatal2 Severity = 22 // FATAL2
	SeverityFatal3 Severity = 23 // FATAL3
	SeverityFatal4 Severity = 24 // FATAL4

	// Convenience definitions for the base severity of each level.
	SeverityTrace = SeverityTrace1
	SeverityDebug = SeverityDebug1
	SeverityInfo  = SeverityInfo1
	SeverityWarn  = SeverityWarn1
	SeverityError = SeverityError1
	SeverityFatal = SeverityFatal1
)
```
Right now the conversion is done via offset 
```
const sevOffset = logrus.Level(log.SeverityDebug) - logrus.DebugLevel
record.SetSeverity(log.Severity(e.Level + sevOffset))
```
and produces pretty strange and unexpected results, when all logrus levels become `debug` or `trace`