### PR TITLE
Add dashpole as an owner of instrumentation/runtime

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -55,7 +55,7 @@ instrumentation/gopkg.in/macaron.v1/otelmacaron/                        @open-te
 instrumentation/host/                                                   @open-telemetry/go-approvers @dmathieu
 instrumentation/net/http/httptrace/otelhttptrace/                       @open-telemetry/go-approvers @dmathieu
 instrumentation/net/http/otelhttp/                                      @open-telemetry/go-approvers @dmathieu
-instrumentation/runtime/                                                @open-telemetry/go-approvers @dmathieu
+instrumentation/runtime/                                                @open-telemetry/go-approvers @dmathieu @dashpole
 
 processors/baggagecopy                                                  @open-telemetry/go-approvers @codeboten @MikeGoldsmith
 processors/minsev                                                       @open-telemetry/go-approvers @MrAlias


### PR DESCRIPTION
Addresses https://github.com/open-telemetry/opentelemetry-go-contrib/issues/6175#issuecomment-2391843925