### PR TITLE
Remove `SemVersion` from `instrumentation/github.com/aws/aws-lambda-go/otellambda` (#7050)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Drop support for [Go 1.22]. (#6853)
 - The deprecated `go.opentelemetry.io/contrib/config` package is removed, use `go.opentelemetry.io/contrib/otelconf` instead. (#6894)
+- The deprecated `SemVersion` function is removed in `go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda`, use `Version` function instead. (#7050)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/version.go
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/version.go
@@ -8,10 +8,3 @@ func Version() string {
 	return "0.60.0"
 	// This string is updated by the pre_release.sh script during release
 }
-
-// SemVersion is the semantic version to be supplied to tracer/meter creation.
-//
-// Deprecated: Use [Version] instead.
-func SemVersion() string {
-	return Version()
-}


### PR DESCRIPTION
First pull request on a real live project! Please be gracious with me regarding any mistakes.