### PR TITLE
feat(otelmux): update `http.route` attribute to support `request.Pattern`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Jaeger remote sampler's probabilistic strategy now uses the same sampling algorithm as `trace.TraceIDRatioBased` in `go.opentelemetry.io/contrib/samplers/jaegerremote`. (#6892)
 - The deprecated `SemVersion` function is removed in `go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/test` package. Use `Version` instead.
+- Update `http.route` attribute to support `request.Pattern` in `go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux`.
 
 ### Fixed
 

--- a/instrumentation/github.com/gorilla/mux/otelmux/mux.go
+++ b/instrumentation/github.com/gorilla/mux/otelmux/mux.go
@@ -114,12 +114,15 @@ func (tw traceware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	routeStr := ""
-	route := mux.CurrentRoute(r)
-	if route != nil {
-		routeStr, _ = route.GetPathTemplate()
-		if routeStr == "" {
-			routeStr, _ = route.GetPathRegexp()
+	routeStr := r.Pattern
+
+	if routeStr == "" {
+		route := mux.CurrentRoute(r)
+		if route != nil {
+			routeStr, _ = route.GetPathTemplate()
+			if routeStr == "" {
+				routeStr, _ = route.GetPathRegexp()
+			}
 		}
 	}
 


### PR DESCRIPTION
see https://github.com/open-telemetry/opentelemetry-go-contrib/issues/6919