### PR TITLE
Only request code owners for reviews on ready PRs

### DIFF
--- a/.github/workflows/request_codeowners_review.yml
+++ b/.github/workflows/request_codeowners_review.yml
@@ -1,14 +1,17 @@
 name: 'Request reviews from code owners of a PR'
 on:
   pull_request_target:
-    types: [opened, synchronize]
+    types:
+      - opened
+      - synchronize
+      - ready_for_review
 
 jobs:
   request_codeowners_review:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    if: ${{ github.repository_owner == 'open-telemetry' }}
+    if: ${{ github.repository_owner == 'open-telemetry' && github.event.pull_request.draft == false }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
A draft PR is by definition not yet ready for review, and may have further changes that add or remove pings (and we never remove labels and review requests).
So this changes the labels assignement and review requests to only happen for PRs that are ready to be reviewed.

Doing this following a need in the collector: https://github.com/open-telemetry/opentelemetry-collector/pull/13410