### PR TITLE
Always set error type and record error in otelhttp transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - Fix data race when writing log entries with `context.Context` fields in `go.opentelemetry.io/contrib/bridges/otelzap`. (#7368)
+- Fix recording errors when the Transport's RoundTrip returns one in `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp`. (#7456)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/instrumentation/net/http/otelhttp/transport.go
+++ b/instrumentation/net/http/otelhttp/transport.go
@@ -130,15 +130,8 @@ func (t *Transport) RoundTrip(r *http.Request) (*http.Response, error) {
 
 	res, err := t.rt.RoundTrip(r)
 	if err != nil {
-		// set error type attribute if the error is part of the predefined
-		// error types.
-		// otherwise, record it as an exception
-		if errType := t.semconv.ErrorType(err); errType.Valid() {
-			span.SetAttributes(errType)
-		} else {
-			span.RecordError(err)
-		}
-
+		span.SetAttributes(t.semconv.ErrorType(err))
+		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		span.End()
 		return res, err


### PR DESCRIPTION
Closes https://github.com/open-telemetry/opentelemetry-go-contrib/issues/7254