### PR TITLE
Ensure all XRay Sampler functionality is under ParentBased logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Possible nil dereference panic in `go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace`. (#5965)
 - Non-200 HTTP status codes when retrieving sampling rules in `go.opentelemetry.io/contrib/samplers/aws/xray` now return an error. (#5718)
+- Ensure all AWS XRay Remote Sampler logic is under a ParentBased Sampler in `go.opentelemetry.io/contrib/samplers/aws/xray`. (#6205)
 
 ### Removed
 

--- a/samplers/aws/xray/remote_sampler.go
+++ b/samplers/aws/xray/remote_sampler.go
@@ -46,7 +46,7 @@ type remoteSampler struct {
 // Compile time assertion that remoteSampler implements the Sampler interface.
 var _ sdktrace.Sampler = (*remoteSampler)(nil)
 
-// NewRemoteSampler returns a sampler which decides to sample a given request or not
+// NewRemoteSampler returns a ParentBased XRay Sampler which decides to sample a given request or not
 // based on the sampling rules set by users on AWS X-Ray console. Sampler also periodically polls
 // sampling rules and sampling targets.
 // NOTE: ctx passed in NewRemoteSampler API is being used in background go routine. Cancellation to this context can kill the background go routine.
@@ -77,7 +77,7 @@ func NewRemoteSampler(ctx context.Context, serviceName string, cloudPlatform str
 
 	remoteSampler.start(ctx)
 
-	return remoteSampler, nil
+	return sdktrace.ParentBased(remoteSampler), nil
 }
 
 // ShouldSample matches span attributes with retrieved sampling rules and returns a sampling result.

--- a/samplers/aws/xray/remote_sampler_test.go
+++ b/samplers/aws/xray/remote_sampler_test.go
@@ -4,7 +4,10 @@
 package xray
 
 import (
+	"context"
+	"net/url"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -15,4 +18,12 @@ func TestRemoteSamplerDescription(t *testing.T) {
 
 	s := rs.Description()
 	assert.Equal(t, "AWSXRayRemoteSampler{remote sampling with AWS X-Ray}", s)
+}
+
+func TestNewRemoteSamplerDescription(t *testing.T) {
+	endpointUrl, _ := url.Parse("http://localhost:2000")
+	rs, _ := NewRemoteSampler(context.Background(), "otel-test", "", WithEndpoint(*endpointUrl), WithSamplingRulesPollingInterval(300*time.Second))
+
+	s := rs.Description()
+	assert.Equal(t, "ParentBased{root:AWSXRayRemoteSampler{remote sampling with AWS X-Ray},remoteParentSampled:AlwaysOnSampler,remoteParentNotSampled:AlwaysOffSampler,localParentSampled:AlwaysOnSampler,localParentNotSampled:AlwaysOffSampler}", s)
 }

--- a/samplers/aws/xray/remote_sampler_test.go
+++ b/samplers/aws/xray/remote_sampler_test.go
@@ -21,8 +21,8 @@ func TestRemoteSamplerDescription(t *testing.T) {
 }
 
 func TestNewRemoteSamplerDescription(t *testing.T) {
-	endpointUrl, _ := url.Parse("http://localhost:2000")
-	rs, _ := NewRemoteSampler(context.Background(), "otel-test", "", WithEndpoint(*endpointUrl), WithSamplingRulesPollingInterval(300*time.Second))
+	endpointURL, _ := url.Parse("http://localhost:2000")
+	rs, _ := NewRemoteSampler(context.Background(), "otel-test", "", WithEndpoint(*endpointURL), WithSamplingRulesPollingInterval(300*time.Second))
 
 	s := rs.Description()
 	assert.Equal(t, "ParentBased{root:AWSXRayRemoteSampler{remote sampling with AWS X-Ray},remoteParentSampled:AlwaysOnSampler,remoteParentNotSampled:AlwaysOffSampler,localParentSampled:AlwaysOnSampler,localParentNotSampled:AlwaysOffSampler}", s)


### PR DESCRIPTION
This fixes the bug where:
- Currently, XRay Sampler in OTel Go will use `ShouldSample` logic for every span, but for child spans, they should always respect the parent span sampling decision in XRay Sampler (as is already done in OTel Java and OTel .NET)

The changes introduced in this PR are as follows:
- Wrap the returned `remote_sampler` of `NewRemoteSampler` under a single ParentBased Sampler

**Existing Issue(s):**
Related
- https://github.com/aws-observability/aws-otel-js-instrumentation/issues/79
- https://github.com/aws-observability/aws-otel-js-instrumentation/pull/80

**Testing:**

- Tested Sampler functionality with XRay Sampler test bed - https://github.com/aws-observability/aws-otel-community/tree/master/centralized-sampling-tests