### PR TITLE
update(renovate): add Go constraint

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,9 @@
   "ignoreDeps": [ "go.opentelemetry.io/contrib/instrgen" ],
   "labels": ["Skip Changelog", "dependencies"],
   "separateMajorMinor": true,
+  "constraints": {
+    "go": "1.22"
+  },
   "postUpdateOptions" : [
     "gomodTidy"
   ],


### PR DESCRIPTION
This ensures that updates to versions that are not supported by 1.22 are avoided. Until you change this configuration item.

https://docs.renovatebot.com/language-constraints-and-upgrading/

> In addition, I think it can skip CHANGELOG.