### PR TITLE
Add documentation on runtime.Start for scheduling metrics

### DIFF
--- a/instrumentation/runtime/runtime.go
+++ b/instrumentation/runtime/runtime.go
@@ -35,6 +35,7 @@ const (
 )
 
 // Start initializes reporting of runtime metrics using the supplied config.
+// For goroutine scheduling metrics, additionally see [NewProducer].
 func Start(opts ...Option) error {
 	c := newConfig(opts...)
 	meter := c.MeterProvider.Meter(


### PR DESCRIPTION
Had completely missed scheduling metrics are separate from what otherwise seems like the full entrypoint to the package. I think a link to the other entrypoint would be very helpful here.