### PR TITLE
otelhttp: close wrappedBody span only once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fixed the value for configuring the OTLP exporter to use `grpc` instead of `grpc/protobuf` in `go.opentelemetry.io/contrib/config`. (#6338)
 - Allow marshaling types in `go.opentelemetry.io/contrib/config`. (#6347)
 - Removed the redundant handling of panic from the `HTML` function in `go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin`. (#6373)
+- Close spans only once in `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp. (#6391)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->


### PR DESCRIPTION
The span was otherwise closed twice: once when the body is exhausted with an `io.EOF` and once when the body is explicitly `Close`d. As a result the span was shipped twice from the application and was leading to duplicate traces like so
<img width="1297" alt="Screenshot 2024-12-02 at 19 45 54" src="https://github.com/user-attachments/assets/d6b99992-ee39-4a33-a5d4-5d0ece08edf1">



This is after this fix
<img width="1361" alt="Screenshot 2024-12-02 at 19 46 11" src="https://github.com/user-attachments/assets/06a15421-0c82-4a0a-9806-9302eaa32ab1">
