### PR TITLE
otelhttp: export SpanNameFormatters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Use Gin's own `ClientIP` method to detect the client's IP, which supports custom proxy headers in `go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin`. (#6095)
 - Added test for Fields in `go.opentelemetry.io/contrib/propagators/jaeger`. (#7119)
 - Allow configuring samplers in `go.opentelemetry.io/contrib/otelconf`. (#7148)
+- Rerun the span name formatter after the request ran if a `req.Pattern` is set, so the span name can include it in `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp`. (#7192)
 
 ### Changed
 

--- a/instrumentation/net/http/otelhttp/config.go
+++ b/instrumentation/net/http/otelhttp/config.go
@@ -176,6 +176,10 @@ func WithMessageEvents(events ...event) Option {
 
 // WithSpanNameFormatter takes a function that will be called on every
 // request and the returned string will become the Span Name.
+//
+// When using `http.ServeMux` (or any middleware that sets `request.Pattern`),
+// the span name formatter will run twice. Once when the span is created, and
+// once after the middleware, so the pattern can be used.
 func WithSpanNameFormatter(f func(operation string, r *http.Request) string) Option {
 	return optionFunc(func(c *config) {
 		c.SpanNameFormatter = f

--- a/instrumentation/net/http/otelhttp/config.go
+++ b/instrumentation/net/http/otelhttp/config.go
@@ -4,6 +4,7 @@
 package otelhttp // import "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 
 import (
+	"cmp"
 	"context"
 	"net/http"
 	"net/http/httptrace"
@@ -174,13 +175,13 @@ func WithMessageEvents(events ...event) Option {
 	})
 }
 
-// WithSpanNameFormatter takes a function that will be called on every
+// WithSpanNameFormatter takes a [SpanNameFormatter] function that will be called on every
 // request and the returned string will become the Span Name.
 //
 // When using `http.ServeMux` (or any middleware that sets `request.Pattern`),
 // the span name formatter will run twice. Once when the span is created, and
 // once after the middleware, so the pattern can be used.
-func WithSpanNameFormatter(f func(operation string, r *http.Request) string) Option {
+func WithSpanNameFormatter(f SpanNameFormatter) Option {
 	return optionFunc(func(c *config) {
 		c.SpanNameFormatter = f
 	})
@@ -208,4 +209,25 @@ func WithMetricAttributesFn(metricAttributesFn func(r *http.Request) []attribute
 	return optionFunc(func(c *config) {
 		c.MetricAttributesFn = metricAttributesFn
 	})
+}
+
+// SpanNameFormatter returns the span name to use for a given request.
+type SpanNameFormatter = func(operation string, r *http.Request) string
+
+// SpanNameFromOperation always uses the operation name as the span name.
+// It is the default formatter for handlers.
+func SpanNameFromOperation(operation string, _ *http.Request) string {
+	return operation
+}
+
+// SpanNameFromPattern uses the matched request pattern as the span name.
+// It falls back to the operation name if there is no pattern.
+func SpanNameFromPattern(operation string, r *http.Request) string {
+	return cmp.Or(r.Pattern, operation)
+}
+
+// SpanNameFromMethod uses "HTTP " + the request method as the span name.
+// It is the default formatter for transports.
+func SpanNameFromMethod(_ string, r *http.Request) string {
+	return "HTTP " + r.Method
 }

--- a/instrumentation/net/http/otelhttp/handler.go
+++ b/instrumentation/net/http/otelhttp/handler.go
@@ -176,7 +176,12 @@ func (h *middleware) serveHTTP(w http.ResponseWriter, r *http.Request, next http
 		ctx = ContextWithLabeler(ctx, labeler)
 	}
 
-	next.ServeHTTP(w, r.WithContext(ctx))
+	r = r.WithContext(ctx)
+	next.ServeHTTP(w, r)
+
+	if r.Pattern != "" {
+		span.SetName(h.spanNameFormatter(h.operation, r))
+	}
 
 	statusCode := rww.StatusCode()
 	bytesWritten := rww.BytesWritten()

--- a/instrumentation/net/http/otelhttp/handler.go
+++ b/instrumentation/net/http/otelhttp/handler.go
@@ -28,16 +28,12 @@ type middleware struct {
 	readEvent          bool
 	writeEvent         bool
 	filters            []Filter
-	spanNameFormatter  func(string, *http.Request) string
+	spanNameFormatter  SpanNameFormatter
 	publicEndpoint     bool
 	publicEndpointFn   func(*http.Request) bool
 	metricAttributesFn func(*http.Request) []attribute.KeyValue
 
 	semconv semconv.HTTPServer
-}
-
-func defaultHandlerFormatter(operation string, _ *http.Request) string {
-	return operation
 }
 
 // NewHandler wraps the passed handler in a span named after the operation and
@@ -56,7 +52,7 @@ func NewMiddleware(operation string, opts ...Option) func(http.Handler) http.Han
 
 	defaultOpts := []Option{
 		WithSpanOptions(trace.WithSpanKind(trace.SpanKindServer)),
-		WithSpanNameFormatter(defaultHandlerFormatter),
+		WithSpanNameFormatter(SpanNameFromOperation),
 	}
 
 	c := newConfig(append(defaultOpts, opts...)...)

--- a/instrumentation/net/http/otelhttp/transport.go
+++ b/instrumentation/net/http/otelhttp/transport.go
@@ -56,7 +56,7 @@ func NewTransport(base http.RoundTripper, opts ...Option) *Transport {
 
 	defaultOpts := []Option{
 		WithSpanOptions(trace.WithSpanKind(trace.SpanKindClient)),
-		WithSpanNameFormatter(defaultTransportFormatter),
+		WithSpanNameFormatter(SpanNameFromMethod),
 	}
 
 	c := newConfig(append(defaultOpts, opts...)...)
@@ -74,10 +74,6 @@ func (t *Transport) applyConfig(c *config) {
 	t.clientTrace = c.ClientTrace
 	t.semconv = semconv.NewHTTPClient(c.Meter)
 	t.metricAttributesFn = c.MetricAttributesFn
-}
-
-func defaultTransportFormatter(_ string, r *http.Request) string {
-	return "HTTP " + r.Method
 }
 
 // RoundTrip creates a Span and propagates its context via the provided request's headers


### PR DESCRIPTION
Based on top of #7192

Makes SpanNameFormatter a type alias for documentation.
Exports the default formatters.
Adds a new formatter for use with http mux patterns.