### PR TITLE
Revert the switch to default to dup semantic conventions for http packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,13 +26,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - Jaeger remote sampler's probabilistic strategy now uses the same sampling algorithm as `trace.TraceIDRatioBased` in `go.opentelemetry.io/contrib/samplers/jaegerremote`. (#6892)
-- Switched the default for `OTEL_SEMCONV_STABILITY_OPT_IN` to emit the v1.26.0 semantic conventions by default in the following modules.
-  - `go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful`
-  - `go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin`
-  - `go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux`
-  - `go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho`
-  - `go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace`
-  - `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp`
 - Improve performance by reducing allocations for http request when using `OTEL_SEMCONV_STABILITY_OPT_IN=http/dup` in the modules below. (#7180)
   - `go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful`
   - `go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin`
@@ -40,9 +33,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - `go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho`
   - `go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace`
   - `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp`
-
-  The `OTEL_SEMCONV_STABILITY_OPT_IN=http/dup` environment variable can be still used to emit both the v1.20.0 and v1.26.0 semantic conventions.
-  It is however impossible to emit only the 1.20.0 semantic conventions, as the next release will drop support for that environment variable. (#6899)
 - Update the Jaeger remote sampler to use "github.com/jaegertracing/jaeger-idl/proto-gen/api_v2" in  `go.opentelemetry.io/contrib/samplers/jaegerremote`. (#7061)
 - Improve performance by reducing allocations in the gRPC stats handler in `go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc`. (#7186)
 - Update `http.route` attribute to support `request.Pattern` in `go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux`. (#7108)

--- a/instrumentation/github.com/emicklei/go-restful/otelrestful/internal/semconv/env.go
+++ b/instrumentation/github.com/emicklei/go-restful/otelrestful/internal/semconv/env.go
@@ -20,7 +20,7 @@ import (
 )
 
 // OTelSemConvStabilityOptIn is an environment variable.
-// That can be set to "http/dup" to keep getting the old HTTP semantic conventions.
+// That can be set to "http/dup" to opt into the new HTTP semantic conventions.
 const OTelSemConvStabilityOptIn = "OTEL_SEMCONV_STABILITY_OPT_IN"
 
 type ResponseTelemetry struct {
@@ -62,9 +62,9 @@ type HTTPServer struct {
 // If the primary server name is not known, server should be an empty string.
 // The req Host will be used to determine the server instead.
 func (s HTTPServer) RequestTraceAttrs(server string, req *http.Request, opts RequestTraceAttrsOpts) []attribute.KeyValue {
-	attrs := CurrentHTTPServer{}.RequestTraceAttrs(server, req, opts)
+	attrs := OldHTTPServer{}.RequestTraceAttrs(server, req, []attribute.KeyValue{})
 	if s.duplicate {
-		return OldHTTPServer{}.RequestTraceAttrs(server, req, attrs)
+		return CurrentHTTPServer{}.RequestTraceAttrs(server, req, opts, attrs)
 	}
 	return attrs
 }
@@ -77,7 +77,7 @@ func (s HTTPServer) NetworkTransportAttr(network string) []attribute.KeyValue {
 		}
 	}
 	return []attribute.KeyValue{
-		CurrentHTTPServer{}.NetworkTransportAttr(network),
+		OldHTTPServer{}.NetworkTransportAttr(network),
 	}
 }
 
@@ -85,9 +85,9 @@ func (s HTTPServer) NetworkTransportAttr(network string) []attribute.KeyValue {
 //
 // If any of the fields in the ResponseTelemetry are not set the attribute will be omitted.
 func (s HTTPServer) ResponseTraceAttrs(resp ResponseTelemetry) []attribute.KeyValue {
-	attrs := CurrentHTTPServer{}.ResponseTraceAttrs(resp)
+	attrs := OldHTTPServer{}.ResponseTraceAttrs(resp, []attribute.KeyValue{})
 	if s.duplicate {
-		return OldHTTPServer{}.ResponseTraceAttrs(resp, attrs)
+		return CurrentHTTPServer{}.ResponseTraceAttrs(resp, attrs)
 	}
 	return attrs
 }
@@ -146,19 +146,7 @@ var (
 )
 
 func (s HTTPServer) RecordMetrics(ctx context.Context, md ServerMetricData) {
-	if s.requestDurationHistogram != nil && s.requestBodySizeHistogram != nil && s.responseBodySizeHistogram != nil {
-		attributes := CurrentHTTPServer{}.MetricAttributes(md.ServerName, md.Req, md.StatusCode, md.AdditionalAttributes)
-		o := metric.WithAttributeSet(attribute.NewSet(attributes...))
-		recordOpts := metricRecordOptionPool.Get().(*[]metric.RecordOption)
-		*recordOpts = append(*recordOpts, o)
-		s.requestBodySizeHistogram.Record(ctx, md.RequestSize, *recordOpts...)
-		s.responseBodySizeHistogram.Record(ctx, md.ResponseSize, *recordOpts...)
-		s.requestDurationHistogram.Record(ctx, md.ElapsedTime/1000.0, o)
-		*recordOpts = (*recordOpts)[:0]
-		metricRecordOptionPool.Put(recordOpts)
-	}
-
-	if s.duplicate && s.requestBytesCounter != nil && s.responseBytesCounter != nil && s.serverLatencyMeasure != nil {
+	if s.requestBytesCounter != nil && s.responseBytesCounter != nil && s.serverLatencyMeasure != nil {
 		attributes := OldHTTPServer{}.MetricAttributes(md.ServerName, md.Req, md.StatusCode, md.AdditionalAttributes)
 		o := metric.WithAttributeSet(attribute.NewSet(attributes...))
 		addOpts := metricAddOptionPool.Get().(*[]metric.AddOption)
@@ -169,6 +157,18 @@ func (s HTTPServer) RecordMetrics(ctx context.Context, md ServerMetricData) {
 		*addOpts = (*addOpts)[:0]
 		metricAddOptionPool.Put(addOpts)
 	}
+
+	if s.duplicate && s.requestDurationHistogram != nil && s.requestBodySizeHistogram != nil && s.responseBodySizeHistogram != nil {
+		attributes := CurrentHTTPServer{}.MetricAttributes(md.ServerName, md.Req, md.StatusCode, md.AdditionalAttributes)
+		o := metric.WithAttributeSet(attribute.NewSet(attributes...))
+		recordOpts := metricRecordOptionPool.Get().(*[]metric.RecordOption)
+		*recordOpts = append(*recordOpts, o)
+		s.requestBodySizeHistogram.Record(ctx, md.RequestSize, *recordOpts...)
+		s.responseBodySizeHistogram.Record(ctx, md.ResponseSize, *recordOpts...)
+		s.requestDurationHistogram.Record(ctx, md.ElapsedTime/1000.0, o)
+		*recordOpts = (*recordOpts)[:0]
+		metricRecordOptionPool.Put(recordOpts)
+	}
 }
 
 func NewHTTPServer(meter metric.Meter) HTTPServer {
@@ -177,9 +177,9 @@ func NewHTTPServer(meter metric.Meter) HTTPServer {
 	server := HTTPServer{
 		duplicate: duplicate,
 	}
-	server.requestBodySizeHistogram, server.responseBodySizeHistogram, server.requestDurationHistogram = CurrentHTTPServer{}.createMeasures(meter)
+	server.requestBytesCounter, server.responseBytesCounter, server.serverLatencyMeasure = OldHTTPServer{}.createMeasures(meter)
 	if duplicate {
-		server.requestBytesCounter, server.responseBytesCounter, server.serverLatencyMeasure = OldHTTPServer{}.createMeasures(meter)
+		server.requestBodySizeHistogram, server.responseBodySizeHistogram, server.requestDurationHistogram = CurrentHTTPServer{}.createMeasures(meter)
 	}
 	return server
 }
@@ -203,9 +203,9 @@ func NewHTTPClient(meter metric.Meter) HTTPClient {
 	client := HTTPClient{
 		duplicate: duplicate,
 	}
-	client.requestBodySize, client.requestDuration = CurrentHTTPClient{}.createMeasures(meter)
+	client.requestBytesCounter, client.responseBytesCounter, client.latencyMeasure = OldHTTPClient{}.createMeasures(meter)
 	if duplicate {
-		client.requestBytesCounter, client.responseBytesCounter, client.latencyMeasure = OldHTTPClient{}.createMeasures(meter)
+		client.requestBodySize, client.requestDuration = CurrentHTTPClient{}.createMeasures(meter)
 	}
 
 	return client
@@ -213,7 +213,7 @@ func NewHTTPClient(meter metric.Meter) HTTPClient {
 
 // RequestTraceAttrs returns attributes for an HTTP request made by a client.
 func (c HTTPClient) RequestTraceAttrs(req *http.Request) []attribute.KeyValue {
-	attrs := CurrentHTTPClient{}.RequestTraceAttrs(req)
+	attrs := CurrentHTTPClient{}.RequestTraceAttrs(req, []attribute.KeyValue{})
 	if c.duplicate {
 		return OldHTTPClient{}.RequestTraceAttrs(req, attrs)
 	}
@@ -222,9 +222,9 @@ func (c HTTPClient) RequestTraceAttrs(req *http.Request) []attribute.KeyValue {
 
 // ResponseTraceAttrs returns metric attributes for an HTTP request made by a client.
 func (c HTTPClient) ResponseTraceAttrs(resp *http.Response) []attribute.KeyValue {
-	attrs := CurrentHTTPClient{}.ResponseTraceAttrs(resp)
+	attrs := OldHTTPClient{}.ResponseTraceAttrs(resp, []attribute.KeyValue{})
 	if c.duplicate {
-		return OldHTTPClient{}.ResponseTraceAttrs(resp, attrs)
+		return CurrentHTTPClient{}.ResponseTraceAttrs(resp, attrs)
 	}
 	return attrs
 }
@@ -259,17 +259,17 @@ func (o MetricOpts) AddOptions() metric.AddOption {
 func (c HTTPClient) MetricOptions(ma MetricAttributes) map[string]MetricOpts {
 	opts := map[string]MetricOpts{}
 
-	attributes := CurrentHTTPClient{}.MetricAttributes(ma.Req, ma.StatusCode, ma.AdditionalAttributes)
+	attributes := OldHTTPClient{}.MetricAttributes(ma.Req, ma.StatusCode, ma.AdditionalAttributes)
 	set := metric.WithAttributeSet(attribute.NewSet(attributes...))
-	opts["new"] = MetricOpts{
+	opts["old"] = MetricOpts{
 		measurement: set,
 		addOptions:  set,
 	}
 
 	if c.duplicate {
-		attributes := OldHTTPClient{}.MetricAttributes(ma.Req, ma.StatusCode, ma.AdditionalAttributes)
+		attributes := CurrentHTTPClient{}.MetricAttributes(ma.Req, ma.StatusCode, ma.AdditionalAttributes)
 		set := metric.WithAttributeSet(attribute.NewSet(attributes...))
-		opts["old"] = MetricOpts{
+		opts["new"] = MetricOpts{
 			measurement: set,
 			addOptions:  set,
 		}
@@ -279,17 +279,17 @@ func (c HTTPClient) MetricOptions(ma MetricAttributes) map[string]MetricOpts {
 }
 
 func (s HTTPClient) RecordMetrics(ctx context.Context, md MetricData, opts map[string]MetricOpts) {
-	if s.requestBodySize == nil || s.requestDuration == nil {
+	if s.requestBytesCounter == nil || s.latencyMeasure == nil {
 		// This will happen if an HTTPClient{} is used instead of NewHTTPClient().
 		return
 	}
 
-	s.requestBodySize.Record(ctx, md.RequestSize, opts["new"].MeasurementOption())
-	s.requestDuration.Record(ctx, md.ElapsedTime/1000, opts["new"].MeasurementOption())
+	s.requestBytesCounter.Add(ctx, md.RequestSize, opts["old"].AddOptions())
+	s.latencyMeasure.Record(ctx, md.ElapsedTime, opts["old"].MeasurementOption())
 
 	if s.duplicate {
-		s.requestBytesCounter.Add(ctx, md.RequestSize, opts["old"].AddOptions())
-		s.latencyMeasure.Record(ctx, md.ElapsedTime, opts["old"].MeasurementOption())
+		s.requestBodySize.Record(ctx, md.RequestSize, opts["new"].MeasurementOption())
+		s.requestDuration.Record(ctx, md.ElapsedTime/1000, opts["new"].MeasurementOption())
 	}
 }
 

--- a/instrumentation/github.com/emicklei/go-restful/otelrestful/internal/semconv/env_test.go
+++ b/instrumentation/github.com/emicklei/go-restful/otelrestful/internal/semconv/env_test.go
@@ -68,7 +68,7 @@ func TestServerNetworkTransportAttr(t *testing.T) {
 			network: "tcp",
 
 			wantAttributes: []attribute.KeyValue{
-				attribute.String("network.transport", "tcp"),
+				attribute.String("net.transport", "ip_tcp"),
 			},
 		},
 		{

--- a/instrumentation/github.com/emicklei/go-restful/otelrestful/internal/semconv/httpconv_test.go
+++ b/instrumentation/github.com/emicklei/go-restful/otelrestful/internal/semconv/httpconv_test.go
@@ -305,7 +305,7 @@ func TestRequestTraceAttrs_HTTPRoute(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/path/abc123", nil)
 			req.Pattern = tt.pattern
 
-			attrs := (CurrentHTTPServer{}).RequestTraceAttrs("", req, RequestTraceAttrsOpts{})
+			attrs := (CurrentHTTPServer{}).RequestTraceAttrs("", req, RequestTraceAttrsOpts{}, []attribute.KeyValue{})
 
 			var gotRoute string
 			for _, attr := range attrs {
@@ -358,7 +358,7 @@ func TestRequestTraceAttrs_ClientIP(t *testing.T) {
 			}
 
 			var found bool
-			for _, attr := range (CurrentHTTPServer{}).RequestTraceAttrs("", req, tt.requestTraceOpts) {
+			for _, attr := range (CurrentHTTPServer{}).RequestTraceAttrs("", req, tt.requestTraceOpts, []attribute.KeyValue{}) {
 				if attr.Key != "client.address" {
 					continue
 				}

--- a/instrumentation/github.com/emicklei/go-restful/otelrestful/test/restful_test.go
+++ b/instrumentation/github.com/emicklei/go-restful/otelrestful/test/restful_test.go
@@ -95,9 +95,9 @@ func TestChildSpanNames(t *testing.T) {
 		t,
 		spans[0],
 		"/user/{id:[0-9]+}",
-		attribute.String("server.address", "foobar"),
-		attribute.Int("http.response.status_code", http.StatusOK),
-		attribute.String("http.request.method", "GET"),
+		attribute.String("net.host.name", "foobar"),
+		attribute.Int("http.status_code", http.StatusOK),
+		attribute.String("http.method", "GET"),
 		attribute.String("http.route", "/user/{id:[0-9]+}"),
 	)
 
@@ -110,9 +110,9 @@ func TestChildSpanNames(t *testing.T) {
 		t,
 		spans[1],
 		"/book/{title}",
-		attribute.String("server.address", "foobar"),
-		attribute.Int("http.response.status_code", http.StatusOK),
-		attribute.String("http.request.method", "GET"),
+		attribute.String("net.host.name", "foobar"),
+		attribute.Int("http.status_code", http.StatusOK),
+		attribute.String("http.method", "GET"),
 		attribute.String("http.route", "/book/{title}"),
 	)
 }

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/internal/semconv/env.go
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/internal/semconv/env.go
@@ -20,7 +20,7 @@ import (
 )
 
 // OTelSemConvStabilityOptIn is an environment variable.
-// That can be set to "http/dup" to keep getting the old HTTP semantic conventions.
+// That can be set to "http/dup" to opt into the new HTTP semantic conventions.
 const OTelSemConvStabilityOptIn = "OTEL_SEMCONV_STABILITY_OPT_IN"
 
 type ResponseTelemetry struct {
@@ -62,9 +62,9 @@ type HTTPServer struct {
 // If the primary server name is not known, server should be an empty string.
 // The req Host will be used to determine the server instead.
 func (s HTTPServer) RequestTraceAttrs(server string, req *http.Request, opts RequestTraceAttrsOpts) []attribute.KeyValue {
-	attrs := CurrentHTTPServer{}.RequestTraceAttrs(server, req, opts)
+	attrs := OldHTTPServer{}.RequestTraceAttrs(server, req, []attribute.KeyValue{})
 	if s.duplicate {
-		return OldHTTPServer{}.RequestTraceAttrs(server, req, attrs)
+		return CurrentHTTPServer{}.RequestTraceAttrs(server, req, opts, attrs)
 	}
 	return attrs
 }
@@ -77,7 +77,7 @@ func (s HTTPServer) NetworkTransportAttr(network string) []attribute.KeyValue {
 		}
 	}
 	return []attribute.KeyValue{
-		CurrentHTTPServer{}.NetworkTransportAttr(network),
+		OldHTTPServer{}.NetworkTransportAttr(network),
 	}
 }
 
@@ -85,9 +85,9 @@ func (s HTTPServer) NetworkTransportAttr(network string) []attribute.KeyValue {
 //
 // If any of the fields in the ResponseTelemetry are not set the attribute will be omitted.
 func (s HTTPServer) ResponseTraceAttrs(resp ResponseTelemetry) []attribute.KeyValue {
-	attrs := CurrentHTTPServer{}.ResponseTraceAttrs(resp)
+	attrs := OldHTTPServer{}.ResponseTraceAttrs(resp, []attribute.KeyValue{})
 	if s.duplicate {
-		return OldHTTPServer{}.ResponseTraceAttrs(resp, attrs)
+		return CurrentHTTPServer{}.ResponseTraceAttrs(resp, attrs)
 	}
 	return attrs
 }
@@ -146,19 +146,7 @@ var (
 )
 
 func (s HTTPServer) RecordMetrics(ctx context.Context, md ServerMetricData) {
-	if s.requestDurationHistogram != nil && s.requestBodySizeHistogram != nil && s.responseBodySizeHistogram != nil {
-		attributes := CurrentHTTPServer{}.MetricAttributes(md.ServerName, md.Req, md.StatusCode, md.AdditionalAttributes)
-		o := metric.WithAttributeSet(attribute.NewSet(attributes...))
-		recordOpts := metricRecordOptionPool.Get().(*[]metric.RecordOption)
-		*recordOpts = append(*recordOpts, o)
-		s.requestBodySizeHistogram.Record(ctx, md.RequestSize, *recordOpts...)
-		s.responseBodySizeHistogram.Record(ctx, md.ResponseSize, *recordOpts...)
-		s.requestDurationHistogram.Record(ctx, md.ElapsedTime/1000.0, o)
-		*recordOpts = (*recordOpts)[:0]
-		metricRecordOptionPool.Put(recordOpts)
-	}
-
-	if s.duplicate && s.requestBytesCounter != nil && s.responseBytesCounter != nil && s.serverLatencyMeasure != nil {
+	if s.requestBytesCounter != nil && s.responseBytesCounter != nil && s.serverLatencyMeasure != nil {
 		attributes := OldHTTPServer{}.MetricAttributes(md.ServerName, md.Req, md.StatusCode, md.AdditionalAttributes)
 		o := metric.WithAttributeSet(attribute.NewSet(attributes...))
 		addOpts := metricAddOptionPool.Get().(*[]metric.AddOption)
@@ -169,6 +157,18 @@ func (s HTTPServer) RecordMetrics(ctx context.Context, md ServerMetricData) {
 		*addOpts = (*addOpts)[:0]
 		metricAddOptionPool.Put(addOpts)
 	}
+
+	if s.duplicate && s.requestDurationHistogram != nil && s.requestBodySizeHistogram != nil && s.responseBodySizeHistogram != nil {
+		attributes := CurrentHTTPServer{}.MetricAttributes(md.ServerName, md.Req, md.StatusCode, md.AdditionalAttributes)
+		o := metric.WithAttributeSet(attribute.NewSet(attributes...))
+		recordOpts := metricRecordOptionPool.Get().(*[]metric.RecordOption)
+		*recordOpts = append(*recordOpts, o)
+		s.requestBodySizeHistogram.Record(ctx, md.RequestSize, *recordOpts...)
+		s.responseBodySizeHistogram.Record(ctx, md.ResponseSize, *recordOpts...)
+		s.requestDurationHistogram.Record(ctx, md.ElapsedTime/1000.0, o)
+		*recordOpts = (*recordOpts)[:0]
+		metricRecordOptionPool.Put(recordOpts)
+	}
 }
 
 func NewHTTPServer(meter metric.Meter) HTTPServer {
@@ -177,9 +177,9 @@ func NewHTTPServer(meter metric.Meter) HTTPServer {
 	server := HTTPServer{
 		duplicate: duplicate,
 	}
-	server.requestBodySizeHistogram, server.responseBodySizeHistogram, server.requestDurationHistogram = CurrentHTTPServer{}.createMeasures(meter)
+	server.requestBytesCounter, server.responseBytesCounter, server.serverLatencyMeasure = OldHTTPServer{}.createMeasures(meter)
 	if duplicate {
-		server.requestBytesCounter, server.responseBytesCounter, server.serverLatencyMeasure = OldHTTPServer{}.createMeasures(meter)
+		server.requestBodySizeHistogram, server.responseBodySizeHistogram, server.requestDurationHistogram = CurrentHTTPServer{}.createMeasures(meter)
 	}
 	return server
 }
@@ -203,9 +203,9 @@ func NewHTTPClient(meter metric.Meter) HTTPClient {
 	client := HTTPClient{
 		duplicate: duplicate,
 	}
-	client.requestBodySize, client.requestDuration = CurrentHTTPClient{}.createMeasures(meter)
+	client.requestBytesCounter, client.responseBytesCounter, client.latencyMeasure = OldHTTPClient{}.createMeasures(meter)
 	if duplicate {
-		client.requestBytesCounter, client.responseBytesCounter, client.latencyMeasure = OldHTTPClient{}.createMeasures(meter)
+		client.requestBodySize, client.requestDuration = CurrentHTTPClient{}.createMeasures(meter)
 	}
 
 	return client
@@ -213,7 +213,7 @@ func NewHTTPClient(meter metric.Meter) HTTPClient {
 
 // RequestTraceAttrs returns attributes for an HTTP request made by a client.
 func (c HTTPClient) RequestTraceAttrs(req *http.Request) []attribute.KeyValue {
-	attrs := CurrentHTTPClient{}.RequestTraceAttrs(req)
+	attrs := CurrentHTTPClient{}.RequestTraceAttrs(req, []attribute.KeyValue{})
 	if c.duplicate {
 		return OldHTTPClient{}.RequestTraceAttrs(req, attrs)
 	}
@@ -222,9 +222,9 @@ func (c HTTPClient) RequestTraceAttrs(req *http.Request) []attribute.KeyValue {
 
 // ResponseTraceAttrs returns metric attributes for an HTTP request made by a client.
 func (c HTTPClient) ResponseTraceAttrs(resp *http.Response) []attribute.KeyValue {
-	attrs := CurrentHTTPClient{}.ResponseTraceAttrs(resp)
+	attrs := OldHTTPClient{}.ResponseTraceAttrs(resp, []attribute.KeyValue{})
 	if c.duplicate {
-		return OldHTTPClient{}.ResponseTraceAttrs(resp, attrs)
+		return CurrentHTTPClient{}.ResponseTraceAttrs(resp, attrs)
 	}
 	return attrs
 }
@@ -259,17 +259,17 @@ func (o MetricOpts) AddOptions() metric.AddOption {
 func (c HTTPClient) MetricOptions(ma MetricAttributes) map[string]MetricOpts {
 	opts := map[string]MetricOpts{}
 
-	attributes := CurrentHTTPClient{}.MetricAttributes(ma.Req, ma.StatusCode, ma.AdditionalAttributes)
+	attributes := OldHTTPClient{}.MetricAttributes(ma.Req, ma.StatusCode, ma.AdditionalAttributes)
 	set := metric.WithAttributeSet(attribute.NewSet(attributes...))
-	opts["new"] = MetricOpts{
+	opts["old"] = MetricOpts{
 		measurement: set,
 		addOptions:  set,
 	}
 
 	if c.duplicate {
-		attributes := OldHTTPClient{}.MetricAttributes(ma.Req, ma.StatusCode, ma.AdditionalAttributes)
+		attributes := CurrentHTTPClient{}.MetricAttributes(ma.Req, ma.StatusCode, ma.AdditionalAttributes)
 		set := metric.WithAttributeSet(attribute.NewSet(attributes...))
-		opts["old"] = MetricOpts{
+		opts["new"] = MetricOpts{
 			measurement: set,
 			addOptions:  set,
 		}
@@ -279,17 +279,17 @@ func (c HTTPClient) MetricOptions(ma MetricAttributes) map[string]MetricOpts {
 }
 
 func (s HTTPClient) RecordMetrics(ctx context.Context, md MetricData, opts map[string]MetricOpts) {
-	if s.requestBodySize == nil || s.requestDuration == nil {
+	if s.requestBytesCounter == nil || s.latencyMeasure == nil {
 		// This will happen if an HTTPClient{} is used instead of NewHTTPClient().
 		return
 	}
 
-	s.requestBodySize.Record(ctx, md.RequestSize, opts["new"].MeasurementOption())
-	s.requestDuration.Record(ctx, md.ElapsedTime/1000, opts["new"].MeasurementOption())
+	s.requestBytesCounter.Add(ctx, md.RequestSize, opts["old"].AddOptions())
+	s.latencyMeasure.Record(ctx, md.ElapsedTime, opts["old"].MeasurementOption())
 
 	if s.duplicate {
-		s.requestBytesCounter.Add(ctx, md.RequestSize, opts["old"].AddOptions())
-		s.latencyMeasure.Record(ctx, md.ElapsedTime, opts["old"].MeasurementOption())
+		s.requestBodySize.Record(ctx, md.RequestSize, opts["new"].MeasurementOption())
+		s.requestDuration.Record(ctx, md.ElapsedTime/1000, opts["new"].MeasurementOption())
 	}
 }
 

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/internal/semconv/env_test.go
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/internal/semconv/env_test.go
@@ -68,7 +68,7 @@ func TestServerNetworkTransportAttr(t *testing.T) {
 			network: "tcp",
 
 			wantAttributes: []attribute.KeyValue{
-				attribute.String("network.transport", "tcp"),
+				attribute.String("net.transport", "ip_tcp"),
 			},
 		},
 		{

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/internal/semconv/httpconv_test.go
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/internal/semconv/httpconv_test.go
@@ -305,7 +305,7 @@ func TestRequestTraceAttrs_HTTPRoute(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/path/abc123", nil)
 			req.Pattern = tt.pattern
 
-			attrs := (CurrentHTTPServer{}).RequestTraceAttrs("", req, RequestTraceAttrsOpts{})
+			attrs := (CurrentHTTPServer{}).RequestTraceAttrs("", req, RequestTraceAttrsOpts{}, []attribute.KeyValue{})
 
 			var gotRoute string
 			for _, attr := range attrs {
@@ -358,7 +358,7 @@ func TestRequestTraceAttrs_ClientIP(t *testing.T) {
 			}
 
 			var found bool
-			for _, attr := range (CurrentHTTPServer{}).RequestTraceAttrs("", req, tt.requestTraceOpts) {
+			for _, attr := range (CurrentHTTPServer{}).RequestTraceAttrs("", req, tt.requestTraceOpts, []attribute.KeyValue{}) {
 				if attr.Key != "client.address" {
 					continue
 				}

--- a/instrumentation/github.com/gorilla/mux/otelmux/internal/semconv/env.go
+++ b/instrumentation/github.com/gorilla/mux/otelmux/internal/semconv/env.go
@@ -20,7 +20,7 @@ import (
 )
 
 // OTelSemConvStabilityOptIn is an environment variable.
-// That can be set to "http/dup" to keep getting the old HTTP semantic conventions.
+// That can be set to "http/dup" to opt into the new HTTP semantic conventions.
 const OTelSemConvStabilityOptIn = "OTEL_SEMCONV_STABILITY_OPT_IN"
 
 type ResponseTelemetry struct {
@@ -62,9 +62,9 @@ type HTTPServer struct {
 // If the primary server name is not known, server should be an empty string.
 // The req Host will be used to determine the server instead.
 func (s HTTPServer) RequestTraceAttrs(server string, req *http.Request, opts RequestTraceAttrsOpts) []attribute.KeyValue {
-	attrs := CurrentHTTPServer{}.RequestTraceAttrs(server, req, opts)
+	attrs := OldHTTPServer{}.RequestTraceAttrs(server, req, []attribute.KeyValue{})
 	if s.duplicate {
-		return OldHTTPServer{}.RequestTraceAttrs(server, req, attrs)
+		return CurrentHTTPServer{}.RequestTraceAttrs(server, req, opts, attrs)
 	}
 	return attrs
 }
@@ -77,7 +77,7 @@ func (s HTTPServer) NetworkTransportAttr(network string) []attribute.KeyValue {
 		}
 	}
 	return []attribute.KeyValue{
-		CurrentHTTPServer{}.NetworkTransportAttr(network),
+		OldHTTPServer{}.NetworkTransportAttr(network),
 	}
 }
 
@@ -85,9 +85,9 @@ func (s HTTPServer) NetworkTransportAttr(network string) []attribute.KeyValue {
 //
 // If any of the fields in the ResponseTelemetry are not set the attribute will be omitted.
 func (s HTTPServer) ResponseTraceAttrs(resp ResponseTelemetry) []attribute.KeyValue {
-	attrs := CurrentHTTPServer{}.ResponseTraceAttrs(resp)
+	attrs := OldHTTPServer{}.ResponseTraceAttrs(resp, []attribute.KeyValue{})
 	if s.duplicate {
-		return OldHTTPServer{}.ResponseTraceAttrs(resp, attrs)
+		return CurrentHTTPServer{}.ResponseTraceAttrs(resp, attrs)
 	}
 	return attrs
 }
@@ -146,19 +146,7 @@ var (
 )
 
 func (s HTTPServer) RecordMetrics(ctx context.Context, md ServerMetricData) {
-	if s.requestDurationHistogram != nil && s.requestBodySizeHistogram != nil && s.responseBodySizeHistogram != nil {
-		attributes := CurrentHTTPServer{}.MetricAttributes(md.ServerName, md.Req, md.StatusCode, md.AdditionalAttributes)
-		o := metric.WithAttributeSet(attribute.NewSet(attributes...))
-		recordOpts := metricRecordOptionPool.Get().(*[]metric.RecordOption)
-		*recordOpts = append(*recordOpts, o)
-		s.requestBodySizeHistogram.Record(ctx, md.RequestSize, *recordOpts...)
-		s.responseBodySizeHistogram.Record(ctx, md.ResponseSize, *recordOpts...)
-		s.requestDurationHistogram.Record(ctx, md.ElapsedTime/1000.0, o)
-		*recordOpts = (*recordOpts)[:0]
-		metricRecordOptionPool.Put(recordOpts)
-	}
-
-	if s.duplicate && s.requestBytesCounter != nil && s.responseBytesCounter != nil && s.serverLatencyMeasure != nil {
+	if s.requestBytesCounter != nil && s.responseBytesCounter != nil && s.serverLatencyMeasure != nil {
 		attributes := OldHTTPServer{}.MetricAttributes(md.ServerName, md.Req, md.StatusCode, md.AdditionalAttributes)
 		o := metric.WithAttributeSet(attribute.NewSet(attributes...))
 		addOpts := metricAddOptionPool.Get().(*[]metric.AddOption)
@@ -169,6 +157,18 @@ func (s HTTPServer) RecordMetrics(ctx context.Context, md ServerMetricData) {
 		*addOpts = (*addOpts)[:0]
 		metricAddOptionPool.Put(addOpts)
 	}
+
+	if s.duplicate && s.requestDurationHistogram != nil && s.requestBodySizeHistogram != nil && s.responseBodySizeHistogram != nil {
+		attributes := CurrentHTTPServer{}.MetricAttributes(md.ServerName, md.Req, md.StatusCode, md.AdditionalAttributes)
+		o := metric.WithAttributeSet(attribute.NewSet(attributes...))
+		recordOpts := metricRecordOptionPool.Get().(*[]metric.RecordOption)
+		*recordOpts = append(*recordOpts, o)
+		s.requestBodySizeHistogram.Record(ctx, md.RequestSize, *recordOpts...)
+		s.responseBodySizeHistogram.Record(ctx, md.ResponseSize, *recordOpts...)
+		s.requestDurationHistogram.Record(ctx, md.ElapsedTime/1000.0, o)
+		*recordOpts = (*recordOpts)[:0]
+		metricRecordOptionPool.Put(recordOpts)
+	}
 }
 
 func NewHTTPServer(meter metric.Meter) HTTPServer {
@@ -177,9 +177,9 @@ func NewHTTPServer(meter metric.Meter) HTTPServer {
 	server := HTTPServer{
 		duplicate: duplicate,
 	}
-	server.requestBodySizeHistogram, server.responseBodySizeHistogram, server.requestDurationHistogram = CurrentHTTPServer{}.createMeasures(meter)
+	server.requestBytesCounter, server.responseBytesCounter, server.serverLatencyMeasure = OldHTTPServer{}.createMeasures(meter)
 	if duplicate {
-		server.requestBytesCounter, server.responseBytesCounter, server.serverLatencyMeasure = OldHTTPServer{}.createMeasures(meter)
+		server.requestBodySizeHistogram, server.responseBodySizeHistogram, server.requestDurationHistogram = CurrentHTTPServer{}.createMeasures(meter)
 	}
 	return server
 }
@@ -203,9 +203,9 @@ func NewHTTPClient(meter metric.Meter) HTTPClient {
 	client := HTTPClient{
 		duplicate: duplicate,
 	}
-	client.requestBodySize, client.requestDuration = CurrentHTTPClient{}.createMeasures(meter)
+	client.requestBytesCounter, client.responseBytesCounter, client.latencyMeasure = OldHTTPClient{}.createMeasures(meter)
 	if duplicate {
-		client.requestBytesCounter, client.responseBytesCounter, client.latencyMeasure = OldHTTPClient{}.createMeasures(meter)
+		client.requestBodySize, client.requestDuration = CurrentHTTPClient{}.createMeasures(meter)
 	}
 
 	return client
@@ -213,7 +213,7 @@ func NewHTTPClient(meter metric.Meter) HTTPClient {
 
 // RequestTraceAttrs returns attributes for an HTTP request made by a client.
 func (c HTTPClient) RequestTraceAttrs(req *http.Request) []attribute.KeyValue {
-	attrs := CurrentHTTPClient{}.RequestTraceAttrs(req)
+	attrs := CurrentHTTPClient{}.RequestTraceAttrs(req, []attribute.KeyValue{})
 	if c.duplicate {
 		return OldHTTPClient{}.RequestTraceAttrs(req, attrs)
 	}
@@ -222,9 +222,9 @@ func (c HTTPClient) RequestTraceAttrs(req *http.Request) []attribute.KeyValue {
 
 // ResponseTraceAttrs returns metric attributes for an HTTP request made by a client.
 func (c HTTPClient) ResponseTraceAttrs(resp *http.Response) []attribute.KeyValue {
-	attrs := CurrentHTTPClient{}.ResponseTraceAttrs(resp)
+	attrs := OldHTTPClient{}.ResponseTraceAttrs(resp, []attribute.KeyValue{})
 	if c.duplicate {
-		return OldHTTPClient{}.ResponseTraceAttrs(resp, attrs)
+		return CurrentHTTPClient{}.ResponseTraceAttrs(resp, attrs)
 	}
 	return attrs
 }
@@ -259,17 +259,17 @@ func (o MetricOpts) AddOptions() metric.AddOption {
 func (c HTTPClient) MetricOptions(ma MetricAttributes) map[string]MetricOpts {
 	opts := map[string]MetricOpts{}
 
-	attributes := CurrentHTTPClient{}.MetricAttributes(ma.Req, ma.StatusCode, ma.AdditionalAttributes)
+	attributes := OldHTTPClient{}.MetricAttributes(ma.Req, ma.StatusCode, ma.AdditionalAttributes)
 	set := metric.WithAttributeSet(attribute.NewSet(attributes...))
-	opts["new"] = MetricOpts{
+	opts["old"] = MetricOpts{
 		measurement: set,
 		addOptions:  set,
 	}
 
 	if c.duplicate {
-		attributes := OldHTTPClient{}.MetricAttributes(ma.Req, ma.StatusCode, ma.AdditionalAttributes)
+		attributes := CurrentHTTPClient{}.MetricAttributes(ma.Req, ma.StatusCode, ma.AdditionalAttributes)
 		set := metric.WithAttributeSet(attribute.NewSet(attributes...))
-		opts["old"] = MetricOpts{
+		opts["new"] = MetricOpts{
 			measurement: set,
 			addOptions:  set,
 		}
@@ -279,17 +279,17 @@ func (c HTTPClient) MetricOptions(ma MetricAttributes) map[string]MetricOpts {
 }
 
 func (s HTTPClient) RecordMetrics(ctx context.Context, md MetricData, opts map[string]MetricOpts) {
-	if s.requestBodySize == nil || s.requestDuration == nil {
+	if s.requestBytesCounter == nil || s.latencyMeasure == nil {
 		// This will happen if an HTTPClient{} is used instead of NewHTTPClient().
 		return
 	}
 
-	s.requestBodySize.Record(ctx, md.RequestSize, opts["new"].MeasurementOption())
-	s.requestDuration.Record(ctx, md.ElapsedTime/1000, opts["new"].MeasurementOption())
+	s.requestBytesCounter.Add(ctx, md.RequestSize, opts["old"].AddOptions())
+	s.latencyMeasure.Record(ctx, md.ElapsedTime, opts["old"].MeasurementOption())
 
 	if s.duplicate {
-		s.requestBytesCounter.Add(ctx, md.RequestSize, opts["old"].AddOptions())
-		s.latencyMeasure.Record(ctx, md.ElapsedTime, opts["old"].MeasurementOption())
+		s.requestBodySize.Record(ctx, md.RequestSize, opts["new"].MeasurementOption())
+		s.requestDuration.Record(ctx, md.ElapsedTime/1000, opts["new"].MeasurementOption())
 	}
 }
 

--- a/instrumentation/github.com/gorilla/mux/otelmux/internal/semconv/env_test.go
+++ b/instrumentation/github.com/gorilla/mux/otelmux/internal/semconv/env_test.go
@@ -68,7 +68,7 @@ func TestServerNetworkTransportAttr(t *testing.T) {
 			network: "tcp",
 
 			wantAttributes: []attribute.KeyValue{
-				attribute.String("network.transport", "tcp"),
+				attribute.String("net.transport", "ip_tcp"),
 			},
 		},
 		{

--- a/instrumentation/github.com/gorilla/mux/otelmux/internal/semconv/httpconv_test.go
+++ b/instrumentation/github.com/gorilla/mux/otelmux/internal/semconv/httpconv_test.go
@@ -305,7 +305,7 @@ func TestRequestTraceAttrs_HTTPRoute(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/path/abc123", nil)
 			req.Pattern = tt.pattern
 
-			attrs := (CurrentHTTPServer{}).RequestTraceAttrs("", req, RequestTraceAttrsOpts{})
+			attrs := (CurrentHTTPServer{}).RequestTraceAttrs("", req, RequestTraceAttrsOpts{}, []attribute.KeyValue{})
 
 			var gotRoute string
 			for _, attr := range attrs {
@@ -358,7 +358,7 @@ func TestRequestTraceAttrs_ClientIP(t *testing.T) {
 			}
 
 			var found bool
-			for _, attr := range (CurrentHTTPServer{}).RequestTraceAttrs("", req, tt.requestTraceOpts) {
+			for _, attr := range (CurrentHTTPServer{}).RequestTraceAttrs("", req, tt.requestTraceOpts, []attribute.KeyValue{}) {
 				if attr.Key != "client.address" {
 					continue
 				}

--- a/instrumentation/github.com/gorilla/mux/otelmux/test/mux_test.go
+++ b/instrumentation/github.com/gorilla/mux/otelmux/test/mux_test.go
@@ -136,9 +136,9 @@ func TestSDKIntegration(t *testing.T) {
 			assertSpan(t, sr.Ended()[0],
 				tt.expected,
 				trace.SpanKindServer,
-				attribute.String("server.address", "foobar"),
-				attribute.Int("http.response.status_code", http.StatusOK),
-				attribute.String("http.request.method", "GET"),
+				attribute.String("net.host.name", "foobar"),
+				attribute.Int("http.status_code", http.StatusOK),
+				attribute.String("http.method", "GET"),
 				attribute.String("http.route", tt.expected),
 			)
 		})
@@ -162,9 +162,9 @@ func TestNotFoundIsNotError(t *testing.T) {
 	assertSpan(t, sr.Ended()[0],
 		"/does/not/exist",
 		trace.SpanKindServer,
-		attribute.String("server.address", "foobar"),
-		attribute.Int("http.response.status_code", http.StatusNotFound),
-		attribute.String("http.request.method", "GET"),
+		attribute.String("net.host.name", "foobar"),
+		attribute.Int("http.status_code", http.StatusNotFound),
+		attribute.String("http.method", "GET"),
 		attribute.String("http.route", "/does/not/exist"),
 	)
 	assert.Equal(t, codes.Unset, sr.Ended()[0].Status().Code)

--- a/instrumentation/net/http/httptrace/otelhttptrace/internal/semconv/env.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/internal/semconv/env.go
@@ -20,7 +20,7 @@ import (
 )
 
 // OTelSemConvStabilityOptIn is an environment variable.
-// That can be set to "http/dup" to keep getting the old HTTP semantic conventions.
+// That can be set to "http/dup" to opt into the new HTTP semantic conventions.
 const OTelSemConvStabilityOptIn = "OTEL_SEMCONV_STABILITY_OPT_IN"
 
 type ResponseTelemetry struct {
@@ -62,9 +62,9 @@ type HTTPServer struct {
 // If the primary server name is not known, server should be an empty string.
 // The req Host will be used to determine the server instead.
 func (s HTTPServer) RequestTraceAttrs(server string, req *http.Request, opts RequestTraceAttrsOpts) []attribute.KeyValue {
-	attrs := CurrentHTTPServer{}.RequestTraceAttrs(server, req, opts)
+	attrs := OldHTTPServer{}.RequestTraceAttrs(server, req, []attribute.KeyValue{})
 	if s.duplicate {
-		return OldHTTPServer{}.RequestTraceAttrs(server, req, attrs)
+		return CurrentHTTPServer{}.RequestTraceAttrs(server, req, opts, attrs)
 	}
 	return attrs
 }
@@ -77,7 +77,7 @@ func (s HTTPServer) NetworkTransportAttr(network string) []attribute.KeyValue {
 		}
 	}
 	return []attribute.KeyValue{
-		CurrentHTTPServer{}.NetworkTransportAttr(network),
+		OldHTTPServer{}.NetworkTransportAttr(network),
 	}
 }
 
@@ -85,9 +85,9 @@ func (s HTTPServer) NetworkTransportAttr(network string) []attribute.KeyValue {
 //
 // If any of the fields in the ResponseTelemetry are not set the attribute will be omitted.
 func (s HTTPServer) ResponseTraceAttrs(resp ResponseTelemetry) []attribute.KeyValue {
-	attrs := CurrentHTTPServer{}.ResponseTraceAttrs(resp)
+	attrs := OldHTTPServer{}.ResponseTraceAttrs(resp, []attribute.KeyValue{})
 	if s.duplicate {
-		return OldHTTPServer{}.ResponseTraceAttrs(resp, attrs)
+		return CurrentHTTPServer{}.ResponseTraceAttrs(resp, attrs)
 	}
 	return attrs
 }
@@ -146,19 +146,7 @@ var (
 )
 
 func (s HTTPServer) RecordMetrics(ctx context.Context, md ServerMetricData) {
-	if s.requestDurationHistogram != nil && s.requestBodySizeHistogram != nil && s.responseBodySizeHistogram != nil {
-		attributes := CurrentHTTPServer{}.MetricAttributes(md.ServerName, md.Req, md.StatusCode, md.AdditionalAttributes)
-		o := metric.WithAttributeSet(attribute.NewSet(attributes...))
-		recordOpts := metricRecordOptionPool.Get().(*[]metric.RecordOption)
-		*recordOpts = append(*recordOpts, o)
-		s.requestBodySizeHistogram.Record(ctx, md.RequestSize, *recordOpts...)
-		s.responseBodySizeHistogram.Record(ctx, md.ResponseSize, *recordOpts...)
-		s.requestDurationHistogram.Record(ctx, md.ElapsedTime/1000.0, o)
-		*recordOpts = (*recordOpts)[:0]
-		metricRecordOptionPool.Put(recordOpts)
-	}
-
-	if s.duplicate && s.requestBytesCounter != nil && s.responseBytesCounter != nil && s.serverLatencyMeasure != nil {
+	if s.requestBytesCounter != nil && s.responseBytesCounter != nil && s.serverLatencyMeasure != nil {
 		attributes := OldHTTPServer{}.MetricAttributes(md.ServerName, md.Req, md.StatusCode, md.AdditionalAttributes)
 		o := metric.WithAttributeSet(attribute.NewSet(attributes...))
 		addOpts := metricAddOptionPool.Get().(*[]metric.AddOption)
@@ -169,6 +157,18 @@ func (s HTTPServer) RecordMetrics(ctx context.Context, md ServerMetricData) {
 		*addOpts = (*addOpts)[:0]
 		metricAddOptionPool.Put(addOpts)
 	}
+
+	if s.duplicate && s.requestDurationHistogram != nil && s.requestBodySizeHistogram != nil && s.responseBodySizeHistogram != nil {
+		attributes := CurrentHTTPServer{}.MetricAttributes(md.ServerName, md.Req, md.StatusCode, md.AdditionalAttributes)
+		o := metric.WithAttributeSet(attribute.NewSet(attributes...))
+		recordOpts := metricRecordOptionPool.Get().(*[]metric.RecordOption)
+		*recordOpts = append(*recordOpts, o)
+		s.requestBodySizeHistogram.Record(ctx, md.RequestSize, *recordOpts...)
+		s.responseBodySizeHistogram.Record(ctx, md.ResponseSize, *recordOpts...)
+		s.requestDurationHistogram.Record(ctx, md.ElapsedTime/1000.0, o)
+		*recordOpts = (*recordOpts)[:0]
+		metricRecordOptionPool.Put(recordOpts)
+	}
 }
 
 func NewHTTPServer(meter metric.Meter) HTTPServer {
@@ -177,9 +177,9 @@ func NewHTTPServer(meter metric.Meter) HTTPServer {
 	server := HTTPServer{
 		duplicate: duplicate,
 	}
-	server.requestBodySizeHistogram, server.responseBodySizeHistogram, server.requestDurationHistogram = CurrentHTTPServer{}.createMeasures(meter)
+	server.requestBytesCounter, server.responseBytesCounter, server.serverLatencyMeasure = OldHTTPServer{}.createMeasures(meter)
 	if duplicate {
-		server.requestBytesCounter, server.responseBytesCounter, server.serverLatencyMeasure = OldHTTPServer{}.createMeasures(meter)
+		server.requestBodySizeHistogram, server.responseBodySizeHistogram, server.requestDurationHistogram = CurrentHTTPServer{}.createMeasures(meter)
 	}
 	return server
 }
@@ -203,9 +203,9 @@ func NewHTTPClient(meter metric.Meter) HTTPClient {
 	client := HTTPClient{
 		duplicate: duplicate,
 	}
-	client.requestBodySize, client.requestDuration = CurrentHTTPClient{}.createMeasures(meter)
+	client.requestBytesCounter, client.responseBytesCounter, client.latencyMeasure = OldHTTPClient{}.createMeasures(meter)
 	if duplicate {
-		client.requestBytesCounter, client.responseBytesCounter, client.latencyMeasure = OldHTTPClient{}.createMeasures(meter)
+		client.requestBodySize, client.requestDuration = CurrentHTTPClient{}.createMeasures(meter)
 	}
 
 	return client
@@ -213,7 +213,7 @@ func NewHTTPClient(meter metric.Meter) HTTPClient {
 
 // RequestTraceAttrs returns attributes for an HTTP request made by a client.
 func (c HTTPClient) RequestTraceAttrs(req *http.Request) []attribute.KeyValue {
-	attrs := CurrentHTTPClient{}.RequestTraceAttrs(req)
+	attrs := CurrentHTTPClient{}.RequestTraceAttrs(req, []attribute.KeyValue{})
 	if c.duplicate {
 		return OldHTTPClient{}.RequestTraceAttrs(req, attrs)
 	}
@@ -222,9 +222,9 @@ func (c HTTPClient) RequestTraceAttrs(req *http.Request) []attribute.KeyValue {
 
 // ResponseTraceAttrs returns metric attributes for an HTTP request made by a client.
 func (c HTTPClient) ResponseTraceAttrs(resp *http.Response) []attribute.KeyValue {
-	attrs := CurrentHTTPClient{}.ResponseTraceAttrs(resp)
+	attrs := OldHTTPClient{}.ResponseTraceAttrs(resp, []attribute.KeyValue{})
 	if c.duplicate {
-		return OldHTTPClient{}.ResponseTraceAttrs(resp, attrs)
+		return CurrentHTTPClient{}.ResponseTraceAttrs(resp, attrs)
 	}
 	return attrs
 }
@@ -259,17 +259,17 @@ func (o MetricOpts) AddOptions() metric.AddOption {
 func (c HTTPClient) MetricOptions(ma MetricAttributes) map[string]MetricOpts {
 	opts := map[string]MetricOpts{}
 
-	attributes := CurrentHTTPClient{}.MetricAttributes(ma.Req, ma.StatusCode, ma.AdditionalAttributes)
+	attributes := OldHTTPClient{}.MetricAttributes(ma.Req, ma.StatusCode, ma.AdditionalAttributes)
 	set := metric.WithAttributeSet(attribute.NewSet(attributes...))
-	opts["new"] = MetricOpts{
+	opts["old"] = MetricOpts{
 		measurement: set,
 		addOptions:  set,
 	}
 
 	if c.duplicate {
-		attributes := OldHTTPClient{}.MetricAttributes(ma.Req, ma.StatusCode, ma.AdditionalAttributes)
+		attributes := CurrentHTTPClient{}.MetricAttributes(ma.Req, ma.StatusCode, ma.AdditionalAttributes)
 		set := metric.WithAttributeSet(attribute.NewSet(attributes...))
-		opts["old"] = MetricOpts{
+		opts["new"] = MetricOpts{
 			measurement: set,
 			addOptions:  set,
 		}
@@ -279,17 +279,17 @@ func (c HTTPClient) MetricOptions(ma MetricAttributes) map[string]MetricOpts {
 }
 
 func (s HTTPClient) RecordMetrics(ctx context.Context, md MetricData, opts map[string]MetricOpts) {
-	if s.requestBodySize == nil || s.requestDuration == nil {
+	if s.requestBytesCounter == nil || s.latencyMeasure == nil {
 		// This will happen if an HTTPClient{} is used instead of NewHTTPClient().
 		return
 	}
 
-	s.requestBodySize.Record(ctx, md.RequestSize, opts["new"].MeasurementOption())
-	s.requestDuration.Record(ctx, md.ElapsedTime/1000, opts["new"].MeasurementOption())
+	s.requestBytesCounter.Add(ctx, md.RequestSize, opts["old"].AddOptions())
+	s.latencyMeasure.Record(ctx, md.ElapsedTime, opts["old"].MeasurementOption())
 
 	if s.duplicate {
-		s.requestBytesCounter.Add(ctx, md.RequestSize, opts["old"].AddOptions())
-		s.latencyMeasure.Record(ctx, md.ElapsedTime, opts["old"].MeasurementOption())
+		s.requestBodySize.Record(ctx, md.RequestSize, opts["new"].MeasurementOption())
+		s.requestDuration.Record(ctx, md.ElapsedTime/1000, opts["new"].MeasurementOption())
 	}
 }
 

--- a/instrumentation/net/http/httptrace/otelhttptrace/internal/semconv/env_test.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/internal/semconv/env_test.go
@@ -68,7 +68,7 @@ func TestServerNetworkTransportAttr(t *testing.T) {
 			network: "tcp",
 
 			wantAttributes: []attribute.KeyValue{
-				attribute.String("network.transport", "tcp"),
+				attribute.String("net.transport", "ip_tcp"),
 			},
 		},
 		{

--- a/instrumentation/net/http/httptrace/otelhttptrace/internal/semconv/httpconv_test.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/internal/semconv/httpconv_test.go
@@ -305,7 +305,7 @@ func TestRequestTraceAttrs_HTTPRoute(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/path/abc123", nil)
 			req.Pattern = tt.pattern
 
-			attrs := (CurrentHTTPServer{}).RequestTraceAttrs("", req, RequestTraceAttrsOpts{})
+			attrs := (CurrentHTTPServer{}).RequestTraceAttrs("", req, RequestTraceAttrsOpts{}, []attribute.KeyValue{})
 
 			var gotRoute string
 			for _, attr := range attrs {
@@ -358,7 +358,7 @@ func TestRequestTraceAttrs_ClientIP(t *testing.T) {
 			}
 
 			var found bool
-			for _, attr := range (CurrentHTTPServer{}).RequestTraceAttrs("", req, tt.requestTraceOpts) {
+			for _, attr := range (CurrentHTTPServer{}).RequestTraceAttrs("", req, tt.requestTraceOpts, []attribute.KeyValue{}) {
 				if attr.Key != "client.address" {
 					continue
 				}

--- a/instrumentation/net/http/otelhttp/internal/semconv/env.go
+++ b/instrumentation/net/http/otelhttp/internal/semconv/env.go
@@ -20,7 +20,7 @@ import (
 )
 
 // OTelSemConvStabilityOptIn is an environment variable.
-// That can be set to "http/dup" to keep getting the old HTTP semantic conventions.
+// That can be set to "http/dup" to opt into the new HTTP semantic conventions.
 const OTelSemConvStabilityOptIn = "OTEL_SEMCONV_STABILITY_OPT_IN"
 
 type ResponseTelemetry struct {
@@ -62,9 +62,9 @@ type HTTPServer struct {
 // If the primary server name is not known, server should be an empty string.
 // The req Host will be used to determine the server instead.
 func (s HTTPServer) RequestTraceAttrs(server string, req *http.Request, opts RequestTraceAttrsOpts) []attribute.KeyValue {
-	attrs := CurrentHTTPServer{}.RequestTraceAttrs(server, req, opts)
+	attrs := OldHTTPServer{}.RequestTraceAttrs(server, req, []attribute.KeyValue{})
 	if s.duplicate {
-		return OldHTTPServer{}.RequestTraceAttrs(server, req, attrs)
+		return CurrentHTTPServer{}.RequestTraceAttrs(server, req, opts, attrs)
 	}
 	return attrs
 }
@@ -77,7 +77,7 @@ func (s HTTPServer) NetworkTransportAttr(network string) []attribute.KeyValue {
 		}
 	}
 	return []attribute.KeyValue{
-		CurrentHTTPServer{}.NetworkTransportAttr(network),
+		OldHTTPServer{}.NetworkTransportAttr(network),
 	}
 }
 
@@ -85,9 +85,9 @@ func (s HTTPServer) NetworkTransportAttr(network string) []attribute.KeyValue {
 //
 // If any of the fields in the ResponseTelemetry are not set the attribute will be omitted.
 func (s HTTPServer) ResponseTraceAttrs(resp ResponseTelemetry) []attribute.KeyValue {
-	attrs := CurrentHTTPServer{}.ResponseTraceAttrs(resp)
+	attrs := OldHTTPServer{}.ResponseTraceAttrs(resp, []attribute.KeyValue{})
 	if s.duplicate {
-		return OldHTTPServer{}.ResponseTraceAttrs(resp, attrs)
+		return CurrentHTTPServer{}.ResponseTraceAttrs(resp, attrs)
 	}
 	return attrs
 }
@@ -146,19 +146,7 @@ var (
 )
 
 func (s HTTPServer) RecordMetrics(ctx context.Context, md ServerMetricData) {
-	if s.requestDurationHistogram != nil && s.requestBodySizeHistogram != nil && s.responseBodySizeHistogram != nil {
-		attributes := CurrentHTTPServer{}.MetricAttributes(md.ServerName, md.Req, md.StatusCode, md.AdditionalAttributes)
-		o := metric.WithAttributeSet(attribute.NewSet(attributes...))
-		recordOpts := metricRecordOptionPool.Get().(*[]metric.RecordOption)
-		*recordOpts = append(*recordOpts, o)
-		s.requestBodySizeHistogram.Record(ctx, md.RequestSize, *recordOpts...)
-		s.responseBodySizeHistogram.Record(ctx, md.ResponseSize, *recordOpts...)
-		s.requestDurationHistogram.Record(ctx, md.ElapsedTime/1000.0, o)
-		*recordOpts = (*recordOpts)[:0]
-		metricRecordOptionPool.Put(recordOpts)
-	}
-
-	if s.duplicate && s.requestBytesCounter != nil && s.responseBytesCounter != nil && s.serverLatencyMeasure != nil {
+	if s.requestBytesCounter != nil && s.responseBytesCounter != nil && s.serverLatencyMeasure != nil {
 		attributes := OldHTTPServer{}.MetricAttributes(md.ServerName, md.Req, md.StatusCode, md.AdditionalAttributes)
 		o := metric.WithAttributeSet(attribute.NewSet(attributes...))
 		addOpts := metricAddOptionPool.Get().(*[]metric.AddOption)
@@ -169,6 +157,18 @@ func (s HTTPServer) RecordMetrics(ctx context.Context, md ServerMetricData) {
 		*addOpts = (*addOpts)[:0]
 		metricAddOptionPool.Put(addOpts)
 	}
+
+	if s.duplicate && s.requestDurationHistogram != nil && s.requestBodySizeHistogram != nil && s.responseBodySizeHistogram != nil {
+		attributes := CurrentHTTPServer{}.MetricAttributes(md.ServerName, md.Req, md.StatusCode, md.AdditionalAttributes)
+		o := metric.WithAttributeSet(attribute.NewSet(attributes...))
+		recordOpts := metricRecordOptionPool.Get().(*[]metric.RecordOption)
+		*recordOpts = append(*recordOpts, o)
+		s.requestBodySizeHistogram.Record(ctx, md.RequestSize, *recordOpts...)
+		s.responseBodySizeHistogram.Record(ctx, md.ResponseSize, *recordOpts...)
+		s.requestDurationHistogram.Record(ctx, md.ElapsedTime/1000.0, o)
+		*recordOpts = (*recordOpts)[:0]
+		metricRecordOptionPool.Put(recordOpts)
+	}
 }
 
 func NewHTTPServer(meter metric.Meter) HTTPServer {
@@ -177,9 +177,9 @@ func NewHTTPServer(meter metric.Meter) HTTPServer {
 	server := HTTPServer{
 		duplicate: duplicate,
 	}
-	server.requestBodySizeHistogram, server.responseBodySizeHistogram, server.requestDurationHistogram = CurrentHTTPServer{}.createMeasures(meter)
+	server.requestBytesCounter, server.responseBytesCounter, server.serverLatencyMeasure = OldHTTPServer{}.createMeasures(meter)
 	if duplicate {
-		server.requestBytesCounter, server.responseBytesCounter, server.serverLatencyMeasure = OldHTTPServer{}.createMeasures(meter)
+		server.requestBodySizeHistogram, server.responseBodySizeHistogram, server.requestDurationHistogram = CurrentHTTPServer{}.createMeasures(meter)
 	}
 	return server
 }
@@ -203,9 +203,9 @@ func NewHTTPClient(meter metric.Meter) HTTPClient {
 	client := HTTPClient{
 		duplicate: duplicate,
 	}
-	client.requestBodySize, client.requestDuration = CurrentHTTPClient{}.createMeasures(meter)
+	client.requestBytesCounter, client.responseBytesCounter, client.latencyMeasure = OldHTTPClient{}.createMeasures(meter)
 	if duplicate {
-		client.requestBytesCounter, client.responseBytesCounter, client.latencyMeasure = OldHTTPClient{}.createMeasures(meter)
+		client.requestBodySize, client.requestDuration = CurrentHTTPClient{}.createMeasures(meter)
 	}
 
 	return client
@@ -213,7 +213,7 @@ func NewHTTPClient(meter metric.Meter) HTTPClient {
 
 // RequestTraceAttrs returns attributes for an HTTP request made by a client.
 func (c HTTPClient) RequestTraceAttrs(req *http.Request) []attribute.KeyValue {
-	attrs := CurrentHTTPClient{}.RequestTraceAttrs(req)
+	attrs := CurrentHTTPClient{}.RequestTraceAttrs(req, []attribute.KeyValue{})
 	if c.duplicate {
 		return OldHTTPClient{}.RequestTraceAttrs(req, attrs)
 	}
@@ -222,9 +222,9 @@ func (c HTTPClient) RequestTraceAttrs(req *http.Request) []attribute.KeyValue {
 
 // ResponseTraceAttrs returns metric attributes for an HTTP request made by a client.
 func (c HTTPClient) ResponseTraceAttrs(resp *http.Response) []attribute.KeyValue {
-	attrs := CurrentHTTPClient{}.ResponseTraceAttrs(resp)
+	attrs := OldHTTPClient{}.ResponseTraceAttrs(resp, []attribute.KeyValue{})
 	if c.duplicate {
-		return OldHTTPClient{}.ResponseTraceAttrs(resp, attrs)
+		return CurrentHTTPClient{}.ResponseTraceAttrs(resp, attrs)
 	}
 	return attrs
 }
@@ -259,17 +259,17 @@ func (o MetricOpts) AddOptions() metric.AddOption {
 func (c HTTPClient) MetricOptions(ma MetricAttributes) map[string]MetricOpts {
 	opts := map[string]MetricOpts{}
 
-	attributes := CurrentHTTPClient{}.MetricAttributes(ma.Req, ma.StatusCode, ma.AdditionalAttributes)
+	attributes := OldHTTPClient{}.MetricAttributes(ma.Req, ma.StatusCode, ma.AdditionalAttributes)
 	set := metric.WithAttributeSet(attribute.NewSet(attributes...))
-	opts["new"] = MetricOpts{
+	opts["old"] = MetricOpts{
 		measurement: set,
 		addOptions:  set,
 	}
 
 	if c.duplicate {
-		attributes := OldHTTPClient{}.MetricAttributes(ma.Req, ma.StatusCode, ma.AdditionalAttributes)
+		attributes := CurrentHTTPClient{}.MetricAttributes(ma.Req, ma.StatusCode, ma.AdditionalAttributes)
 		set := metric.WithAttributeSet(attribute.NewSet(attributes...))
-		opts["old"] = MetricOpts{
+		opts["new"] = MetricOpts{
 			measurement: set,
 			addOptions:  set,
 		}
@@ -279,17 +279,17 @@ func (c HTTPClient) MetricOptions(ma MetricAttributes) map[string]MetricOpts {
 }
 
 func (s HTTPClient) RecordMetrics(ctx context.Context, md MetricData, opts map[string]MetricOpts) {
-	if s.requestBodySize == nil || s.requestDuration == nil {
+	if s.requestBytesCounter == nil || s.latencyMeasure == nil {
 		// This will happen if an HTTPClient{} is used instead of NewHTTPClient().
 		return
 	}
 
-	s.requestBodySize.Record(ctx, md.RequestSize, opts["new"].MeasurementOption())
-	s.requestDuration.Record(ctx, md.ElapsedTime/1000, opts["new"].MeasurementOption())
+	s.requestBytesCounter.Add(ctx, md.RequestSize, opts["old"].AddOptions())
+	s.latencyMeasure.Record(ctx, md.ElapsedTime, opts["old"].MeasurementOption())
 
 	if s.duplicate {
-		s.requestBytesCounter.Add(ctx, md.RequestSize, opts["old"].AddOptions())
-		s.latencyMeasure.Record(ctx, md.ElapsedTime, opts["old"].MeasurementOption())
+		s.requestBodySize.Record(ctx, md.RequestSize, opts["new"].MeasurementOption())
+		s.requestDuration.Record(ctx, md.ElapsedTime/1000, opts["new"].MeasurementOption())
 	}
 }
 

--- a/instrumentation/net/http/otelhttp/internal/semconv/env_test.go
+++ b/instrumentation/net/http/otelhttp/internal/semconv/env_test.go
@@ -68,7 +68,7 @@ func TestServerNetworkTransportAttr(t *testing.T) {
 			network: "tcp",
 
 			wantAttributes: []attribute.KeyValue{
-				attribute.String("network.transport", "tcp"),
+				attribute.String("net.transport", "ip_tcp"),
 			},
 		},
 		{

--- a/instrumentation/net/http/otelhttp/internal/semconv/httpconv_test.go
+++ b/instrumentation/net/http/otelhttp/internal/semconv/httpconv_test.go
@@ -305,7 +305,7 @@ func TestRequestTraceAttrs_HTTPRoute(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/path/abc123", nil)
 			req.Pattern = tt.pattern
 
-			attrs := (CurrentHTTPServer{}).RequestTraceAttrs("", req, RequestTraceAttrsOpts{})
+			attrs := (CurrentHTTPServer{}).RequestTraceAttrs("", req, RequestTraceAttrsOpts{}, []attribute.KeyValue{})
 
 			var gotRoute string
 			for _, attr := range attrs {
@@ -358,7 +358,7 @@ func TestRequestTraceAttrs_ClientIP(t *testing.T) {
 			}
 
 			var found bool
-			for _, attr := range (CurrentHTTPServer{}).RequestTraceAttrs("", req, tt.requestTraceOpts) {
+			for _, attr := range (CurrentHTTPServer{}).RequestTraceAttrs("", req, tt.requestTraceOpts, []attribute.KeyValue{}) {
 				if attr.Key != "client.address" {
 					continue
 				}

--- a/internal/shared/semconv/env.go.tmpl
+++ b/internal/shared/semconv/env.go.tmpl
@@ -20,7 +20,7 @@ import (
 )
 
 // OTelSemConvStabilityOptIn is an environment variable.
-// That can be set to "http/dup" to keep getting the old HTTP semantic conventions.
+// That can be set to "http/dup" to opt into the new HTTP semantic conventions.
 const OTelSemConvStabilityOptIn = "OTEL_SEMCONV_STABILITY_OPT_IN"
 
 type ResponseTelemetry struct {
@@ -62,9 +62,9 @@ type HTTPServer struct {
 // If the primary server name is not known, server should be an empty string.
 // The req Host will be used to determine the server instead.
 func (s HTTPServer) RequestTraceAttrs(server string, req *http.Request, opts RequestTraceAttrsOpts) []attribute.KeyValue {
-	attrs := CurrentHTTPServer{}.RequestTraceAttrs(server, req, opts)
+	attrs := OldHTTPServer{}.RequestTraceAttrs(server, req, []attribute.KeyValue{})
 	if s.duplicate {
-		return OldHTTPServer{}.RequestTraceAttrs(server, req, attrs)
+		return CurrentHTTPServer{}.RequestTraceAttrs(server, req, opts, attrs)
 	}
 	return attrs
 }
@@ -77,7 +77,7 @@ func (s HTTPServer) NetworkTransportAttr(network string) []attribute.KeyValue {
 		}
 	}
 	return []attribute.KeyValue{
-		CurrentHTTPServer{}.NetworkTransportAttr(network),
+		OldHTTPServer{}.NetworkTransportAttr(network),
 	}
 }
 
@@ -85,9 +85,9 @@ func (s HTTPServer) NetworkTransportAttr(network string) []attribute.KeyValue {
 //
 // If any of the fields in the ResponseTelemetry are not set the attribute will be omitted.
 func (s HTTPServer) ResponseTraceAttrs(resp ResponseTelemetry) []attribute.KeyValue {
-	attrs := CurrentHTTPServer{}.ResponseTraceAttrs(resp)
+	attrs := OldHTTPServer{}.ResponseTraceAttrs(resp, []attribute.KeyValue{})
 	if s.duplicate {
-		return OldHTTPServer{}.ResponseTraceAttrs(resp, attrs)
+		return CurrentHTTPServer{}.ResponseTraceAttrs(resp, attrs)
 	}
 	return attrs
 }
@@ -146,19 +146,7 @@ var (
 )
 
 func (s HTTPServer) RecordMetrics(ctx context.Context, md ServerMetricData) {
-	if s.requestDurationHistogram != nil && s.requestBodySizeHistogram != nil && s.responseBodySizeHistogram != nil {
-		attributes := CurrentHTTPServer{}.MetricAttributes(md.ServerName, md.Req, md.StatusCode, md.AdditionalAttributes)
-		o := metric.WithAttributeSet(attribute.NewSet(attributes...))
-		recordOpts := metricRecordOptionPool.Get().(*[]metric.RecordOption)
-		*recordOpts = append(*recordOpts, o)
-		s.requestBodySizeHistogram.Record(ctx, md.RequestSize, *recordOpts...)
-		s.responseBodySizeHistogram.Record(ctx, md.ResponseSize, *recordOpts...)
-		s.requestDurationHistogram.Record(ctx, md.ElapsedTime/1000.0, o)
-		*recordOpts = (*recordOpts)[:0]
-		metricRecordOptionPool.Put(recordOpts)
-	}
-
-	if s.duplicate && s.requestBytesCounter != nil && s.responseBytesCounter != nil && s.serverLatencyMeasure != nil {
+	if s.requestBytesCounter != nil && s.responseBytesCounter != nil && s.serverLatencyMeasure != nil {
 		attributes := OldHTTPServer{}.MetricAttributes(md.ServerName, md.Req, md.StatusCode, md.AdditionalAttributes)
 		o := metric.WithAttributeSet(attribute.NewSet(attributes...))
 		addOpts := metricAddOptionPool.Get().(*[]metric.AddOption)
@@ -169,6 +157,18 @@ func (s HTTPServer) RecordMetrics(ctx context.Context, md ServerMetricData) {
 		*addOpts = (*addOpts)[:0]
 		metricAddOptionPool.Put(addOpts)
 	}
+
+	if s.duplicate && s.requestDurationHistogram != nil && s.requestBodySizeHistogram != nil && s.responseBodySizeHistogram != nil {
+		attributes := CurrentHTTPServer{}.MetricAttributes(md.ServerName, md.Req, md.StatusCode, md.AdditionalAttributes)
+		o := metric.WithAttributeSet(attribute.NewSet(attributes...))
+		recordOpts := metricRecordOptionPool.Get().(*[]metric.RecordOption)
+		*recordOpts = append(*recordOpts, o)
+		s.requestBodySizeHistogram.Record(ctx, md.RequestSize, *recordOpts...)
+		s.responseBodySizeHistogram.Record(ctx, md.ResponseSize, *recordOpts...)
+		s.requestDurationHistogram.Record(ctx, md.ElapsedTime/1000.0, o)
+		*recordOpts = (*recordOpts)[:0]
+		metricRecordOptionPool.Put(recordOpts)
+	}
 }
 
 func NewHTTPServer(meter metric.Meter) HTTPServer {
@@ -177,9 +177,9 @@ func NewHTTPServer(meter metric.Meter) HTTPServer {
 	server := HTTPServer{
 		duplicate: duplicate,
 	}
-	server.requestBodySizeHistogram, server.responseBodySizeHistogram, server.requestDurationHistogram = CurrentHTTPServer{}.createMeasures(meter)
+	server.requestBytesCounter, server.responseBytesCounter, server.serverLatencyMeasure = OldHTTPServer{}.createMeasures(meter)
 	if duplicate {
-		server.requestBytesCounter, server.responseBytesCounter, server.serverLatencyMeasure = OldHTTPServer{}.createMeasures(meter)
+		server.requestBodySizeHistogram, server.responseBodySizeHistogram, server.requestDurationHistogram = CurrentHTTPServer{}.createMeasures(meter)
 	}
 	return server
 }
@@ -203,9 +203,9 @@ func NewHTTPClient(meter metric.Meter) HTTPClient {
 	client := HTTPClient{
 		duplicate: duplicate,
 	}
-	client.requestBodySize, client.requestDuration = CurrentHTTPClient{}.createMeasures(meter)
+	client.requestBytesCounter, client.responseBytesCounter, client.latencyMeasure = OldHTTPClient{}.createMeasures(meter)
 	if duplicate {
-		client.requestBytesCounter, client.responseBytesCounter, client.latencyMeasure = OldHTTPClient{}.createMeasures(meter)
+		client.requestBodySize, client.requestDuration = CurrentHTTPClient{}.createMeasures(meter)
 	}
 
 	return client
@@ -213,7 +213,7 @@ func NewHTTPClient(meter metric.Meter) HTTPClient {
 
 // RequestTraceAttrs returns attributes for an HTTP request made by a client.
 func (c HTTPClient) RequestTraceAttrs(req *http.Request) []attribute.KeyValue {
-	attrs := CurrentHTTPClient{}.RequestTraceAttrs(req)
+	attrs := CurrentHTTPClient{}.RequestTraceAttrs(req, []attribute.KeyValue{})
 	if c.duplicate {
 		return OldHTTPClient{}.RequestTraceAttrs(req, attrs)
 	}
@@ -222,9 +222,9 @@ func (c HTTPClient) RequestTraceAttrs(req *http.Request) []attribute.KeyValue {
 
 // ResponseTraceAttrs returns metric attributes for an HTTP request made by a client.
 func (c HTTPClient) ResponseTraceAttrs(resp *http.Response) []attribute.KeyValue {
-	attrs := CurrentHTTPClient{}.ResponseTraceAttrs(resp)
+	attrs := OldHTTPClient{}.ResponseTraceAttrs(resp, []attribute.KeyValue{})
 	if c.duplicate {
-		return OldHTTPClient{}.ResponseTraceAttrs(resp, attrs)
+		return CurrentHTTPClient{}.ResponseTraceAttrs(resp, attrs)
 	}
 	return attrs
 }
@@ -259,17 +259,17 @@ func (o MetricOpts) AddOptions() metric.AddOption {
 func (c HTTPClient) MetricOptions(ma MetricAttributes) map[string]MetricOpts {
 	opts := map[string]MetricOpts{}
 
-	attributes := CurrentHTTPClient{}.MetricAttributes(ma.Req, ma.StatusCode, ma.AdditionalAttributes)
+	attributes := OldHTTPClient{}.MetricAttributes(ma.Req, ma.StatusCode, ma.AdditionalAttributes)
 	set := metric.WithAttributeSet(attribute.NewSet(attributes...))
-	opts["new"] = MetricOpts{
+	opts["old"] = MetricOpts{
 		measurement: set,
 		addOptions:  set,
 	}
 
 	if c.duplicate {
-		attributes := OldHTTPClient{}.MetricAttributes(ma.Req, ma.StatusCode, ma.AdditionalAttributes)
+		attributes := CurrentHTTPClient{}.MetricAttributes(ma.Req, ma.StatusCode, ma.AdditionalAttributes)
 		set := metric.WithAttributeSet(attribute.NewSet(attributes...))
-		opts["old"] = MetricOpts{
+		opts["new"] = MetricOpts{
 			measurement: set,
 			addOptions:  set,
 		}
@@ -279,17 +279,17 @@ func (c HTTPClient) MetricOptions(ma MetricAttributes) map[string]MetricOpts {
 }
 
 func (s HTTPClient) RecordMetrics(ctx context.Context, md MetricData, opts map[string]MetricOpts) {
-	if s.requestBodySize == nil || s.requestDuration == nil {
+	if s.requestBytesCounter == nil || s.latencyMeasure == nil {
 		// This will happen if an HTTPClient{} is used instead of NewHTTPClient().
 		return
 	}
 
-	s.requestBodySize.Record(ctx, md.RequestSize, opts["new"].MeasurementOption())
-	s.requestDuration.Record(ctx, md.ElapsedTime/1000, opts["new"].MeasurementOption())
+	s.requestBytesCounter.Add(ctx, md.RequestSize, opts["old"].AddOptions())
+	s.latencyMeasure.Record(ctx, md.ElapsedTime, opts["old"].MeasurementOption())
 
 	if s.duplicate {
-		s.requestBytesCounter.Add(ctx, md.RequestSize, opts["old"].AddOptions())
-		s.latencyMeasure.Record(ctx, md.ElapsedTime, opts["old"].MeasurementOption())
+		s.requestBodySize.Record(ctx, md.RequestSize, opts["new"].MeasurementOption())
+		s.requestDuration.Record(ctx, md.ElapsedTime/1000, opts["new"].MeasurementOption())
 	}
 }
 

--- a/internal/shared/semconv/env_test.go.tmpl
+++ b/internal/shared/semconv/env_test.go.tmpl
@@ -68,7 +68,7 @@ func TestServerNetworkTransportAttr(t *testing.T) {
 			network: "tcp",
 
 			wantAttributes: []attribute.KeyValue{
-				attribute.String("network.transport", "tcp"),
+				attribute.String("net.transport", "ip_tcp"),
 			},
 		},
 		{

--- a/internal/shared/semconv/httpconv_test.go.tmpl
+++ b/internal/shared/semconv/httpconv_test.go.tmpl
@@ -305,7 +305,7 @@ func TestRequestTraceAttrs_HTTPRoute(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/path/abc123", nil)
 			req.Pattern = tt.pattern
 
-			attrs := (CurrentHTTPServer{}).RequestTraceAttrs("", req, RequestTraceAttrsOpts{})
+			attrs := (CurrentHTTPServer{}).RequestTraceAttrs("", req, RequestTraceAttrsOpts{}, []attribute.KeyValue{})
 
 			var gotRoute string
 			for _, attr := range attrs {
@@ -358,7 +358,7 @@ func TestRequestTraceAttrs_ClientIP(t *testing.T) {
 			}
 
 			var found bool
-			for _, attr := range (CurrentHTTPServer{}).RequestTraceAttrs("", req, tt.requestTraceOpts) {
+			for _, attr := range (CurrentHTTPServer{}).RequestTraceAttrs("", req, tt.requestTraceOpts, []attribute.KeyValue{}) {
 				if attr.Key != "client.address" {
 					continue
 				}


### PR DESCRIPTION
This reverts #6899, as we've had several bug fixes we needed to bring into the main branch and waiting for an additional release will put less pressure on folks.

See SIG discussions: https://github.com/open-telemetry/opentelemetry-go/issues/6648
Closes https://github.com/open-telemetry/opentelemetry-go-contrib/issues/7269