### PR TITLE
Removed deprecated StreamServerInterceptor func

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Removed
 
+- The `deprecated StreamServerInterceptor function` from `otelgrpc` is removed.
 - The `Minimum` field of the `LogProcessor` in `go.opentelemetry.io/contrib/processors/minsev` is removed.
   Use `NewLogProcessor` to configure this setting. (#6116)
 - The deprecated `go.opentelemetry.io/contrib/instrumentation/gopkg.in/macaron.v1/otelmacaron` package is removed. (#6186)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - The `deprecated StreamServerInterceptor function` from `otelgrpc` is removed.
 
+
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Use `context.Background()` as default context instead of nil in `go.opentelemetry.io/contrib/bridges/otellogr`. (#6527)
 
+### Removed
+
+- The `deprecated StreamServerInterceptor function` from `otelgrpc` is removed.
+
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->
 
@@ -116,7 +120,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Removed
 
-- The `deprecated StreamServerInterceptor function` from `otelgrpc` is removed.
 - The `Minimum` field of the `LogProcessor` in `go.opentelemetry.io/contrib/processors/minsev` is removed.
   Use `NewLogProcessor` to configure this setting. (#6116)
 - The deprecated `go.opentelemetry.io/contrib/instrumentation/gopkg.in/macaron.v1/otelmacaron` package is removed. (#6186)

--- a/instrumentation/google.golang.org/grpc/otelgrpc/benchmark_test.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/benchmark_test.go
@@ -78,14 +78,6 @@ func BenchmarkUnaryServerInterceptor(b *testing.B) {
 	})
 }
 
-func BenchmarkStreamServerInterceptor(b *testing.B) {
-	benchmark(b, nil, []grpc.ServerOption{
-		grpc.StreamInterceptor(otelgrpc.StreamServerInterceptor(
-			otelgrpc.WithTracerProvider(tracerProvider),
-		)),
-	})
-}
-
 func BenchmarkUnaryClientInterceptor(b *testing.B) {
 	benchmark(b, []grpc.DialOption{
 		grpc.WithUnaryInterceptor(otelgrpc.UnaryClientInterceptor(

--- a/instrumentation/google.golang.org/grpc/otelgrpc/interceptor.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/interceptor.go
@@ -390,63 +390,6 @@ func wrapServerStream(ctx context.Context, ss grpc.ServerStream, cfg *config) *s
 	}
 }
 
-// StreamServerInterceptor returns a grpc.StreamServerInterceptor suitable
-// for use in a grpc.NewServer call.
-//
-// Deprecated: Use [NewServerHandler] instead.
-func StreamServerInterceptor(opts ...Option) grpc.StreamServerInterceptor {
-	cfg := newConfig(opts, "server")
-	tracer := cfg.TracerProvider.Tracer(
-		ScopeName,
-		trace.WithInstrumentationVersion(Version()),
-	)
-
-	return func(
-		srv interface{},
-		ss grpc.ServerStream,
-		info *grpc.StreamServerInfo,
-		handler grpc.StreamHandler,
-	) error {
-		ctx := ss.Context()
-		i := &InterceptorInfo{
-			StreamServerInfo: info,
-			Type:             StreamServer,
-		}
-		if cfg.InterceptorFilter != nil && !cfg.InterceptorFilter(i) {
-			return handler(srv, wrapServerStream(ctx, ss, cfg))
-		}
-
-		ctx = extract(ctx, cfg.Propagators)
-		name, attr, _ := telemetryAttributes(info.FullMethod, peerFromCtx(ctx))
-
-		startOpts := append([]trace.SpanStartOption{
-			trace.WithSpanKind(trace.SpanKindServer),
-			trace.WithAttributes(attr...),
-		},
-			cfg.SpanStartOptions...,
-		)
-
-		ctx, span := tracer.Start(
-			trace.ContextWithRemoteSpanContext(ctx, trace.SpanContextFromContext(ctx)),
-			name,
-			startOpts...,
-		)
-		defer span.End()
-
-		err := handler(srv, wrapServerStream(ctx, ss, cfg))
-		if err != nil {
-			s, _ := status.FromError(err)
-			statusCode, msg := serverStatus(s)
-			span.SetStatus(statusCode, msg)
-			span.SetAttributes(statusCodeAttr(s.Code()))
-		} else {
-			span.SetAttributes(statusCodeAttr(grpc_codes.OK))
-		}
-
-		return err
-	}
-}
-
 // telemetryAttributes returns a span name and span and metric attributes from
 // the gRPC method and peer address.
 func telemetryAttributes(fullMethod, peerAddress string) (string, []attribute.KeyValue, []attribute.KeyValue) {


### PR DESCRIPTION
This PR addresses #7107


- [X] Removed the deprecated `UnaryServerInterceptor` function
- [X] Removed the benchmark test
- [X] Removed tests
- [X] Added a changelog entry in the `### Removed` section of the unreleased changelog for the removal
