### PR TITLE
otellogrus: Add more appropriate level mapping

### DIFF
--- a/bridges/otellogrus/hook.go
+++ b/bridges/otellogrus/hook.go
@@ -16,13 +16,14 @@
 //     set.
 //   - Fields are transformed and set as the attributes.
 //
-// The Level is transformed by using the static offset to the OpenTelemetry
-// Severity types. For example:
-//
+// The Level is transformed to the OpenTelemetry Severity types as follows.
+//   - [logrus.TraceLevel] is transformed to [log.SeverityTrace]
 //   - [logrus.DebugLevel] is transformed to [log.SeverityDebug]
-//   - [logrus.InfoLevel] is transformed to [log.SeverityTrace4]
-//   - [logrus.WarnLevel] is transformed to [log.SeverityTrace3]
-//   - [logrus.ErrorLevel] is transformed to [log.SeverityTrace2]
+//   - [logrus.InfoLevel] is transformed to [log.SeverityInfo]
+//   - [logrus.WarnLevel] is transformed to [log.SeverityWarn]
+//   - [logrus.ErrorLevel] is transformed to [log.SeverityError]
+//   - [logrus.FatalLevel] is transformed to [log.SeverityFatal1]
+//   - [logrus.PanicLevel] is transformed to [log.SeverityFatal2]
 //
 // Field values are transformed based on their type into log attributes, or
 // into a string value if there is no matching type.
@@ -165,11 +166,31 @@ func (h *Hook) convertEntry(e *logrus.Entry) log.Record {
 	record.SetTimestamp(e.Time)
 	record.SetBody(log.StringValue(e.Message))
 
-	const sevOffset = logrus.Level(log.SeverityDebug) - logrus.DebugLevel
-	record.SetSeverity(log.Severity(e.Level + sevOffset))
+	record.SetSeverity(convertLevel(e.Level))
 	record.AddAttributes(convertFields(e.Data)...)
 
 	return record
+}
+
+func convertLevel(level logrus.Level) log.Severity {
+	switch level {
+	case logrus.TraceLevel:
+		return log.SeverityTrace
+	case logrus.DebugLevel:
+		return log.SeverityDebug
+	case logrus.InfoLevel:
+		return log.SeverityInfo
+	case logrus.WarnLevel:
+		return log.SeverityWarn
+	case logrus.ErrorLevel:
+		return log.SeverityError
+	case logrus.FatalLevel:
+		return log.SeverityFatal1
+	case logrus.PanicLevel:
+		return log.SeverityFatal2
+	default:
+		return log.SeverityUndefined
+	}
 }
 
 func convertFields(fields logrus.Fields) []log.KeyValue {

--- a/bridges/otellogrus/hook_test.go
+++ b/bridges/otellogrus/hook_test.go
@@ -162,7 +162,7 @@ func TestHookFire(t *testing.T) {
 
 			wantRecords: map[string][]log.Record{
 				name: {
-					buildRecord(log.StringValue(""), time.Time{}, 0, nil),
+					buildRecord(log.StringValue(""), time.Time{}, log.SeverityFatal2, nil),
 				},
 			},
 		},
@@ -173,7 +173,7 @@ func TestHookFire(t *testing.T) {
 			},
 			wantRecords: map[string][]log.Record{
 				name: {
-					buildRecord(log.StringValue(""), now, 0, nil),
+					buildRecord(log.StringValue(""), now, log.SeverityFatal2, nil),
 				},
 			},
 		},
@@ -184,7 +184,7 @@ func TestHookFire(t *testing.T) {
 			},
 			wantRecords: map[string][]log.Record{
 				name: {
-					buildRecord(log.StringValue(""), time.Time{}, log.SeverityTrace1, nil),
+					buildRecord(log.StringValue(""), time.Time{}, log.SeverityFatal1, nil),
 				},
 			},
 		},
@@ -197,7 +197,7 @@ func TestHookFire(t *testing.T) {
 			},
 			wantRecords: map[string][]log.Record{
 				name: {
-					buildRecord(log.StringValue(""), time.Time{}, 0, []log.KeyValue{
+					buildRecord(log.StringValue(""), time.Time{}, log.SeverityFatal2, []log.KeyValue{
 						log.String("hello", "world"),
 					}),
 				},


### PR DESCRIPTION
The current log level mapping for logrus is this

```
logrus.DebugLevel - > log.SeverityDebug
logrus.InfoLevel  - > log.SeverityTrace4
logrus.FatalLevel - > log.SeverityTrace1
logrus.ErrorLevel - > log.SeverityTrace2
logrus.PanicLevel - > log.SeverityUndefined
```

this may be more appropriate mapping. And this PR aims to do that

```
[logrus.TraceLevel]  to [log.SeverityTrace]
[logrus.DebugLevel]  to [log.SeverityDebug]
[logrus.InfoLevel] to [log.SeverityInfo]
[logrus.WarnLevel] to [log.SeverityWarn]
[logrus.ErrorLevel] to [log.SeverityError]
[logrus.FatalLevel] to [log.SeverityFatal1]
[logrus.PanicLevel] to [log.SeverityFatal2]
```
