### PR TITLE
Fix close stale value to be relative

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -19,8 +19,8 @@ jobs:
           close-issue-label: 'closed as inactive'
           days-before-pr-stale: 730
           days-before-issue-stale: 730
-          days-before-pr-close: 744
-          days-before-issue-close: 744
+          days-before-pr-close: 14
+          days-before-issue-close: 14
           exempt-issue-labels: 'never stale'
           exempt-pr-labels: 'never stale'
           ascending: true


### PR DESCRIPTION
It appears the close value is relative to the issue being marked as stale.
Which makes sense. Marking as stale updates the issue, so we'd have to wait for 2 more years before closing.

See https://github.com/actions/stale?tab=readme-ov-file#days-before-close
And https://github.com/open-telemetry/opentelemetry-go-contrib/actions/runs/13893660912/job/38869749363