### PR TITLE
Fix lint issue for golangci-lint 1.62.0

### DIFF
--- a/bridges/otelzap/encoder.go
+++ b/bridges/otelzap/encoder.go
@@ -31,8 +31,8 @@ type objectEncoder struct {
 	cur *namespace
 }
 
-func newObjectEncoder(le int) *objectEncoder {
-	keyval := make([]log.KeyValue, 0, le)
+func newObjectEncoder(n int) *objectEncoder {
+	keyval := make([]log.KeyValue, 0, n)
 	m := &namespace{
 		attrs: keyval,
 	}

--- a/bridges/otelzap/encoder.go
+++ b/bridges/otelzap/encoder.go
@@ -31,8 +31,8 @@ type objectEncoder struct {
 	cur *namespace
 }
 
-func newObjectEncoder(len int) *objectEncoder {
-	keyval := make([]log.KeyValue, 0, len)
+func newObjectEncoder(le int) *objectEncoder {
+	keyval := make([]log.KeyValue, 0, le)
 	m := &namespace{
 		attrs: keyval,
 	}


### PR DESCRIPTION
This fixes the sole linting issue required to allow the upgrade to golangci-lint 1.62.0 in https://github.com/open-telemetry/opentelemetry-go-contrib/pull/6320.