### PR TITLE
add metricAttributesFn to http server handler in otelhttp,

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added SNS instrumentation in `go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws`. (#6388)
 - Use a `sync.Pool` for metric options in `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp`. (#6394)
 - Added support for configuring `Certificate` field when configuring OTLP exporters in `go.opentelemetry.io/contrib/config`. (#6376)
+- Added `metricAttributesFn` to `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp` to allow setting dynamic, per-request metric attributes for http server metrics. (#6541)
 
 ### Changed
 

--- a/instrumentation/net/http/otelhttp/handler.go
+++ b/instrumentation/net/http/otelhttp/handler.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/internal/request"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/internal/semconv"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -21,15 +22,16 @@ type middleware struct {
 	operation string
 	server    string
 
-	tracer            trace.Tracer
-	propagators       propagation.TextMapPropagator
-	spanStartOptions  []trace.SpanStartOption
-	readEvent         bool
-	writeEvent        bool
-	filters           []Filter
-	spanNameFormatter func(string, *http.Request) string
-	publicEndpoint    bool
-	publicEndpointFn  func(*http.Request) bool
+	tracer             trace.Tracer
+	propagators        propagation.TextMapPropagator
+	spanStartOptions   []trace.SpanStartOption
+	readEvent          bool
+	writeEvent         bool
+	filters            []Filter
+	spanNameFormatter  func(string, *http.Request) string
+	publicEndpoint     bool
+	publicEndpointFn   func(*http.Request) bool
+	metricAttributesFn func(*http.Request) []attribute.KeyValue
 
 	semconv semconv.HTTPServer
 }
@@ -189,19 +191,29 @@ func (h *middleware) serveHTTP(w http.ResponseWriter, r *http.Request, next http
 	// Use floating point division here for higher precision (instead of Millisecond method).
 	elapsedTime := float64(time.Since(requestStartTime)) / float64(time.Millisecond)
 
+	metricAttributes := semconv.MetricAttributes{
+		Req:                  r,
+		StatusCode:           statusCode,
+		AdditionalAttributes: append(labeler.Get(), h.metricAttributesFromRequest(r)...),
+	}
+
 	h.semconv.RecordMetrics(ctx, semconv.ServerMetricData{
-		ServerName:   h.server,
-		ResponseSize: bytesWritten,
-		MetricAttributes: semconv.MetricAttributes{
-			Req:                  r,
-			StatusCode:           statusCode,
-			AdditionalAttributes: labeler.Get(),
-		},
+		ServerName:       h.server,
+		ResponseSize:     bytesWritten,
+		MetricAttributes: metricAttributes,
 		MetricData: semconv.MetricData{
 			RequestSize: bw.BytesRead(),
 			ElapsedTime: elapsedTime,
 		},
 	})
+}
+
+func (h *middleware) metricAttributesFromRequest(r *http.Request) []attribute.KeyValue {
+	var attributeForRequest []attribute.KeyValue
+	if h.metricAttributesFn != nil {
+		attributeForRequest = h.metricAttributesFn(r)
+	}
+	return attributeForRequest
 }
 
 // WithRouteTag annotates spans and metrics with the provided route name


### PR DESCRIPTION
 add metricAttributesFn to http server handler in otelhttp, for dynamically setting per-request metric attributes