### PR TITLE
[FEAT] Add ClientErrorsAsSpanErrors config to otelecho middleware

### DIFF
--- a/instrumentation/github.com/labstack/echo/otelecho/config.go
+++ b/instrumentation/github.com/labstack/echo/otelecho/config.go
@@ -12,9 +12,10 @@ import (
 
 // config is used to configure the mux middleware.
 type config struct {
-	TracerProvider oteltrace.TracerProvider
-	Propagators    propagation.TextMapPropagator
-	Skipper        middleware.Skipper
+	TracerProvider           oteltrace.TracerProvider
+	Propagators              propagation.TextMapPropagator
+	Skipper                  middleware.Skipper
+	ClientErrorsAsSpanErrors bool
 }
 
 // Option specifies instrumentation configuration options.
@@ -53,5 +54,13 @@ func WithTracerProvider(provider oteltrace.TracerProvider) Option {
 func WithSkipper(skipper middleware.Skipper) Option {
 	return optionFunc(func(cfg *config) {
 		cfg.Skipper = skipper
+	})
+}
+
+// WithClientErrorsAsSpanErrors specifies whether all HTTP error codes (4xx and 5xx)
+// should be treated as errors in spans. By default, only 5xx are treated as errors.
+func WithClientErrorsAsSpanErrors(enabled bool) Option {
+	return optionFunc(func(cfg *config) {
+		cfg.ClientErrorsAsSpanErrors = enabled
 	})
 }


### PR DESCRIPTION
Closes: https://github.com/open-telemetry/opentelemetry-go-contrib/issues/6975

This PR introduces a `ClientErrorsAsSpanErrors` configuration option to the `otelecho` middleware. When enabled, HTTP 4xx and 5xx status codes are treated as span errors (setting `otel.status_code=ERROR` and `error=true` in the root span). The default remains `false`, where only 5xx codes are errors, preserving existing behavior.

**Motivation**:  
While debugging with Jaeger, I found that traces with 4xx status codes (e.g., 401 Unauthorized) weren’t tagged as errors in the root span, making them hard to filter. For example:  
- `curl 'http://localhost:16686/api/traces?service=jaeger-nl-demo&tags={%22http.method%22:%22POST%22}'` returns a trace with `http.status_code=401` at `/v1/auth/login`, but no `error=true` in the root span. Child spans like `validateCredentials` have `error=true`, but the root span doesn’t reflect this.  
- Adding an error filter, like `curl 'http://localhost:16686/api/traces?service=jaeger-nl-demo&tags={%22http.method%22:%22POST%22,%22error%22:%22true%22}'` or `...?tags={"http.method":"POST","error":"true"}`, returns no results because the middleware doesn’t mark 4xx as errors.  
- Even combining filters like `http.route=/v1/auth/login` with `"error":"true"` fails for the same reason.

This disconnect complicates debugging, as users expect error filters to catch application-level failures (e.g., authentication errors). The new option lets users opt into treating 4xx as errors, aligning the root span with downstream error signals.

**Changes**:  
- Added `ClientErrorsAsSpanErrors` to `config.go` with a `WithClientErrorsAsSpanErrors` setter.  
- Modified `echo.go` to set `codes.Error` for 4xx/5xx when enabled.  
- Default behavior unchanged (only 5xx are errors).

**Impact**:  
- With `ClientErrorsAsSpanErrors=true`, a 401 response at `/v1/auth/login` now includes `otel.status_code=ERROR` and `error=true` in the root span, making it visible in Jaeger error queries.  
- Tested locally with Jaeger; queries like `tags={"error":"true"}` now return 4xx traces as expected.

**Testing**:  
- No unit tests added yet—existing status code tests may cover this, but I can add a specific 4xx case if requested.

Feedback welcome!