### PR TITLE
Add the tmp directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ instrumentation/google.golang.org/grpc/otelgrpc/example/server/server
 instrumentation/google.golang.org/grpc/otelgrpc/example/client/client
 
 instrgen/driver/testdata/**/*.go_pass_*
+
+tmp


### PR DESCRIPTION
Running `make genjsonschema` creates a `tmp` directory that is not present in the .gitignore file, this makes sure contributors don't need to worry about having it in their repo directory.