### PR TITLE
update go directives in go.mod files

### DIFF
--- a/bridges/otellogr/go.mod
+++ b/bridges/otellogr/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/bridges/otellogr
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/go-logr/logr v1.4.2

--- a/bridges/otellogrus/go.mod
+++ b/bridges/otellogrus/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/bridges/otellogrus
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/sirupsen/logrus v1.9.3

--- a/bridges/otelslog/go.mod
+++ b/bridges/otelslog/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/bridges/otelslog
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/bridges/otelzap/go.mod
+++ b/bridges/otelzap/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/bridges/otelzap
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/bridges/prometheus/go.mod
+++ b/bridges/prometheus/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/bridges/prometheus
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/prometheus/client_golang v1.20.5

--- a/detectors/aws/ec2/go.mod
+++ b/detectors/aws/ec2/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/detectors/aws/ec2
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/aws/aws-sdk-go v1.55.5

--- a/detectors/aws/ecs/go.mod
+++ b/detectors/aws/ecs/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/detectors/aws/ecs
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20221221133751-67e37ae746cd

--- a/detectors/aws/lambda/go.mod
+++ b/detectors/aws/lambda/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/detectors/aws/lambda
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/detectors/azure/azurevm/go.mod
+++ b/detectors/azure/azurevm/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/detectors/azure/azurevm
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/detectors/gcp/go.mod
+++ b/detectors/gcp/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/detectors/gcp
 
-go 1.22
+go 1.22.0
 
 require (
 	cloud.google.com/go/compute/metadata v0.5.2

--- a/examples/dice/go.mod
+++ b/examples/dice/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/examples/dice
 
-go 1.22
+go 1.22.0
 
 require (
 	go.opentelemetry.io/contrib/bridges/otelslog v0.7.0

--- a/examples/namedtracer/go.mod
+++ b/examples/namedtracer/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/examples/namedtracer
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/go-logr/stdr v1.2.2

--- a/examples/opencensus/go.mod
+++ b/examples/opencensus/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/examples/opencensus
 
-go 1.22
+go 1.22.0
 
 require (
 	go.opencensus.io v0.24.0

--- a/examples/passthrough/go.mod
+++ b/examples/passthrough/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/examples/passthrough
 
-go 1.22
+go 1.22.0
 
 require (
 	go.opentelemetry.io/otel v1.32.0

--- a/examples/prometheus/go.mod
+++ b/examples/prometheus/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/examples/prometheus
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/prometheus/client_golang v1.20.5

--- a/examples/zipkin/go.mod
+++ b/examples/zipkin/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/examples/zipkin
 
-go 1.22
+go 1.22.0
 
 require (
 	go.opentelemetry.io/otel v1.32.0

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module go.opentelemetry.io/contrib
 
-go 1.22
+go 1.22.0

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/example/go.mod
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/example/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda/example
 
-go 1.22
+go 1.22.0
 
 replace (
 	go.opentelemetry.io/contrib/detectors/aws/lambda => ../../../../../../detectors/aws/lambda

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/go.mod
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/aws/aws-lambda-go v1.47.0

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/test/go.mod
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/test/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda/test
 
-go 1.22
+go 1.22.0
 
 replace (
 	go.opentelemetry.io/contrib/detectors/aws/lambda => ../../../../../../detectors/aws/lambda

--- a/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/example/go.mod
+++ b/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/example/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/example
 
-go 1.22
+go 1.22.0
 
 replace go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws => ../
 

--- a/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/go.mod
+++ b/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.32.5

--- a/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/test/go.mod
+++ b/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/test/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/test
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.32.5

--- a/instrumentation/github.com/emicklei/go-restful/otelrestful/example/go.mod
+++ b/instrumentation/github.com/emicklei/go-restful/otelrestful/example/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful/example
 
-go 1.22
+go 1.22.0
 
 replace (
 	go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful => ../

--- a/instrumentation/github.com/emicklei/go-restful/otelrestful/go.mod
+++ b/instrumentation/github.com/emicklei/go-restful/otelrestful/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful
 
-go 1.22
+go 1.22.0
 
 replace go.opentelemetry.io/contrib/propagators/b3 => ../../../../../propagators/b3
 

--- a/instrumentation/github.com/emicklei/go-restful/otelrestful/test/go.mod
+++ b/instrumentation/github.com/emicklei/go-restful/otelrestful/test/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful/test
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/emicklei/go-restful/v3 v3.12.1

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/example/go.mod
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/example/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin/example
 
-go 1.22
+go 1.22.0
 
 replace (
 	go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin => ../

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/go.mod
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/gin-gonic/gin v1.10.0

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/test/go.mod
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/test/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin/test
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/gin-gonic/gin v1.10.0

--- a/instrumentation/github.com/gorilla/mux/otelmux/example/go.mod
+++ b/instrumentation/github.com/gorilla/mux/otelmux/example/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux/example
 
-go 1.22
+go 1.22.0
 
 replace go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux => ../
 

--- a/instrumentation/github.com/gorilla/mux/otelmux/go.mod
+++ b/instrumentation/github.com/gorilla/mux/otelmux/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/felixge/httpsnoop v1.0.4

--- a/instrumentation/github.com/gorilla/mux/otelmux/test/go.mod
+++ b/instrumentation/github.com/gorilla/mux/otelmux/test/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux/test
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/gorilla/mux v1.8.1

--- a/instrumentation/github.com/labstack/echo/otelecho/example/go.mod
+++ b/instrumentation/github.com/labstack/echo/otelecho/example/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho/example
 
-go 1.22
+go 1.22.0
 
 replace (
 	go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho => ../

--- a/instrumentation/github.com/labstack/echo/otelecho/go.mod
+++ b/instrumentation/github.com/labstack/echo/otelecho/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho
 
-go 1.22
+go 1.22.0
 
 replace go.opentelemetry.io/contrib/propagators/b3 => ../../../../../propagators/b3
 

--- a/instrumentation/github.com/labstack/echo/otelecho/test/go.mod
+++ b/instrumentation/github.com/labstack/echo/otelecho/test/go.mod
@@ -1,7 +1,7 @@
 // Deprecated: otelecho has no Code Owner.
 module go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho/test
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/labstack/echo/v4 v4.12.0

--- a/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/go.mod
+++ b/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo
 
-go 1.22
+go 1.22.0
 
 require (
 	go.mongodb.org/mongo-driver v1.17.1

--- a/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/test/go.mod
+++ b/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/test/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/test
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/instrumentation/host/example/go.mod
+++ b/instrumentation/host/example/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/host/example
 
-go 1.22
+go 1.22.0
 
 replace go.opentelemetry.io/contrib/instrumentation/host => ../
 

--- a/instrumentation/host/go.mod
+++ b/instrumentation/host/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/host
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/shirou/gopsutil/v4 v4.24.10

--- a/instrumentation/net/http/httptrace/otelhttptrace/example/go.mod
+++ b/instrumentation/net/http/httptrace/otelhttptrace/example/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace/example
 
-go 1.22
+go 1.22.0
 
 replace (
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace => ../

--- a/instrumentation/net/http/httptrace/otelhttptrace/go.mod
+++ b/instrumentation/net/http/httptrace/otelhttptrace/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/instrumentation/net/http/httptrace/otelhttptrace/test/go.mod
+++ b/instrumentation/net/http/httptrace/otelhttptrace/test/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace/test
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/instrumentation/net/http/otelhttp/example/go.mod
+++ b/instrumentation/net/http/otelhttp/example/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/example
 
-go 1.22
+go 1.22.0
 
 replace go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp => ../
 

--- a/instrumentation/net/http/otelhttp/go.mod
+++ b/instrumentation/net/http/otelhttp/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/felixge/httpsnoop v1.0.4

--- a/instrumentation/net/http/otelhttp/test/go.mod
+++ b/instrumentation/net/http/otelhttp/test/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/test
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/instrumentation/runtime/go.mod
+++ b/instrumentation/runtime/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/runtime
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/processors/baggagecopy/go.mod
+++ b/processors/baggagecopy/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/processors/baggagecopy
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/processors/minsev/go.mod
+++ b/processors/minsev/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/processors/minsev
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/propagators/autoprop/go.mod
+++ b/propagators/autoprop/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/propagators/autoprop
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/propagators/aws/go.mod
+++ b/propagators/aws/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/propagators/aws
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/propagators/b3/go.mod
+++ b/propagators/b3/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/propagators/b3
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/propagators/jaeger/go.mod
+++ b/propagators/jaeger/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/propagators/jaeger
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/propagators/opencensus/go.mod
+++ b/propagators/opencensus/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/propagators/opencensus
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/propagators/ot/go.mod
+++ b/propagators/ot/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/propagators/ot
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/samplers/jaegerremote/example/go.mod
+++ b/samplers/jaegerremote/example/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/samplers/jaegerremote/example
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/davecgh/go-spew v1.1.1

--- a/samplers/jaegerremote/go.mod
+++ b/samplers/jaegerremote/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/samplers/jaegerremote
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/go-logr/logr v1.4.2

--- a/samplers/probability/consistent/go.mod
+++ b/samplers/probability/consistent/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/samplers/probability/consistent
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/zpages/go.mod
+++ b/zpages/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/zpages
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/stretchr/testify v1.10.0


### PR DESCRIPTION
Go updated their toolchain to not accept directives of the form `go a.b`. You must provide either `go a.b.c`, or include a `toolchain` directive as well. This prevents this repository from building on newer versions of go. More details: https://github.com/golang/go/issues/62278