### PR TITLE
Duplicate client metrics with semconv v1.26 in otelhttp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Generate server metrics with semantic conventions v1.26 in `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp` when `OTEL_SEMCONV_STABILITY_OPT_IN` is set to `http/dup`. (#6411)
+- Generate client metrics with semantic conventions v1.26 in `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp` when `OTEL_SEMCONV_STABILITY_OPT_IN` is set to `http/dup`. (#6607)
 
 ### Fixed
 

--- a/instrumentation/net/http/otelhttp/internal/semconv/env_test.go
+++ b/instrumentation/net/http/otelhttp/internal/semconv/env_test.go
@@ -81,7 +81,7 @@ func TestHTTPClientDoesNotPanic(t *testing.T) {
 					Req:        req,
 					StatusCode: 200,
 				})
-				tt.client.RecordResponseSize(context.Background(), 40, opts.AddOptions())
+				tt.client.RecordResponseSize(context.Background(), 40, opts)
 				tt.client.RecordMetrics(context.Background(), MetricData{
 					RequestSize: 20,
 					ElapsedTime: 1,

--- a/instrumentation/net/http/otelhttp/internal/semconv/test/v1.20.0_test.go
+++ b/instrumentation/net/http/otelhttp/internal/semconv/test/v1.20.0_test.go
@@ -236,7 +236,7 @@ func TestV120ClientMetrics(t *testing.T) {
 
 	ctx := context.Background()
 
-	client.RecordResponseSize(ctx, 200, opts.AddOptions())
+	client.RecordResponseSize(ctx, 200, opts)
 
 	client.RecordMetrics(ctx, semconv.MetricData{
 		RequestSize: 100,

--- a/instrumentation/net/http/otelhttp/transport.go
+++ b/instrumentation/net/http/otelhttp/transport.go
@@ -153,7 +153,7 @@ func (t *Transport) RoundTrip(r *http.Request) (*http.Response, error) {
 
 	// For handling response bytes we leverage a callback when the client reads the http response
 	readRecordFunc := func(n int64) {
-		t.semconv.RecordResponseSize(ctx, n, metricOpts.AddOptions())
+		t.semconv.RecordResponseSize(ctx, n, metricOpts)
 	}
 
 	// traces


### PR DESCRIPTION
Closes #6261 