### PR TITLE
[chore] Fix codecov action usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,9 +87,8 @@ jobs:
         cp coverage.html $TEST_RESULTS
     - name: Upload coverage report
       uses: codecov/codecov-action@v5.0.0
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
+        fail_ci_if_error: true
         files: ./coverage.txt
         verbose: true
     - name: Store coverage test output


### PR DESCRIPTION
Same as https://github.com/open-telemetry/opentelemetry-go/pull/5979.

This change makes sure that an unsuccessful upload will fail the workflow as this does not happen at the moment. 

Additionally, it configures the codecov action to be tokenless.