### PR TITLE
Fix panic for nil attributes and move convert funcs to internal/shared/logutil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The deprecated `go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho` package has found a Code Owner.
   The package is no longer deprecated. (#6207)
 
-
 ### Fixed
 
 - Possible nil dereference panic in `go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace`. (#5965)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `NewSDK` in `go.opentelemetry.io/contrib/config` now returns a no-op SDK if `disabled` is set to `true`. (#6185)
 - The deprecated `go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho` package has found a Code Owner.
   The package is no longer deprecated. (#6207)
+- Aligned convertvalue in `otellogr`, `otellogrus` and `otelzap` with convert tmpl. (#6237)
 
 ### Fixed
 
 - Possible nil dereference panic in `go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace`. (#5965)
 - `logrus.Level` transformed to appropriate `log.Severity` in `go.opentelemetry.io/contrib/bridges/otellogrus`. (#6191)
+- Possible nil dereference panic in `go.opentelemetry.io/contrib/bridges/otellogrus`. (#6237)
+- Possible nil dereference panic in `go.opentelemetry.io/contrib/bridges/otelzap`. (#6237)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- Transform nil attribute values to `log.Value` zero value instead of panicking in `go.opentelemetry.io/contrib/bridges/otellogrus`. (#6237)
+- Transform nil attribute values to `log.Value` zero value instead of panicking in `go.opentelemetry.io/contrib/bridges/otelzap`. (#6237)
+
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->
 
@@ -28,14 +33,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `NewSDK` in `go.opentelemetry.io/contrib/config` now returns a no-op SDK if `disabled` is set to `true`. (#6185)
 - The deprecated `go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho` package has found a Code Owner.
   The package is no longer deprecated. (#6207)
-- Aligned convertvalue in `otellogr`, `otellogrus` and `otelzap` with convert tmpl. (#6237)
+
 
 ### Fixed
 
 - Possible nil dereference panic in `go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace`. (#5965)
 - `logrus.Level` transformed to appropriate `log.Severity` in `go.opentelemetry.io/contrib/bridges/otellogrus`. (#6191)
-- Possible nil dereference panic in `go.opentelemetry.io/contrib/bridges/otellogrus`. (#6237)
-- Possible nil dereference panic in `go.opentelemetry.io/contrib/bridges/otelzap`. (#6237)
 
 ### Removed
 

--- a/bridges/otellogr/convert.go
+++ b/bridges/otellogr/convert.go
@@ -16,8 +16,8 @@ import (
 	"go.opentelemetry.io/otel/log"
 )
 
-// Convert various types to log.Value.
-func ConvertValue(v any) log.Value {
+// convertValue converts various types to log.Value.
+func convertValue(v any) log.Value {
 	// Handling the most common types without reflect is a small perf win.
 	switch val := v.(type) {
 	case bool:
@@ -79,7 +79,7 @@ func ConvertValue(v any) log.Value {
 	case reflect.Slice, reflect.Array:
 		items := make([]log.Value, 0, val.Len())
 		for i := 0; i < val.Len(); i++ {
-			items = append(items, ConvertValue(val.Index(i).Interface()))
+			items = append(items, convertValue(val.Index(i).Interface()))
 		}
 		return log.SliceValue(items...)
 	case reflect.Map:
@@ -94,7 +94,7 @@ func ConvertValue(v any) log.Value {
 			}
 			kvs = append(kvs, log.KeyValue{
 				Key:   key,
-				Value: ConvertValue(val.MapIndex(k).Interface()),
+				Value: convertValue(val.MapIndex(k).Interface()),
 			})
 		}
 		return log.MapValue(kvs...)
@@ -102,7 +102,7 @@ func ConvertValue(v any) log.Value {
 		if val.IsNil() {
 			return log.Value{}
 		}
-		return ConvertValue(val.Elem().Interface())
+		return convertValue(val.Elem().Interface())
 	}
 
 	// Try to handle this as gracefully as possible.
@@ -113,7 +113,7 @@ func ConvertValue(v any) log.Value {
 	return log.StringValue(fmt.Sprintf("unhandled: (%s) %+v", t, v))
 }
 
-// ConvertUintValue converts a uint64 to a log.Value.
+// convertUintValue converts a uint64 to a log.Value.
 // If the value is too large to fit in an int64, it is converted to a string.
 func convertUintValue(v uint64) log.Value {
 	if v > math.MaxInt64 {

--- a/bridges/otellogr/convert_test.go
+++ b/bridges/otellogr/convert_test.go
@@ -252,13 +252,13 @@ func TestConvertValue(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.wantValue, ConvertValue(tt.value))
+			assert.Equal(t, tt.wantValue, convertValue(tt.value))
 		})
 	}
 }
 
 func TestConvertValueFloat32(t *testing.T) {
-	value := ConvertValue(float32(3.14))
+	value := convertValue(float32(3.14))
 	want := log.Float64Value(3.14)
 
 	assert.InDelta(t, value.AsFloat64(), want.AsFloat64(), 0.0001)

--- a/bridges/otellogr/gen.go
+++ b/bridges/otellogr/gen.go
@@ -1,0 +1,8 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otellogr // import "go.opentelemetry.io/contrib/bridges/otellogr"
+
+// Generate convert:
+//go:generate gotmpl --body=../../internal/shared/logutil/convert_test.go.tmpl "--data={ \"pkg\": \"otellogr\" }" --out=convert_test.go
+//go:generate gotmpl --body=../../internal/shared/logutil/convert.go.tmpl "--data={ \"pkg\": \"otellogr\" }" --out=convert.go

--- a/bridges/otellogr/logsink.go
+++ b/bridges/otellogr/logsink.go
@@ -229,7 +229,7 @@ func convertKVs(ctx context.Context, keysAndValues ...any) (context.Context, []l
 
 		kvs = append(kvs, log.KeyValue{
 			Key:   k,
-			Value: ConvertValue(v),
+			Value: convertValue(v),
 		})
 	}
 

--- a/bridges/otellogr/logsink_test.go
+++ b/bridges/otellogr/logsink_test.go
@@ -3,6 +3,7 @@
 package otellogr
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -216,6 +217,21 @@ func TestLogSink(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "info_with_normal_attr_and_nil_pointer_attr",
+			f: func(l *logr.Logger) {
+				var p *int
+				l.WithValues("key", "value", "nil_pointer", p).Info("info message with attrs")
+			},
+			wantRecords: map[string][]log.Record{
+				name: {
+					buildRecord(log.StringValue("info message with attrs"), time.Time{}, log.SeverityInfo, []log.KeyValue{
+						log.String("key", "value"),
+						log.Empty("nil_pointer"),
+					}),
+				},
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			rec := logtest.NewRecorder()
@@ -261,5 +277,69 @@ func assertRecords(t *testing.T, want, got []logtest.EmittedRecord) {
 
 	for i, j := range want {
 		logtest.AssertRecordEqual(t, j.Record, got[i].Record)
+	}
+}
+
+func TestConvertKVs(t *testing.T) {
+	ctx := context.WithValue(context.Background(), "key", "value") // nolint: revive,staticcheck // test context
+
+	for _, tt := range []struct {
+		name    string
+		kvs     []any
+		wantKVs []log.KeyValue
+		wantCtx context.Context
+	}{
+		{
+			name: "empty",
+			kvs:  []any{},
+		},
+		{
+			name: "single_value",
+			kvs:  []any{"key", "value"},
+			wantKVs: []log.KeyValue{
+				log.String("key", "value"),
+			},
+		},
+		{
+			name: "multiple_values",
+			kvs:  []any{"key1", "value1", "key2", "value2"},
+			wantKVs: []log.KeyValue{
+				log.String("key1", "value1"),
+				log.String("key2", "value2"),
+			},
+		},
+		{
+			name: "missing_value",
+			kvs:  []any{"key1", "value1", "key2"},
+			wantKVs: []log.KeyValue{
+				log.String("key1", "value1"),
+				{Key: "key2", Value: log.Value{}},
+			},
+		},
+		{
+			name: "key_not_string",
+			kvs:  []any{42, "value"},
+			wantKVs: []log.KeyValue{
+				log.String("42", "value"),
+			},
+		},
+		{
+			name:    "context",
+			kvs:     []any{"ctx", ctx, "key", "value"},
+			wantKVs: []log.KeyValue{log.String("key", "value")},
+			wantCtx: ctx,
+		},
+		{
+			name:    "last_context",
+			kvs:     []any{"key", context.Background(), "ctx", ctx},
+			wantKVs: []log.KeyValue{},
+			wantCtx: ctx,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, kvs := convertKVs(nil, tt.kvs...) // nolint: staticcheck // pass nil context
+			assert.Equal(t, tt.wantKVs, kvs)
+			assert.Equal(t, tt.wantCtx, ctx)
+		})
 	}
 }

--- a/bridges/otellogrus/convert.go
+++ b/bridges/otellogrus/convert.go
@@ -4,7 +4,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package otellogr // import "go.opentelemetry.io/contrib/bridges/otellogr"
+package otellogrus // import "go.opentelemetry.io/contrib/bridges/otellogrus"
 
 import (
 	"fmt"

--- a/bridges/otellogrus/convert.go
+++ b/bridges/otellogrus/convert.go
@@ -16,8 +16,8 @@ import (
 	"go.opentelemetry.io/otel/log"
 )
 
-// Convert various types to log.Value.
-func ConvertValue(v any) log.Value {
+// convertValue converts various types to log.Value.
+func convertValue(v any) log.Value {
 	// Handling the most common types without reflect is a small perf win.
 	switch val := v.(type) {
 	case bool:
@@ -79,7 +79,7 @@ func ConvertValue(v any) log.Value {
 	case reflect.Slice, reflect.Array:
 		items := make([]log.Value, 0, val.Len())
 		for i := 0; i < val.Len(); i++ {
-			items = append(items, ConvertValue(val.Index(i).Interface()))
+			items = append(items, convertValue(val.Index(i).Interface()))
 		}
 		return log.SliceValue(items...)
 	case reflect.Map:
@@ -94,7 +94,7 @@ func ConvertValue(v any) log.Value {
 			}
 			kvs = append(kvs, log.KeyValue{
 				Key:   key,
-				Value: ConvertValue(val.MapIndex(k).Interface()),
+				Value: convertValue(val.MapIndex(k).Interface()),
 			})
 		}
 		return log.MapValue(kvs...)
@@ -102,7 +102,7 @@ func ConvertValue(v any) log.Value {
 		if val.IsNil() {
 			return log.Value{}
 		}
-		return ConvertValue(val.Elem().Interface())
+		return convertValue(val.Elem().Interface())
 	}
 
 	// Try to handle this as gracefully as possible.
@@ -113,7 +113,7 @@ func ConvertValue(v any) log.Value {
 	return log.StringValue(fmt.Sprintf("unhandled: (%s) %+v", t, v))
 }
 
-// ConvertUintValue converts a uint64 to a log.Value.
+// convertUintValue converts a uint64 to a log.Value.
 // If the value is too large to fit in an int64, it is converted to a string.
 func convertUintValue(v uint64) log.Value {
 	if v > math.MaxInt64 {

--- a/bridges/otellogrus/convert_test.go
+++ b/bridges/otellogrus/convert_test.go
@@ -252,13 +252,13 @@ func TestConvertValue(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.wantValue, ConvertValue(tt.value))
+			assert.Equal(t, tt.wantValue, convertValue(tt.value))
 		})
 	}
 }
 
 func TestConvertValueFloat32(t *testing.T) {
-	value := ConvertValue(float32(3.14))
+	value := convertValue(float32(3.14))
 	want := log.Float64Value(3.14)
 
 	assert.InDelta(t, value.AsFloat64(), want.AsFloat64(), 0.0001)

--- a/bridges/otellogrus/convert_test.go
+++ b/bridges/otellogrus/convert_test.go
@@ -4,7 +4,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package otellogr
+package otellogrus
 
 import (
 	"context"

--- a/bridges/otellogrus/gen.go
+++ b/bridges/otellogrus/gen.go
@@ -1,0 +1,8 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otellogrus // import "go.opentelemetry.io/contrib/bridges/otellogrus"
+
+// Generate convert:
+//go:generate gotmpl --body=../../internal/shared/logutil/convert_test.go.tmpl "--data={ \"pkg\": \"otellogrus\" }" --out=convert_test.go
+//go:generate gotmpl --body=../../internal/shared/logutil/convert.go.tmpl "--data={ \"pkg\": \"otellogrus\" }" --out=convert.go

--- a/bridges/otellogrus/hook.go
+++ b/bridges/otellogrus/hook.go
@@ -174,7 +174,7 @@ func convertFields(fields logrus.Fields) []log.KeyValue {
 	for k, v := range fields {
 		kvs = append(kvs, log.KeyValue{
 			Key:   k,
-			Value: ConvertValue(v),
+			Value: convertValue(v),
 		})
 	}
 	return kvs

--- a/bridges/otellogrus/hook_test.go
+++ b/bridges/otellogrus/hook_test.go
@@ -148,6 +148,7 @@ func TestHookLevels(t *testing.T) {
 func TestHookFire(t *testing.T) {
 	const name = "name"
 	now := time.Now()
+	var nilPointer *struct{}
 
 	for _, tt := range []struct {
 		name  string
@@ -265,6 +266,21 @@ func TestHookFire(t *testing.T) {
 				name: {
 					buildRecord(log.StringValue(""), time.Time{}, log.SeverityFatal4, []log.KeyValue{
 						log.String("hello", "world"),
+					}),
+				},
+			},
+		},
+		{
+			name: "emits a log entry with data containing a nil pointer",
+			entry: &logrus.Entry{
+				Data: logrus.Fields{
+					"nil_pointer": nilPointer,
+				},
+			},
+			wantRecords: map[string][]log.Record{
+				name: {
+					buildRecord(log.StringValue(""), time.Time{}, log.SeverityFatal4, []log.KeyValue{
+						{Key: "nil_pointer", Value: log.Value{}},
 					}),
 				},
 			},

--- a/bridges/otelzap/convert.go
+++ b/bridges/otelzap/convert.go
@@ -4,7 +4,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package otellogr // import "go.opentelemetry.io/contrib/bridges/otellogr"
+package otelzap // import "go.opentelemetry.io/contrib/bridges/otelzap"
 
 import (
 	"fmt"

--- a/bridges/otelzap/convert.go
+++ b/bridges/otelzap/convert.go
@@ -16,8 +16,8 @@ import (
 	"go.opentelemetry.io/otel/log"
 )
 
-// Convert various types to log.Value.
-func ConvertValue(v any) log.Value {
+// convertValue converts various types to log.Value.
+func convertValue(v any) log.Value {
 	// Handling the most common types without reflect is a small perf win.
 	switch val := v.(type) {
 	case bool:
@@ -79,7 +79,7 @@ func ConvertValue(v any) log.Value {
 	case reflect.Slice, reflect.Array:
 		items := make([]log.Value, 0, val.Len())
 		for i := 0; i < val.Len(); i++ {
-			items = append(items, ConvertValue(val.Index(i).Interface()))
+			items = append(items, convertValue(val.Index(i).Interface()))
 		}
 		return log.SliceValue(items...)
 	case reflect.Map:
@@ -94,7 +94,7 @@ func ConvertValue(v any) log.Value {
 			}
 			kvs = append(kvs, log.KeyValue{
 				Key:   key,
-				Value: ConvertValue(val.MapIndex(k).Interface()),
+				Value: convertValue(val.MapIndex(k).Interface()),
 			})
 		}
 		return log.MapValue(kvs...)
@@ -102,7 +102,7 @@ func ConvertValue(v any) log.Value {
 		if val.IsNil() {
 			return log.Value{}
 		}
-		return ConvertValue(val.Elem().Interface())
+		return convertValue(val.Elem().Interface())
 	}
 
 	// Try to handle this as gracefully as possible.
@@ -113,7 +113,7 @@ func ConvertValue(v any) log.Value {
 	return log.StringValue(fmt.Sprintf("unhandled: (%s) %+v", t, v))
 }
 
-// ConvertUintValue converts a uint64 to a log.Value.
+// convertUintValue converts a uint64 to a log.Value.
 // If the value is too large to fit in an int64, it is converted to a string.
 func convertUintValue(v uint64) log.Value {
 	if v > math.MaxInt64 {

--- a/bridges/otelzap/convert_test.go
+++ b/bridges/otelzap/convert_test.go
@@ -4,7 +4,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package otellogr
+package otelzap
 
 import (
 	"context"

--- a/bridges/otelzap/convert_test.go
+++ b/bridges/otelzap/convert_test.go
@@ -252,13 +252,13 @@ func TestConvertValue(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.wantValue, ConvertValue(tt.value))
+			assert.Equal(t, tt.wantValue, convertValue(tt.value))
 		})
 	}
 }
 
 func TestConvertValueFloat32(t *testing.T) {
-	value := ConvertValue(float32(3.14))
+	value := convertValue(float32(3.14))
 	want := log.Float64Value(3.14)
 
 	assert.InDelta(t, value.AsFloat64(), want.AsFloat64(), 0.0001)

--- a/bridges/otelzap/encoder.go
+++ b/bridges/otelzap/encoder.go
@@ -119,7 +119,7 @@ func (m *objectEncoder) AddReflected(k string, v interface{}) error {
 	m.cur.attrs = append(m.cur.attrs,
 		log.KeyValue{
 			Key:   k,
-			Value: ConvertValue(v),
+			Value: convertValue(v),
 		})
 	return nil
 }
@@ -219,7 +219,7 @@ func (a *arrayEncoder) AppendObject(v zapcore.ObjectMarshaler) error {
 }
 
 func (a *arrayEncoder) AppendReflected(v interface{}) error {
-	a.elems = append(a.elems, ConvertValue(v))
+	a.elems = append(a.elems, convertValue(v))
 	return nil
 }
 

--- a/bridges/otelzap/encoder.go
+++ b/bridges/otelzap/encoder.go
@@ -4,8 +4,6 @@
 package otelzap // import "go.opentelemetry.io/contrib/bridges/otelzap"
 
 import (
-	"fmt"
-	"reflect"
 	"time"
 
 	"go.uber.org/zap/zapcore"
@@ -121,7 +119,7 @@ func (m *objectEncoder) AddReflected(k string, v interface{}) error {
 	m.cur.attrs = append(m.cur.attrs,
 		log.KeyValue{
 			Key:   k,
-			Value: convertValue(v),
+			Value: ConvertValue(v),
 		})
 	return nil
 }
@@ -221,7 +219,7 @@ func (a *arrayEncoder) AppendObject(v zapcore.ObjectMarshaler) error {
 }
 
 func (a *arrayEncoder) AppendReflected(v interface{}) error {
-	a.elems = append(a.elems, convertValue(v))
+	a.elems = append(a.elems, ConvertValue(v))
 	return nil
 }
 
@@ -274,56 +272,3 @@ func (a *arrayEncoder) AppendUint32(v uint32)          { a.AppendInt64(int64(v))
 func (a *arrayEncoder) AppendUint16(v uint16)          { a.AppendInt64(int64(v)) }
 func (a *arrayEncoder) AppendUint8(v uint8)            { a.AppendInt64(int64(v)) }
 func (a *arrayEncoder) AppendUintptr(v uintptr)        { a.AppendUint64(uint64(v)) }
-
-func convertValue(v interface{}) log.Value {
-	switch v := v.(type) {
-	case bool:
-		return log.BoolValue(v)
-	case []byte:
-		return log.BytesValue(v)
-	case float64:
-		return log.Float64Value(v)
-	case int:
-		return log.IntValue(v)
-	case int64:
-		return log.Int64Value(v)
-	case string:
-		return log.StringValue(v)
-	}
-
-	t := reflect.TypeOf(v)
-	if t == nil {
-		return log.Value{}
-	}
-	val := reflect.ValueOf(v)
-	switch t.Kind() {
-	case reflect.Struct:
-		return log.StringValue(fmt.Sprintf("%+v", v))
-	case reflect.Slice, reflect.Array:
-		items := make([]log.Value, 0, val.Len())
-		for i := 0; i < val.Len(); i++ {
-			items = append(items, convertValue(val.Index(i).Interface()))
-		}
-		return log.SliceValue(items...)
-	case reflect.Map:
-		kvs := make([]log.KeyValue, 0, val.Len())
-		for _, k := range val.MapKeys() {
-			var key string
-			// If the key is a struct, use %+v to print the struct fields.
-			if k.Kind() == reflect.Struct {
-				key = fmt.Sprintf("%+v", k.Interface())
-			} else {
-				key = fmt.Sprintf("%v", k.Interface())
-			}
-			kvs = append(kvs, log.KeyValue{
-				Key:   key,
-				Value: convertValue(val.MapIndex(k).Interface()),
-			})
-		}
-		return log.MapValue(kvs...)
-	case reflect.Ptr, reflect.Interface:
-		return convertValue(val.Elem().Interface())
-	}
-
-	return log.StringValue(fmt.Sprintf("unhandled attribute type: (%s) %+v", t, v))
-}

--- a/bridges/otelzap/encoder_test.go
+++ b/bridges/otelzap/encoder_test.go
@@ -73,6 +73,14 @@ func TestObjectEncoder(t *testing.T) {
 			expected: map[string]interface{}{"foo": int64(5)},
 		},
 		{
+			desc: "AddReflected (nil pointer)",
+			f: func(e zapcore.ObjectEncoder) {
+				var p *struct{}
+				assert.NoError(t, e.AddReflected("k", p), "Expected AddReflected to succeed.")
+			},
+			expected: nil,
+		},
+		{
 			desc:     "AddBinary",
 			f:        func(e zapcore.ObjectEncoder) { e.AddBinary("k", []byte("foo")) },
 			expected: []byte("foo"),

--- a/bridges/otelzap/gen.go
+++ b/bridges/otelzap/gen.go
@@ -1,0 +1,8 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otelzap // import "go.opentelemetry.io/contrib/bridges/otelzap"
+
+// Generate convert:
+//go:generate gotmpl --body=../../internal/shared/logutil/convert_test.go.tmpl "--data={ \"pkg\": \"otelzap\" }" --out=convert_test.go
+//go:generate gotmpl --body=../../internal/shared/logutil/convert.go.tmpl "--data={ \"pkg\": \"otelzap\" }" --out=convert.go

--- a/internal/shared/logutil/convert.go.tmpl
+++ b/internal/shared/logutil/convert.go.tmpl
@@ -113,7 +113,7 @@ func ConvertValue(v any) log.Value {
 	return log.StringValue(fmt.Sprintf("unhandled: (%s) %+v", t, v))
 }
 
-// ConvertUintValue converts a uint64 to a log.Value.
+// convertUintValue converts a uint64 to a log.Value.
 // If the value is too large to fit in an int64, it is converted to a string.
 func convertUintValue(v uint64) log.Value {
 	if v > math.MaxInt64 {

--- a/internal/shared/logutil/convert.go.tmpl
+++ b/internal/shared/logutil/convert.go.tmpl
@@ -16,8 +16,8 @@ import (
 	"go.opentelemetry.io/otel/log"
 )
 
-// Convert various types to log.Value.
-func ConvertValue(v any) log.Value {
+// convertValue converts various types to log.Value.
+func convertValue(v any) log.Value {
 	// Handling the most common types without reflect is a small perf win.
 	switch val := v.(type) {
 	case bool:
@@ -79,7 +79,7 @@ func ConvertValue(v any) log.Value {
 	case reflect.Slice, reflect.Array:
 		items := make([]log.Value, 0, val.Len())
 		for i := 0; i < val.Len(); i++ {
-			items = append(items, ConvertValue(val.Index(i).Interface()))
+			items = append(items, convertValue(val.Index(i).Interface()))
 		}
 		return log.SliceValue(items...)
 	case reflect.Map:
@@ -94,7 +94,7 @@ func ConvertValue(v any) log.Value {
 			}
 			kvs = append(kvs, log.KeyValue{
 				Key:   key,
-				Value: ConvertValue(val.MapIndex(k).Interface()),
+				Value: convertValue(val.MapIndex(k).Interface()),
 			})
 		}
 		return log.MapValue(kvs...)
@@ -102,7 +102,7 @@ func ConvertValue(v any) log.Value {
 		if val.IsNil() {
 			return log.Value{}
 		}
-		return ConvertValue(val.Elem().Interface())
+		return convertValue(val.Elem().Interface())
 	}
 
 	// Try to handle this as gracefully as possible.

--- a/internal/shared/logutil/convert.go.tmpl
+++ b/internal/shared/logutil/convert.go.tmpl
@@ -4,7 +4,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package otellogr // import "go.opentelemetry.io/contrib/bridges/otellogr"
+package {{.pkg}} // import "go.opentelemetry.io/contrib/bridges/{{.pkg}}"
 
 import (
 	"fmt"

--- a/internal/shared/logutil/convert_test.go.tmpl
+++ b/internal/shared/logutil/convert_test.go.tmpl
@@ -4,7 +4,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package otellogr
+package {{.pkg}}
 
 import (
 	"context"

--- a/internal/shared/logutil/convert_test.go.tmpl
+++ b/internal/shared/logutil/convert_test.go.tmpl
@@ -252,13 +252,13 @@ func TestConvertValue(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.wantValue, ConvertValue(tt.value))
+			assert.Equal(t, tt.wantValue, convertValue(tt.value))
 		})
 	}
 }
 
 func TestConvertValueFloat32(t *testing.T) {
-	value := ConvertValue(float32(3.14))
+	value := convertValue(float32(3.14))
 	want := log.Float64Value(3.14)
 
 	assert.InDelta(t, value.AsFloat64(), want.AsFloat64(), 0.0001)


### PR DESCRIPTION
This pull request aligns the `convertValue` function in the `otellogrus` package with the `otellogr`. 
Also fix #6235 