### PR TITLE
Remove SemVersion from instrumentation/github.com/aws/aws-sdk-go-v2/otelaws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The deprecated `SemVersion` function is removed in `go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin`, use `Version` function instead. (#7085)
 - The deprecated `SemVersion` function is removed in `go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin/test`, use `Version` function instead. (#7087)
 - The deprecated `SemVersion` function is removed in `go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho`, use `Version` function instead. (#7089)
+- The deprecated `SemVersion` function is removed in `go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws`, use `Version` function instead. (#7154)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/version.go
+++ b/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/version.go
@@ -8,10 +8,3 @@ func Version() string {
 	return "0.60.0"
 	// This string is updated by the pre_release.sh script during release
 }
-
-// SemVersion is the semantic version to be supplied to tracer/meter creation.
-//
-// Deprecated: Use [Version] instead.
-func SemVersion() string {
-	return Version()
-}


### PR DESCRIPTION
Closes: #7048 