### PR TITLE
otellambda: allow custom attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Add the `WithCustomAttributes` option to `go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda`. (#7556)
+
 - Add the unit `ns` to deprecated runtime metrics `process.runtime.go.gc.pause_total_ns` and `process.runtime.go.gc.pause_ns` in `go.opentelemetry.io/contrib/instrumentation/runtime`. (#7490)
 
 <!-- Released section -->
@@ -20,8 +22,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Add the `WithPublicEndpoint` and `WithPublicEndpointFn` options to `go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc`. (#7407)
-
-- Add the `WithCustomAttributes` option to `go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda`. (#7556)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Add the `WithPublicEndpoint` and `WithPublicEndpointFn` options to `go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc`. (#7407)
 
+- Add the `WithCustomAttributes` option to `go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda`. (#7556)
+
 ### Changed
 
 - `go.opentelemetry.io/contrib/instrumentation/runtime` now produces the new metrics by default. Set `OTEL_GO_X_DEPRECATED_RUNTIME_METRICS=true` environment variable to additionally produce the deprecated metrics. (#7418)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- Add the `WithCustomAttributes` option to `go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda`. (#7556)
+- Add the `WithTraceAttributesFn` option to `go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda`. (#7556)
 
 - Add the unit `ns` to deprecated runtime metrics `process.runtime.go.gc.pause_total_ns` and `process.runtime.go.gc.pause_ns` in `go.opentelemetry.io/contrib/instrumentation/runtime`. (#7490)
 

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/README.md
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/README.md
@@ -61,6 +61,7 @@ func main() {
 | `WithFlusher` | `otellambda.Flusher`  | This instrumentation will call the `ForceFlush` method of its `Flusher` at the end of each invocation. Should you be using asynchronous logic (such as `sddktrace's BatchSpanProcessor`) it is very import for spans to be `ForceFlush`'ed before [Lambda freezes](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-context.html) to avoid data delays. | `Flusher` with noop `ForceFlush`
 | `WithEventToCarrier` | `func(eventJSON []byte) propagation.TextMapCarrier{}` | Function for providing custom logic to support retrieving trace header from different event types that are handled by AWS Lambda (e.g., SQS, CloudWatch, Kinesis, API Gateway) and returning them in a `propagation.TextMapCarrier` which a Propagator can use to extract the trace header into the context. | Function which returns an empty `TextMapCarrier` - new spans will be part of a new Trace and have no parent past Lambda instrumentation span
 | `WithPropagator` | `propagation.Propagator` | The `Propagator` the instrumentation will use to extract trace information into the context. | `otel.GetTextMapPropagator()` |
+| `WithCustomAttributes` | `func(eventJSON []byte) []attribute.KeyValue` | Function to extract custom attributes from different event types (e.g., SQS, CloudWatch, Kinesis, API Gateway, custom event) and return them as a slice of `attribute.KeyValue` to be added to the span. | Function which returns an empty `[]]attribute.KeyValue` (no custom attributes) |
 
 ### Usage With Options Example
 
@@ -76,6 +77,12 @@ func mockEventToCarrier(eventJSON []byte) propagation.TextMapCarrier{
 	var request mockHTTPRequest
 	_ = json.unmarshal(eventJSON, &request)
 	return propagation.HeaderCarrier{someHeaderKey: []string{request.Headers[someHeaderKey]}}
+}
+
+func mockEventAttrExtractor(eventJSON []byte) []attribute.KeyValue {
+	var request mockRequest
+	_ = json.unmarshal(eventJSON, &request)
+	return []attribute.KeyValue{attribute.String("mock.request.type", reflect.TypeOf(request).String())}
 }
 
 type mockPropagator struct{}
@@ -96,6 +103,7 @@ func main() {
 	lambda.Start(otellambda.InstrumentHandler(HandleRequest,
 		                                    otellambda.WithTracerProvider(tp),
 		                                    otellambda.WithFlusher(tp),
+		                                    otellambda.WithCustomAttributes(mockEventAttrExtractor),
 		                                    otellambda.WithEventToCarrier(mockEventToCarrier),
 		                                    otellambda.WithPropagator(mockPropagator{})))
 }

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/README.md
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/README.md
@@ -80,7 +80,7 @@ func mockEventToCarrier(eventJSON []byte) propagation.TextMapCarrier{
 }
 
 func mockEventAttrExtractor(eventJSON []byte) []attribute.KeyValue {
-	var request mockRequest
+	var request mockHTTPRequest
 	_ = json.unmarshal(eventJSON, &request)
 	return []attribute.KeyValue{attribute.String("mock.request.type", reflect.TypeOf(request).String())}
 }

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/README.md
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/README.md
@@ -61,7 +61,7 @@ func main() {
 | `WithFlusher` | `otellambda.Flusher`  | This instrumentation will call the `ForceFlush` method of its `Flusher` at the end of each invocation. Should you be using asynchronous logic (such as `sddktrace's BatchSpanProcessor`) it is very import for spans to be `ForceFlush`'ed before [Lambda freezes](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-context.html) to avoid data delays. | `Flusher` with noop `ForceFlush`
 | `WithEventToCarrier` | `func(eventJSON []byte) propagation.TextMapCarrier{}` | Function for providing custom logic to support retrieving trace header from different event types that are handled by AWS Lambda (e.g., SQS, CloudWatch, Kinesis, API Gateway) and returning them in a `propagation.TextMapCarrier` which a Propagator can use to extract the trace header into the context. | Function which returns an empty `TextMapCarrier` - new spans will be part of a new Trace and have no parent past Lambda instrumentation span
 | `WithPropagator` | `propagation.Propagator` | The `Propagator` the instrumentation will use to extract trace information into the context. | `otel.GetTextMapPropagator()` |
-| `WithCustomAttributes` | `func(eventJSON []byte) []attribute.KeyValue` | Function to extract custom attributes from different event types (e.g., SQS, CloudWatch, Kinesis, API Gateway, custom event) and return them as a slice of `attribute.KeyValue` to be added to the span. | Function which returns an empty `[]]attribute.KeyValue` (no custom attributes) |
+| `WithTraceAttributesFn` | `func(eventJSON []byte) []attribute.KeyValue` | Function to extract custom attributes from different event types (e.g., SQS, CloudWatch, Kinesis, API Gateway, custom event) and return them as a slice of `attribute.KeyValue` to be added to the span. | Function which returns an empty `[]]attribute.KeyValue` (no custom attributes) |
 
 ### Usage With Options Example
 
@@ -103,7 +103,7 @@ func main() {
 	lambda.Start(otellambda.InstrumentHandler(HandleRequest,
 		                                    otellambda.WithTracerProvider(tp),
 		                                    otellambda.WithFlusher(tp),
-		                                    otellambda.WithCustomAttributes(mockEventAttrExtractor),
+		                                    otellambda.WithTraceAttributesFn(mockEventAttrExtractor),
 		                                    otellambda.WithEventToCarrier(mockEventToCarrier),
 		                                    otellambda.WithPropagator(mockPropagator{})))
 }

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/config.go
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/config.go
@@ -130,8 +130,8 @@ func WithPropagator(propagator propagation.TextMapPropagator) Option {
 	})
 }
 
-// WithCustomAttributes configures a function that returns custom attributes.
-func WithCustomAttributes(eventAttrExtractor EventAttrExtractor) Option {
+// WithTraceAttributesFn configures a function that returns custom attributes.
+func WithTraceAttributesFn(eventAttrExtractor EventAttrExtractor) Option {
 	return optionFunc(func(c *config) {
 		c.CustomAttributes = eventAttrExtractor
 	})

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/config.go
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/config.go
@@ -36,7 +36,7 @@ var _ Flusher = &noopFlusher{}
 // trace information is instead stored in the Lambda environment.
 type EventToCarrier func(eventJSON []byte) propagation.TextMapCarrier
 
-// EventAttributesExtractor defines a function that extracts attributes
+// EventAttrExtractor defines a function that extracts attributes
 // from the event JSON to be added to the span created by the instrumentation.
 type EventAttrExtractor func(eventJSON []byte) []attribute.KeyValue
 
@@ -130,7 +130,7 @@ func WithPropagator(propagator propagation.TextMapPropagator) Option {
 	})
 }
 
-// WithCustomAttributes configures a function that returns custom attributes
+// WithCustomAttributes configures a function that returns custom attributes.
 func WithCustomAttributes(eventAttrExtractor EventAttrExtractor) Option {
 	return optionFunc(func(c *config) {
 		c.CustomAttributes = eventAttrExtractor

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/lambda.go
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/lambda.go
@@ -32,10 +32,10 @@ type instrumentor struct {
 
 func newInstrumentor(opts ...Option) instrumentor {
 	cfg := config{
-		TracerProvider: otel.GetTracerProvider(),
-		Flusher:        &noopFlusher{},
-		EventToCarrier: emptyEventToCarrier,
-		Propagator:     otel.GetTextMapPropagator(),
+		TracerProvider:   otel.GetTracerProvider(),
+		Flusher:          &noopFlusher{},
+		EventToCarrier:   emptyEventToCarrier,
+		Propagator:       otel.GetTextMapPropagator(),
 		CustomAttributes: emptyEventAttrExtractor,
 	}
 	for _, opt := range opts {

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/lambda.go
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/lambda.go
@@ -36,6 +36,7 @@ func newInstrumentor(opts ...Option) instrumentor {
 		Flusher:        &noopFlusher{},
 		EventToCarrier: emptyEventToCarrier,
 		Propagator:     otel.GetTextMapPropagator(),
+		CustomAttributes: emptyEventAttrExtractor,
 	}
 	for _, opt := range opts {
 		opt.apply(&cfg)
@@ -58,6 +59,8 @@ func (i *instrumentor) tracingBegin(ctx context.Context, eventJSON []byte) (cont
 	spanName := os.Getenv("AWS_LAMBDA_FUNCTION_NAME")
 
 	var attributes []attribute.KeyValue
+	customAttrs := i.configuration.CustomAttributes(eventJSON)
+	attributes = append(attributes, customAttrs...)
 	lc, ok := lambdacontext.FromContext(ctx)
 	if !ok {
 		errorLogger.Println("failed to load lambda context from context, ensure tracing enabled in Lambda")

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/lambdatest_test.go
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/lambdatest_test.go
@@ -409,14 +409,14 @@ func TestWrapHandlerTracingWithMockPropagator(t *testing.T) {
 	assertStubEqualsIgnoreTime(t, mockPropagatorTestsExpectedSpanStub, stub)
 }
 
-func TestWrapHandlerTracingWithCustomAttributes(t *testing.T) {
+func TestWrapHandlerTracingWithTraceAttributesFn(t *testing.T) {
 	setEnvVars(t)
 	tp, memExporter := initMockTracerProvider()
 
 	// No flusher needed as SimpleSpanProcessor is synchronous
 	wrapped := otellambda.WrapHandler(emptyHandler{},
 		otellambda.WithTracerProvider(tp),
-		otellambda.WithCustomAttributes(mockEventAttrExtractor),
+		otellambda.WithTraceAttributesFn(mockEventAttrExtractor),
 	)
 
 	payload, _ := json.Marshal(mockPropagatorTestsEvent)

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/lambdatest_test.go
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/lambdatest_test.go
@@ -355,6 +355,16 @@ func mockRequestCarrier(eventJSON []byte) propagation.TextMapCarrier {
 	return propagation.HeaderCarrier{mockPropagatorKey: []string{event.Headers[mockPropagatorKey]}}
 }
 
+func mockEventAttrExtractor(eventJSON []byte) []attribute.KeyValue {
+	var event mockRequest
+	err := json.Unmarshal(eventJSON, &event)
+	if err != nil {
+		fmt.Println("event type: ", reflect.TypeOf(event))
+		panic("mockRequestCarrier only supports events of type mockRequest")
+	}
+	return []attribute.KeyValue{attribute.String("mock.request.type", reflect.TypeOf(event).String())}
+}
+
 func TestInstrumentHandlerTracingWithMockPropagator(t *testing.T) {
 	setEnvVars(t)
 	tp, memExporter := initMockTracerProvider()
@@ -397,4 +407,24 @@ func TestWrapHandlerTracingWithMockPropagator(t *testing.T) {
 	assert.Len(t, memExporter.GetSpans(), 1)
 	stub := memExporter.GetSpans()[0]
 	assertStubEqualsIgnoreTime(t, mockPropagatorTestsExpectedSpanStub, stub)
+}
+
+func TestWrapHandlerTracingWithCustomAttributes(t *testing.T) {
+    setEnvVars(t)
+    tp, memExporter := initMockTracerProvider()
+
+    // No flusher needed as SimpleSpanProcessor is synchronous
+    wrapped := otellambda.WrapHandler(emptyHandler{},
+        otellambda.WithTracerProvider(tp),
+        otellambda.WithCustomAttributes(mockEventAttrExtractor),
+    )
+
+    payload, _ := json.Marshal(mockPropagatorTestsEvent)
+    _, err := wrapped.Invoke(mockPropagatorTestsContext, payload)
+    assert.NoError(t, err)
+
+    assert.Len(t, memExporter.GetSpans(), 1)
+    stub := memExporter.GetSpans()[0]
+	expectedAttr := attribute.KeyValue{Key: "mock.request.type", Value: attribute.StringValue(reflect.TypeOf(mockPropagatorTestsEvent).String())}
+    assert.Contains(t, stub.Attributes, expectedAttr, "custom attribute 'mock.request.type' with value 'otellambda_test.mockRequest' not found")
 }

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/lambdatest_test.go
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/lambdatest_test.go
@@ -410,21 +410,21 @@ func TestWrapHandlerTracingWithMockPropagator(t *testing.T) {
 }
 
 func TestWrapHandlerTracingWithCustomAttributes(t *testing.T) {
-    setEnvVars(t)
-    tp, memExporter := initMockTracerProvider()
+	setEnvVars(t)
+	tp, memExporter := initMockTracerProvider()
 
-    // No flusher needed as SimpleSpanProcessor is synchronous
-    wrapped := otellambda.WrapHandler(emptyHandler{},
-        otellambda.WithTracerProvider(tp),
-        otellambda.WithCustomAttributes(mockEventAttrExtractor),
-    )
+	// No flusher needed as SimpleSpanProcessor is synchronous
+	wrapped := otellambda.WrapHandler(emptyHandler{},
+		otellambda.WithTracerProvider(tp),
+		otellambda.WithCustomAttributes(mockEventAttrExtractor),
+	)
 
-    payload, _ := json.Marshal(mockPropagatorTestsEvent)
-    _, err := wrapped.Invoke(mockPropagatorTestsContext, payload)
-    assert.NoError(t, err)
+	payload, _ := json.Marshal(mockPropagatorTestsEvent)
+	_, err := wrapped.Invoke(mockPropagatorTestsContext, payload)
+	assert.NoError(t, err)
 
-    assert.Len(t, memExporter.GetSpans(), 1)
-    stub := memExporter.GetSpans()[0]
+	assert.Len(t, memExporter.GetSpans(), 1)
+	stub := memExporter.GetSpans()[0]
 	expectedAttr := attribute.KeyValue{Key: "mock.request.type", Value: attribute.StringValue(reflect.TypeOf(mockPropagatorTestsEvent).String())}
-    assert.Contains(t, stub.Attributes, expectedAttr, "custom attribute 'mock.request.type' with value 'otellambda_test.mockRequest' not found")
+	assert.Contains(t, stub.Attributes, expectedAttr, "custom attribute 'mock.request.type' with value 'otellambda_test.mockRequest' not found")
 }


### PR DESCRIPTION
This PR introduces a new feature to the AWS Lambda OpenTelemetry Go instrumentation, allowing users to attach custom attributes to spans based on the Lambda event payload. This enhancement provides greater flexibility for enriching traces with application-specific context.

## Changes 
### New Option: WithCustomAttributes

* Added a new option function, WithCustomAttributes, which accepts an EventAttrExtractor (a function that extracts attributes from the event JSON).
* Updated the internal config struct to include a CustomAttributes field.
* The default extractor is a no-op, returning no attributes.
## Instrumentation Logic Update

* During span creation, the configured CustomAttributes extractor is called with the event payload.
* Any attributes returned by the extractor are appended to the span’s attributes.
## Unit Tests

* Added a new test, [TestWrapHandlerTracingWithCustomAttributes](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html), to verify that custom attributes extracted from the event are correctly attached to the span.
* The test uses a mock extractor and asserts that the expected custom attribute is present in the span.