### PR TITLE
[chore]: enable perfsprint linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,7 @@ linters:
     - govet
     - ineffassign
     - misspell
+    - perfsprint
     - revive
     - staticcheck
     - tenv
@@ -62,10 +63,11 @@ issues:
       text: "calls to (.+) only in main[(][)] or init[(][)] functions"
       linters:
         - revive
-    # It's okay to not run gosec in a test.
+    # It's okay to not run gosec and perfsprint in a test.
     - path: _test\.go
       linters:
         - gosec
+        - perfsprint
   include:
     # revive exported should have comment or be unexported.
     - EXC0012
@@ -109,6 +111,12 @@ linters-settings:
     locale: US
     ignore-words:
       - cancelled
+  perfsprint:
+    err-error: true
+    errorf: true
+    int-conversion: true
+    sprintf1: true
+    strconcat: true
   revive:
     # Sets the default failure confidence.
     # This means that linting errors with less than 0.8 confidence will be ignored.

--- a/config/config_json.go
+++ b/config/config_json.go
@@ -5,6 +5,7 @@ package config // import "go.opentelemetry.io/contrib/config"
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 )
@@ -55,7 +56,7 @@ func (j *BatchLogRecordProcessor) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if _, ok := raw["exporter"]; raw != nil && !ok {
-		return fmt.Errorf("field exporter in BatchLogRecordProcessor: required")
+		return errors.New("field exporter in BatchLogRecordProcessor: required")
 	}
 	type Plain BatchLogRecordProcessor
 	var plain Plain
@@ -73,7 +74,7 @@ func (j *BatchSpanProcessor) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if _, ok := raw["exporter"]; raw != nil && !ok {
-		return fmt.Errorf("field exporter in BatchSpanProcessor: required")
+		return errors.New("field exporter in BatchSpanProcessor: required")
 	}
 	type Plain BatchSpanProcessor
 	var plain Plain
@@ -91,10 +92,10 @@ func (j *GeneralInstrumentationPeerServiceMappingElem) UnmarshalJSON(b []byte) e
 		return err
 	}
 	if _, ok := raw["peer"]; raw != nil && !ok {
-		return fmt.Errorf("field peer in GeneralInstrumentationPeerServiceMappingElem: required")
+		return errors.New("field peer in GeneralInstrumentationPeerServiceMappingElem: required")
 	}
 	if _, ok := raw["service"]; raw != nil && !ok {
-		return fmt.Errorf("field service in GeneralInstrumentationPeerServiceMappingElem: required")
+		return errors.New("field service in GeneralInstrumentationPeerServiceMappingElem: required")
 	}
 	type Plain GeneralInstrumentationPeerServiceMappingElem
 	var plain Plain
@@ -112,10 +113,10 @@ func (j *NameStringValuePair) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if _, ok := raw["name"]; raw != nil && !ok {
-		return fmt.Errorf("field name in NameStringValuePair: required")
+		return errors.New("field name in NameStringValuePair: required")
 	}
 	if _, ok := raw["value"]; raw != nil && !ok {
-		return fmt.Errorf("field value in NameStringValuePair: required")
+		return errors.New("field value in NameStringValuePair: required")
 	}
 	type Plain NameStringValuePair
 	var plain Plain
@@ -158,10 +159,10 @@ func (j *OTLPMetric) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if _, ok := raw["endpoint"]; raw != nil && !ok {
-		return fmt.Errorf("field endpoint in OTLPMetric: required")
+		return errors.New("field endpoint in OTLPMetric: required")
 	}
 	if _, ok := raw["protocol"]; raw != nil && !ok {
-		return fmt.Errorf("field protocol in OTLPMetric: required")
+		return errors.New("field protocol in OTLPMetric: required")
 	}
 	type Plain OTLPMetric
 	var plain Plain
@@ -179,10 +180,10 @@ func (j *OTLP) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if _, ok := raw["endpoint"]; raw != nil && !ok {
-		return fmt.Errorf("field endpoint in OTLP: required")
+		return errors.New("field endpoint in OTLP: required")
 	}
 	if _, ok := raw["protocol"]; raw != nil && !ok {
-		return fmt.Errorf("field protocol in OTLP: required")
+		return errors.New("field protocol in OTLP: required")
 	}
 	type Plain OTLP
 	var plain Plain
@@ -200,7 +201,7 @@ func (j *OpenTelemetryConfiguration) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if _, ok := raw["file_format"]; raw != nil && !ok {
-		return fmt.Errorf("field file_format in OpenTelemetryConfiguration: required")
+		return errors.New("field file_format in OpenTelemetryConfiguration: required")
 	}
 	type Plain OpenTelemetryConfiguration
 	var plain Plain
@@ -218,7 +219,7 @@ func (j *PeriodicMetricReader) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if _, ok := raw["exporter"]; raw != nil && !ok {
-		return fmt.Errorf("field exporter in PeriodicMetricReader: required")
+		return errors.New("field exporter in PeriodicMetricReader: required")
 	}
 	type Plain PeriodicMetricReader
 	var plain Plain
@@ -236,7 +237,7 @@ func (j *PullMetricReader) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if _, ok := raw["exporter"]; raw != nil && !ok {
-		return fmt.Errorf("field exporter in PullMetricReader: required")
+		return errors.New("field exporter in PullMetricReader: required")
 	}
 	type Plain PullMetricReader
 	var plain Plain
@@ -254,7 +255,7 @@ func (j *SimpleLogRecordProcessor) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if _, ok := raw["exporter"]; raw != nil && !ok {
-		return fmt.Errorf("field exporter in SimpleLogRecordProcessor: required")
+		return errors.New("field exporter in SimpleLogRecordProcessor: required")
 	}
 	type Plain SimpleLogRecordProcessor
 	var plain Plain
@@ -272,7 +273,7 @@ func (j *SimpleSpanProcessor) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if _, ok := raw["exporter"]; raw != nil && !ok {
-		return fmt.Errorf("field exporter in SimpleSpanProcessor: required")
+		return errors.New("field exporter in SimpleSpanProcessor: required")
 	}
 	type Plain SimpleSpanProcessor
 	var plain Plain
@@ -319,7 +320,7 @@ func (j *Zipkin) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if _, ok := raw["endpoint"]; raw != nil && !ok {
-		return fmt.Errorf("field endpoint in Zipkin: required")
+		return errors.New("field endpoint in Zipkin: required")
 	}
 	type Plain Zipkin
 	var plain Plain
@@ -337,10 +338,10 @@ func (j *AttributeNameValue) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if _, ok := raw["name"]; raw != nil && !ok {
-		return fmt.Errorf("field name in AttributeNameValue: required")
+		return errors.New("field name in AttributeNameValue: required")
 	}
 	if _, ok := raw["value"]; raw != nil && !ok {
-		return fmt.Errorf("field value in AttributeNameValue: required")
+		return errors.New("field value in AttributeNameValue: required")
 	}
 	type Plain AttributeNameValue
 	var plain Plain

--- a/config/log.go
+++ b/config/log.go
@@ -61,7 +61,7 @@ func logProcessor(ctx context.Context, processor LogRecordProcessor) (sdklog.Pro
 		}
 		return sdklog.NewSimpleProcessor(exp), nil
 	}
-	return nil, fmt.Errorf("unsupported log processor type, must be one of simple or batch")
+	return nil, errors.New("unsupported log processor type, must be one of simple or batch")
 }
 
 func logExporter(ctx context.Context, exporter LogRecordExporter) (sdklog.Exporter, error) {

--- a/config/metric.go
+++ b/config/metric.go
@@ -299,10 +299,10 @@ func newIncludeExcludeFilter(lists *IncludeExclude) (attribute.Filter, error) {
 
 func prometheusReader(ctx context.Context, prometheusConfig *Prometheus) (sdkmetric.Reader, error) {
 	if prometheusConfig.Host == nil {
-		return nil, fmt.Errorf("host must be specified")
+		return nil, errors.New("host must be specified")
 	}
 	if prometheusConfig.Port == nil {
-		return nil, fmt.Errorf("port must be specified")
+		return nil, errors.New("port must be specified")
 	}
 
 	opts, err := prometheusReaderOpts(prometheusConfig)

--- a/config/resource.go
+++ b/config/resource.go
@@ -5,6 +5,7 @@ package config // import "go.opentelemetry.io/contrib/config"
 
 import (
 	"fmt"
+	"strconv"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -17,7 +18,7 @@ func keyVal(k string, v any) attribute.KeyValue {
 	case int64:
 		return attribute.Int64(k, val)
 	case uint64:
-		return attribute.String(k, fmt.Sprintf("%d", val))
+		return attribute.String(k, strconv.FormatUint(val, 10))
 	case float64:
 		return attribute.Float64(k, val)
 	case int8:
@@ -37,7 +38,7 @@ func keyVal(k string, v any) attribute.KeyValue {
 	case int:
 		return attribute.Int(k, val)
 	case uint:
-		return attribute.String(k, fmt.Sprintf("%d", val))
+		return attribute.String(k, strconv.FormatUint(uint64(val), 10))
 	case string:
 		return attribute.String(k, val)
 	default:

--- a/config/trace.go
+++ b/config/trace.go
@@ -83,7 +83,7 @@ func spanProcessor(ctx context.Context, processor SpanProcessor) (sdktrace.SpanP
 		}
 		return sdktrace.NewSimpleSpanProcessor(exp), nil
 	}
-	return nil, fmt.Errorf("unsupported span processor type, must be one of simple or batch")
+	return nil, errors.New("unsupported span processor type, must be one of simple or batch")
 }
 
 func otlpGRPCSpanExporter(ctx context.Context, otlpConfig *OTLP) (sdktrace.SpanExporter, error) {

--- a/detectors/aws/eks/detector.go
+++ b/detectors/aws/eks/detector.go
@@ -5,6 +5,7 @@ package eks // import "go.opentelemetry.io/contrib/detectors/aws/eks"
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -130,7 +131,7 @@ func newK8sDetectorUtils() (*eksDetectorUtils, error) {
 	// Create clientset using generated configuration
 	clientset, err := kubernetes.NewForConfig(confs)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create clientset for Kubernetes client")
+		return nil, errors.New("failed to create clientset for Kubernetes client")
 	}
 
 	return &eksDetectorUtils{clientset: clientset}, nil

--- a/examples/dice/rolldice.go
+++ b/examples/dice/rolldice.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"fmt"
 	"io"
 	"math/rand"
 	"net/http"
@@ -43,7 +42,7 @@ func rolldice(w http.ResponseWriter, r *http.Request) {
 
 	var msg string
 	if player := r.PathValue("player"); player != "" {
-		msg = fmt.Sprintf("%s is rolling the dice", player)
+		msg = player + " is rolling the dice"
 	} else {
 		msg = "Anonymous player is rolling the dice"
 	}

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/wrapLambdaHandler.go
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/wrapLambdaHandler.go
@@ -6,6 +6,7 @@ package otellambda // import "go.opentelemetry.io/contrib/instrumentation/github
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 )
@@ -47,14 +48,14 @@ func validateReturns(handler reflect.Type) error {
 
 	switch n := handler.NumOut(); {
 	case n > 2:
-		return fmt.Errorf("handler may not return more than two values")
+		return errors.New("handler may not return more than two values")
 	case n == 2:
 		if !handler.Out(1).Implements(errorType) {
-			return fmt.Errorf("handler returns two values, but the second does not implement error")
+			return errors.New("handler returns two values, but the second does not implement error")
 		}
 	case n == 1:
 		if !handler.Out(0).Implements(errorType) {
-			return fmt.Errorf("handler returns a single value, but it does not implement error")
+			return errors.New("handler returns a single value, but it does not implement error")
 		}
 	}
 
@@ -88,7 +89,7 @@ func InstrumentHandler(handlerFunc interface{}, options ...Option) interface{} {
 	whf := wrappedHandlerFunction{instrumentor: newInstrumentor(options...)}
 
 	if handlerFunc == nil {
-		return errorHandler(fmt.Errorf("handler is nil"))
+		return errorHandler(errors.New("handler is nil"))
 	}
 	handlerType := reflect.TypeOf(handlerFunc)
 	if handlerType.Kind() != reflect.Func {

--- a/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/mongo.go
+++ b/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/mongo.go
@@ -5,6 +5,7 @@ package otelmongo // import "go.opentelemetry.io/contrib/instrumentation/go.mong
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -118,7 +119,7 @@ func extractCollection(evt *event.CommandStartedEvent) (string, error) {
 		}
 		return v.StringValue(), nil
 	}
-	return "", fmt.Errorf("collection name not found")
+	return "", errors.New("collection name not found")
 }
 
 // NewMonitor creates a new mongodb event CommandMonitor.

--- a/instrumentation/host/host.go
+++ b/instrumentation/host/host.go
@@ -5,6 +5,7 @@ package host // import "go.opentelemetry.io/contrib/instrumentation/host"
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -204,7 +205,7 @@ func (h *host) register() error {
 				return err
 			}
 			if len(hostTimeSlice) != 1 {
-				return fmt.Errorf("host CPU usage: incorrect summary count")
+				return errors.New("host CPU usage: incorrect summary count")
 			}
 
 			vmStats, err := mem.VirtualMemoryWithContext(ctx)
@@ -217,7 +218,7 @@ func (h *host) register() error {
 				return err
 			}
 			if len(ioStats) != 1 {
-				return fmt.Errorf("host network usage: incorrect summary count")
+				return errors.New("host network usage: incorrect summary count")
 			}
 
 			hostTime := hostTimeSlice[0]

--- a/instrumentation/runtime/producer.go
+++ b/instrumentation/runtime/producer.go
@@ -5,7 +5,7 @@ package runtime // import "go.opentelemetry.io/contrib/instrumentation/runtime"
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"math"
 	"runtime/metrics"
 	"sync"
@@ -50,7 +50,7 @@ func (p *Producer) Produce(context.Context) ([]metricdata.ScopeMetrics, error) {
 	// Use the last collection time (which may or may not be now) for the timestamp.
 	histDp := convertRuntimeHistogram(schedHist, p.collector.lastCollect)
 	if len(histDp) == 0 {
-		return nil, fmt.Errorf("unable to obtain go.schedule.duration metric from the runtime")
+		return nil, errors.New("unable to obtain go.schedule.duration metric from the runtime")
 	}
 	return []metricdata.ScopeMetrics{
 		{

--- a/samplers/probability/consistent/tracestate.go
+++ b/samplers/probability/consistent/tracestate.go
@@ -4,6 +4,7 @@
 package consistent // import "go.opentelemetry.io/contrib/samplers/probability/consistent"
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -20,7 +21,7 @@ const (
 
 var (
 	errTraceStateSyntax       = fmt.Errorf("otel tracestate: %w", strconv.ErrSyntax)
-	errTraceStateInconsistent = fmt.Errorf("r-value and p-value are inconsistent")
+	errTraceStateInconsistent = errors.New("r-value and p-value are inconsistent")
 )
 
 type otelTraceState struct {


### PR DESCRIPTION
Description
[perfsprint](https://github.com/catenacyber/perfsprint) is a linter for performance, aiming at usages of fmt.Sprintf which have faster alternatives.