### PR TITLE
Use lychee new cache-exclude-status option

### DIFF
--- a/.github/workflows/links-fail-fast.yml
+++ b/.github/workflows/links-fail-fast.yml
@@ -25,5 +25,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           fail: true
-          # TODO: Remove 429s exception once https://github.com/open-telemetry/opentelemetry-go-contrib/issues/6183 is resolved
-          args: --max-concurrency 5 --cache --max-cache-age 1d --accept 100..=103,200..=299,429 .
+          args: --max-concurrency 5 --cache --max-cache-age 1d --cache-exclude-status 300..=599 .

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -30,8 +30,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-          # TODO: Remove 429s exception once https://github.com/open-telemetry/opentelemetry-go-contrib/issues/6183 is resolved
-          args: --max-concurrency 1 --cache --max-cache-age 1d --accept 100..=103,200..=299,429 .
+          args: --max-concurrency 1 --cache --max-cache-age 1d --cache-exclude-status 300..=599 .
 
     - name: Create Issue From File
       if: steps.lychee.outputs.exit_code != 0


### PR DESCRIPTION
Lychee's `cache-exclude-status` option has shipped. So we can use it rather than ignore 429s.