### PR TITLE
Add support for detecting MIG attributes on GCE VMs

### DIFF
--- a/detectors/gcp/types.go
+++ b/detectors/gcp/types.go
@@ -30,4 +30,5 @@ type gcpDetector interface {
 	GCEInstanceName() (string, error)
 	CloudRunJobExecution() (string, error)
 	CloudRunJobTaskIndex() (string, error)
+	GCEManagedInstanceGroup() (gcp.ManagedInstanceGroup, error)
 }


### PR DESCRIPTION
This adds support for two new resource attributes, `gcp.gce.instance_group_manager.name` and `gcp.gce.instance_group_manager.{zone,region}`, that indicate the managed instance group that a Compute Engine VM is part of. The equivalent Collector change is in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/36142