### PR TITLE
config: fix issue causing a crash on invalid value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Use `context.Background()` as default context instead of nil in `go.opentelemetry.io/contrib/bridges/otellogr`. (#6527)
 - Convert Prometheus histogram buckets to non-cumulative otel histogram buckets in `go.opentelemetry.io/contrib/bridges/prometheus`. (#6685)
 - Don't start spans that never end for filtered out gRPC stats handler in `go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc`. (#6695)
+- Fix a possible nil dereference panic in `NewSDK` of `go.opentelemetry.io/contrib/config/v0.3.0`. (#6752)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/config/v0.3.0/config.go
+++ b/config/v0.3.0/config.go
@@ -155,7 +155,9 @@ func ParseYAML(file []byte) (*OpenTelemetryConfiguration, error) {
 func toStringMap(pairs []NameStringValuePair) map[string]string {
 	output := make(map[string]string)
 	for _, v := range pairs {
-		output[v.Name] = *v.Value
+		if v.Value != nil && len(v.Name) > 0 {
+			output[v.Name] = *v.Value
+		}
 	}
 	return output
 }

--- a/config/v0.3.0/config_test.go
+++ b/config/v0.3.0/config_test.go
@@ -568,6 +568,12 @@ func TestCreateTLSConfig(t *testing.T) {
 	}
 }
 
+func TestToStringMap(t *testing.T) {
+	require.Equal(t, map[string]string{}, toStringMap([]NameStringValuePair{}))
+	require.Equal(t, map[string]string{}, toStringMap([]NameStringValuePair{{Name: "test"}}))
+	require.Equal(t, map[string]string{}, toStringMap([]NameStringValuePair{{Value: ptr("test")}}))
+}
+
 func ptr[T any](v T) *T {
 	return &v
 }


### PR DESCRIPTION
This addresses a bug that was uncovered in the collector after updating to the latest version of `config` where an unset value in the `NameStringValuePair` results in a [nil dereferencing](https://github.com/open-telemetry/opentelemetry-collector/issues/12332#issuecomment-2649263189).