### PR TITLE
Fix: error logged on empty OTEL_TRACES_SAMPLER_ARG

### DIFF
--- a/samplers/jaegerremote/sampler_remote_options.go
+++ b/samplers/jaegerremote/sampler_remote_options.go
@@ -46,7 +46,12 @@ func getEnvOptions() ([]Option, []error) {
 	// list of errors which will be logged once logger is set by the user
 	var errs []error
 
-	args := strings.Split(os.Getenv("OTEL_TRACES_SAMPLER_ARG"), ",")
+	rawEnvArgs, ok := os.LookupEnv("OTEL_TRACES_SAMPLER_ARG")
+	if !ok {
+		return nil, nil
+	}
+
+	args := strings.Split(rawEnvArgs, ",")
 	for _, arg := range args {
 		keyValue := strings.Split(arg, "=")
 		if len(keyValue) != 2 {

--- a/samplers/jaegerremote/sampler_remote_test.go
+++ b/samplers/jaegerremote/sampler_remote_test.go
@@ -22,6 +22,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -653,4 +654,16 @@ func TestEnvVarSettingForNewTracer(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("No-op when env var not set", func(t *testing.T) {
+		// t.Setenv to restore this environment variable at the end of the test
+		t.Setenv("OTEL_TRACES_SAMPLER_ARG", "")
+		// unset it during the test
+		require.NoError(t, os.Unsetenv("OTEL_TRACES_SAMPLER_ARG"))
+
+		opts, errs := getEnvOptions()
+
+		require.Empty(t, errs)
+		require.Empty(t, opts)
+	})
 }


### PR DESCRIPTION
We were noticing errors like:

> time=2024-12-18T15:00:02.080Z level=ERROR
source=/go/pkg/mod/go.opentelemetry.io/contrib/samplers/jaegerremote@v0.27.0/sampler_remote_options.go:112 msg="env variable parsing failure" err="argument  is not of type '<key>=<value>'"

In applications using the Jaeger sampler but had not set the `OTEL_TRACES_SAMPLER_ARG` environment variable. The issue was:

* `os.Getenv` would return `""` when this var was not set, and
* `strings.Split("", ",")` would return `[]string{""}`

since `""` does not contain `=` an error is emitted.