### PR TITLE
otellogrus: set `SeverityText` field to logrus hook

### DIFF
--- a/bridges/otellogrus/hook.go
+++ b/bridges/otellogrus/hook.go
@@ -12,8 +12,7 @@
 //
 //   - Time is set as the Timestamp.
 //   - Message is set as the Body using a [log.StringValue].
-//   - Level is transformed and set as the Severity. The SeverityText is not
-//     set.
+//   - Level is transformed and set as the Severity. The SeverityText is also set.
 //   - Fields are transformed and set as the attributes.
 //
 // The Level is transformed to the OpenTelemetry
@@ -178,6 +177,7 @@ func (h *Hook) convertEntry(e *logrus.Entry) log.Record {
 	record.SetTimestamp(e.Time)
 	record.SetBody(log.StringValue(e.Message))
 	record.SetSeverity(convertSeverity(e.Level))
+	record.SetSeverityText(e.Level.String())
 	record.AddAttributes(convertFields(e.Data)...)
 
 	return record

--- a/bridges/otellogrus/hook_test.go
+++ b/bridges/otellogrus/hook_test.go
@@ -167,7 +167,11 @@ func TestHookFire(t *testing.T) {
 
 			want: logtest.Recording{
 				logtest.Scope{Name: name}: {
-					{Severity: log.SeverityFatal4, Body: log.StringValue("")},
+					{
+						Severity:     log.SeverityFatal4,
+						SeverityText: "panic",
+						Body:         log.StringValue(""),
+					},
 				},
 			},
 		},
@@ -178,7 +182,12 @@ func TestHookFire(t *testing.T) {
 			},
 			want: logtest.Recording{
 				logtest.Scope{Name: name}: {
-					{Severity: log.SeverityFatal4, Body: log.StringValue(""), Timestamp: now},
+					{
+						Severity:     log.SeverityFatal4,
+						SeverityText: "panic",
+						Body:         log.StringValue(""),
+						Timestamp:    now,
+					},
 				},
 			},
 		},
@@ -189,7 +198,11 @@ func TestHookFire(t *testing.T) {
 			},
 			want: logtest.Recording{
 				logtest.Scope{Name: name}: {
-					{Severity: log.SeverityFatal4, Body: log.StringValue("")},
+					{
+						Severity:     log.SeverityFatal4,
+						SeverityText: "panic",
+						Body:         log.StringValue(""),
+					},
 				},
 			},
 		},
@@ -200,7 +213,11 @@ func TestHookFire(t *testing.T) {
 			},
 			want: logtest.Recording{
 				logtest.Scope{Name: name}: {
-					{Severity: log.SeverityFatal, Body: log.StringValue("")},
+					{
+						Severity:     log.SeverityFatal,
+						SeverityText: "fatal",
+						Body:         log.StringValue(""),
+					},
 				},
 			},
 		},
@@ -211,7 +228,11 @@ func TestHookFire(t *testing.T) {
 			},
 			want: logtest.Recording{
 				logtest.Scope{Name: name}: {
-					{Severity: log.SeverityError, Body: log.StringValue("")},
+					{
+						Severity:     log.SeverityError,
+						SeverityText: "error",
+						Body:         log.StringValue(""),
+					},
 				},
 			},
 		},
@@ -222,7 +243,11 @@ func TestHookFire(t *testing.T) {
 			},
 			want: logtest.Recording{
 				logtest.Scope{Name: name}: {
-					{Severity: log.SeverityWarn, Body: log.StringValue("")},
+					{
+						Severity:     log.SeverityWarn,
+						SeverityText: "warning",
+						Body:         log.StringValue(""),
+					},
 				},
 			},
 		},
@@ -233,7 +258,11 @@ func TestHookFire(t *testing.T) {
 			},
 			want: logtest.Recording{
 				logtest.Scope{Name: name}: {
-					{Severity: log.SeverityInfo, Body: log.StringValue("")},
+					{
+						Severity:     log.SeverityInfo,
+						SeverityText: "info",
+						Body:         log.StringValue(""),
+					},
 				},
 			},
 		},
@@ -244,7 +273,11 @@ func TestHookFire(t *testing.T) {
 			},
 			want: logtest.Recording{
 				logtest.Scope{Name: name}: {
-					{Severity: log.SeverityDebug, Body: log.StringValue("")},
+					{
+						Severity:     log.SeverityDebug,
+						SeverityText: "debug",
+						Body:         log.StringValue(""),
+					},
 				},
 			},
 		},
@@ -255,7 +288,11 @@ func TestHookFire(t *testing.T) {
 			},
 			want: logtest.Recording{
 				logtest.Scope{Name: name}: {
-					{Severity: log.SeverityTrace, Body: log.StringValue("")},
+					{
+						Severity:     log.SeverityTrace,
+						SeverityText: "trace",
+						Body:         log.StringValue(""),
+					},
 				},
 			},
 		},
@@ -269,7 +306,8 @@ func TestHookFire(t *testing.T) {
 			want: logtest.Recording{
 				logtest.Scope{Name: name}: {
 					{
-						Severity: log.SeverityFatal4,
+						Severity:     log.SeverityFatal4,
+						SeverityText: "panic",
 						Attributes: []log.KeyValue{
 							log.String("hello", "world"),
 						},
@@ -288,7 +326,8 @@ func TestHookFire(t *testing.T) {
 			want: logtest.Recording{
 				logtest.Scope{Name: name}: {
 					{
-						Severity: log.SeverityFatal4,
+						Severity:     log.SeverityFatal4,
+						SeverityText: "panic",
 						Attributes: []log.KeyValue{
 							log.Empty("nil_pointer"),
 						},


### PR DESCRIPTION
The `Severity` field is used to represent the severity of the log, but it does not provide a human-readable representation of the log `level`.
The `SeverityText` [^1] field seems to be intended to provide a human-readable representation of the log level in otel's specification.

This PR is to set the `SeverityText` field based on the [logrus.Level] in the otellogrus hook.

[^1]: [OTEL Spec: Data Model for Logs #SeverityText](https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-severitytext)

[logrus.Level]: https://pkg.go.dev/github.com/sirupsen/logrus#Level