### PR TITLE
Updated ECS detector containerID logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - `go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace`
   - `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp`
 
+### Fixed
+
+- Fixed ECS detector failing tests on Ubuntu by updating `getContainerID` method. (#7500)
+
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->
 

--- a/detectors/aws/ecs/ecs.go
+++ b/detectors/aws/ecs/ecs.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"regexp"
 	"runtime"
 	"strings"
 
@@ -35,6 +36,7 @@ var (
 	errCannotParseTaskArn                 = errors.New("cannot parse region and account ID from the Task's ARN: the ARN does not contain at least 6 segments separated by the ':' character")
 	errCannotRetrieveLogsGroupMetadataV4  = errors.New("the ECS Metadata v4 did not return a AwsLogGroup name")
 	errCannotRetrieveLogsStreamMetadataV4 = errors.New("the ECS Metadata v4 did not return a AwsLogStream name")
+	ecsCgroupPathPattern                  = regexp.MustCompile(`/ecs/[^/]+/[a-f0-9]{64}$`)
 )
 
 // Create interface for methods needing to be mocked.
@@ -246,13 +248,7 @@ func (ecsUtils ecsDetectorUtils) getContainerID() (string, error) {
 		// For example, windows; or when running integration tests outside of a container.
 		return "", nil
 	}
-	splitData := strings.Split(strings.TrimSpace(string(fileData)), "\n")
-	for _, str := range splitData {
-		if len(str) > containerIDLength {
-			return str[len(str)-containerIDLength:], nil
-		}
-	}
-	return "", nil
+	return getCgroupContainerID(fileData)
 }
 
 // returns host name reported by the kernel.
@@ -262,4 +258,14 @@ func (ecsUtils ecsDetectorUtils) getContainerName() (string, error) {
 		return "", errCannotReadContainerName
 	}
 	return hostName, nil
+}
+
+func getCgroupContainerID(fileData []byte) (string, error) {
+	splitData := strings.Split(strings.TrimSpace(string(fileData)), "\n")
+	for _, str := range splitData {
+		if ecsCgroupPathPattern.MatchString(str) {
+			return str[len(str)-containerIDLength:], nil
+		}
+	}
+	return "", nil
 }

--- a/detectors/aws/ecs/ecs_test.go
+++ b/detectors/aws/ecs/ecs_test.go
@@ -230,3 +230,34 @@ func TestLogsAttributesAlternatePartition(t *testing.T) {
 	}
 	assert.Equal(t, expectedAttributes, actualAttributes, "logs attributes are incorrect")
 }
+
+func TestCgroupContainerID(t *testing.T) {
+	cgroups := []struct {
+		cgroupPath      string
+		wantContainerID string
+	}{
+		{
+			"10:memory:/ecs/my-task-name/1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+		},
+		{
+			"10:memory:/ecs/api_service_1/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		},
+		{
+			"10:memory:/ecs/my-task-name/12345abc",
+			"",
+		},
+		{
+			"10:memory:/docker/my-task-name/1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			"",
+		},
+	}
+
+	for _, c := range cgroups {
+		t.Run(c.cgroupPath, func(t *testing.T) {
+			containerID, _ := getCgroupContainerID([]byte(c.cgroupPath))
+			assert.Equal(t, c.wantContainerID, containerID)
+		})
+	}
+}


### PR DESCRIPTION
Update the ECS detector to properly extract the containerID from cgroup file.

Resolves #7500

Failing tests in `opentelemetry-go-contrib/detectors/aws/ecs/test/ecs_test.go` were due to incorrect logic pertaining to cgroup paths on valid ecs containers vs other non empty values

Added tests for extracting containerIDs from various cgroup path values