### PR TITLE
Reset appropriate byte-unit histogram bounds for RPC and HTTP instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - `go.opentelemetry.io/contrib/bridges/otellogrus`
   - `go.opentelemetry.io/contrib/bridges/otelslog`
   - `go.opentelemetry.io/contrib/bridges/otelzap`
+- Chang the default By-unit explicit histogram bucket bounds to [0, 50MB) for `google.golang.org/grpc` and `net/http` instrumentation packages. (#7696)
 
 ### Deprecated
 

--- a/instrumentation/github.com/emicklei/go-restful/otelrestful/internal/semconv/env.go
+++ b/instrumentation/github.com/emicklei/go-restful/otelrestful/internal/semconv/env.go
@@ -121,6 +121,9 @@ var (
 			return &[]metric.RecordOption{}
 		},
 	}
+
+	// defaultByteHistogramBounds defines the default By unit explicit bucket bounds: [0, 50MB].
+	defaultByteHistogramBounds = []float64{100_000, 500_000, 1000_000, 1500_000, 2000_000, 2500_000, 3000_000, 3500_000, 4000_000, 8000_000, 10000_000, 2000_0000, 30000_000, 40000_000, 50000_000}
 )
 
 func (s HTTPServer) RecordMetrics(ctx context.Context, md ServerMetricData) {
@@ -150,10 +153,12 @@ func NewHTTPServer(meter metric.Meter) HTTPServer {
 	server := HTTPServer{}
 
 	var err error
-	server.requestBodySizeHistogram, err = httpconv.NewServerRequestBodySize(meter)
+	server.requestBodySizeHistogram, err = httpconv.NewServerRequestBodySize(meter,
+		metric.WithExplicitBucketBoundaries(defaultByteHistogramBounds...))
 	handleErr(err)
 
-	server.responseBodySizeHistogram, err = httpconv.NewServerResponseBodySize(meter)
+	server.responseBodySizeHistogram, err = httpconv.NewServerResponseBodySize(meter,
+		metric.WithExplicitBucketBoundaries(defaultByteHistogramBounds...))
 	handleErr(err)
 
 	server.requestDurationHistogram, err = httpconv.NewServerRequestDuration(
@@ -176,7 +181,8 @@ func NewHTTPClient(meter metric.Meter) HTTPClient {
 	client := HTTPClient{}
 
 	var err error
-	client.requestBodySize, err = httpconv.NewClientRequestBodySize(meter)
+	client.requestBodySize, err = httpconv.NewClientRequestBodySize(meter,
+		metric.WithExplicitBucketBoundaries(defaultByteHistogramBounds...))
 	handleErr(err)
 
 	client.requestDuration, err = httpconv.NewClientRequestDuration(

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/internal/semconv/env.go
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/internal/semconv/env.go
@@ -121,6 +121,9 @@ var (
 			return &[]metric.RecordOption{}
 		},
 	}
+
+	// defaultByteHistogramBounds defines the default By unit explicit bucket bounds: [0, 50MB].
+	defaultByteHistogramBounds = []float64{100_000, 500_000, 1000_000, 1500_000, 2000_000, 2500_000, 3000_000, 3500_000, 4000_000, 8000_000, 10000_000, 2000_0000, 30000_000, 40000_000, 50000_000}
 )
 
 func (s HTTPServer) RecordMetrics(ctx context.Context, md ServerMetricData) {
@@ -150,10 +153,12 @@ func NewHTTPServer(meter metric.Meter) HTTPServer {
 	server := HTTPServer{}
 
 	var err error
-	server.requestBodySizeHistogram, err = httpconv.NewServerRequestBodySize(meter)
+	server.requestBodySizeHistogram, err = httpconv.NewServerRequestBodySize(meter,
+		metric.WithExplicitBucketBoundaries(defaultByteHistogramBounds...))
 	handleErr(err)
 
-	server.responseBodySizeHistogram, err = httpconv.NewServerResponseBodySize(meter)
+	server.responseBodySizeHistogram, err = httpconv.NewServerResponseBodySize(meter,
+		metric.WithExplicitBucketBoundaries(defaultByteHistogramBounds...))
 	handleErr(err)
 
 	server.requestDurationHistogram, err = httpconv.NewServerRequestDuration(
@@ -176,7 +181,8 @@ func NewHTTPClient(meter metric.Meter) HTTPClient {
 	client := HTTPClient{}
 
 	var err error
-	client.requestBodySize, err = httpconv.NewClientRequestBodySize(meter)
+	client.requestBodySize, err = httpconv.NewClientRequestBodySize(meter,
+		metric.WithExplicitBucketBoundaries(defaultByteHistogramBounds...))
 	handleErr(err)
 
 	client.requestDuration, err = httpconv.NewClientRequestDuration(

--- a/instrumentation/github.com/gorilla/mux/otelmux/internal/semconv/env.go
+++ b/instrumentation/github.com/gorilla/mux/otelmux/internal/semconv/env.go
@@ -121,6 +121,9 @@ var (
 			return &[]metric.RecordOption{}
 		},
 	}
+
+	// defaultByteHistogramBounds defines the default By unit explicit bucket bounds: [0, 50MB].
+	defaultByteHistogramBounds = []float64{100_000, 500_000, 1000_000, 1500_000, 2000_000, 2500_000, 3000_000, 3500_000, 4000_000, 8000_000, 10000_000, 2000_0000, 30000_000, 40000_000, 50000_000}
 )
 
 func (s HTTPServer) RecordMetrics(ctx context.Context, md ServerMetricData) {
@@ -150,10 +153,12 @@ func NewHTTPServer(meter metric.Meter) HTTPServer {
 	server := HTTPServer{}
 
 	var err error
-	server.requestBodySizeHistogram, err = httpconv.NewServerRequestBodySize(meter)
+	server.requestBodySizeHistogram, err = httpconv.NewServerRequestBodySize(meter,
+		metric.WithExplicitBucketBoundaries(defaultByteHistogramBounds...))
 	handleErr(err)
 
-	server.responseBodySizeHistogram, err = httpconv.NewServerResponseBodySize(meter)
+	server.responseBodySizeHistogram, err = httpconv.NewServerResponseBodySize(meter,
+		metric.WithExplicitBucketBoundaries(defaultByteHistogramBounds...))
 	handleErr(err)
 
 	server.requestDurationHistogram, err = httpconv.NewServerRequestDuration(
@@ -176,7 +181,8 @@ func NewHTTPClient(meter metric.Meter) HTTPClient {
 	client := HTTPClient{}
 
 	var err error
-	client.requestBodySize, err = httpconv.NewClientRequestBodySize(meter)
+	client.requestBodySize, err = httpconv.NewClientRequestBodySize(meter,
+		metric.WithExplicitBucketBoundaries(defaultByteHistogramBounds...))
 	handleErr(err)
 
 	client.requestDuration, err = httpconv.NewClientRequestDuration(

--- a/instrumentation/github.com/labstack/echo/otelecho/internal/semconv/env.go
+++ b/instrumentation/github.com/labstack/echo/otelecho/internal/semconv/env.go
@@ -121,6 +121,9 @@ var (
 			return &[]metric.RecordOption{}
 		},
 	}
+
+	// defaultByteHistogramBounds defines the default By unit explicit bucket bounds: [0, 50MB].
+	defaultByteHistogramBounds = []float64{100_000, 500_000, 1000_000, 1500_000, 2000_000, 2500_000, 3000_000, 3500_000, 4000_000, 8000_000, 10000_000, 2000_0000, 30000_000, 40000_000, 50000_000}
 )
 
 func (s HTTPServer) RecordMetrics(ctx context.Context, md ServerMetricData) {
@@ -150,10 +153,12 @@ func NewHTTPServer(meter metric.Meter) HTTPServer {
 	server := HTTPServer{}
 
 	var err error
-	server.requestBodySizeHistogram, err = httpconv.NewServerRequestBodySize(meter)
+	server.requestBodySizeHistogram, err = httpconv.NewServerRequestBodySize(meter,
+		metric.WithExplicitBucketBoundaries(defaultByteHistogramBounds...))
 	handleErr(err)
 
-	server.responseBodySizeHistogram, err = httpconv.NewServerResponseBodySize(meter)
+	server.responseBodySizeHistogram, err = httpconv.NewServerResponseBodySize(meter,
+		metric.WithExplicitBucketBoundaries(defaultByteHistogramBounds...))
 	handleErr(err)
 
 	server.requestDurationHistogram, err = httpconv.NewServerRequestDuration(
@@ -176,7 +181,8 @@ func NewHTTPClient(meter metric.Meter) HTTPClient {
 	client := HTTPClient{}
 
 	var err error
-	client.requestBodySize, err = httpconv.NewClientRequestBodySize(meter)
+	client.requestBodySize, err = httpconv.NewClientRequestBodySize(meter,
+		metric.WithExplicitBucketBoundaries(defaultByteHistogramBounds...))
 	handleErr(err)
 
 	client.requestDuration, err = httpconv.NewClientRequestDuration(

--- a/instrumentation/google.golang.org/grpc/otelgrpc/stats_handler.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/stats_handler.go
@@ -44,6 +44,9 @@ type serverHandler struct {
 	outMsg   rpcconv.ServerResponsesPerRPC
 }
 
+// defaultByteHistogramBounds defines the default By unit explicit bucket bounds: [0, 50MB].
+var defaultByteHistogramBounds = []float64{100_000, 500_000, 1000_000, 1500_000, 2000_000, 2500_000, 3000_000, 3500_000, 4000_000, 8000_000, 10000_000, 2000_0000, 30000_000, 40000_000, 50000_000}
+
 // NewServerHandler creates a stats.Handler for a gRPC server.
 func NewServerHandler(opts ...Option) stats.Handler {
 	c := newConfig(opts)
@@ -66,12 +69,12 @@ func NewServerHandler(opts ...Option) stats.Handler {
 		otel.Handle(err)
 	}
 
-	h.inSize, err = rpcconv.NewServerRequestSize(meter)
+	h.inSize, err = rpcconv.NewServerRequestSize(meter, metric.WithExplicitBucketBoundaries(defaultByteHistogramBounds...))
 	if err != nil {
 		otel.Handle(err)
 	}
 
-	h.outSize, err = rpcconv.NewServerResponseSize(meter)
+	h.outSize, err = rpcconv.NewServerResponseSize(meter, metric.WithExplicitBucketBoundaries(defaultByteHistogramBounds...))
 	if err != nil {
 		otel.Handle(err)
 	}

--- a/instrumentation/net/http/httptrace/otelhttptrace/internal/semconv/env.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/internal/semconv/env.go
@@ -121,6 +121,9 @@ var (
 			return &[]metric.RecordOption{}
 		},
 	}
+
+	// defaultByteHistogramBounds defines the default By unit explicit bucket bounds: [0, 50MB].
+	defaultByteHistogramBounds = []float64{100_000, 500_000, 1000_000, 1500_000, 2000_000, 2500_000, 3000_000, 3500_000, 4000_000, 8000_000, 10000_000, 2000_0000, 30000_000, 40000_000, 50000_000}
 )
 
 func (s HTTPServer) RecordMetrics(ctx context.Context, md ServerMetricData) {
@@ -150,10 +153,12 @@ func NewHTTPServer(meter metric.Meter) HTTPServer {
 	server := HTTPServer{}
 
 	var err error
-	server.requestBodySizeHistogram, err = httpconv.NewServerRequestBodySize(meter)
+	server.requestBodySizeHistogram, err = httpconv.NewServerRequestBodySize(meter,
+		metric.WithExplicitBucketBoundaries(defaultByteHistogramBounds...))
 	handleErr(err)
 
-	server.responseBodySizeHistogram, err = httpconv.NewServerResponseBodySize(meter)
+	server.responseBodySizeHistogram, err = httpconv.NewServerResponseBodySize(meter,
+		metric.WithExplicitBucketBoundaries(defaultByteHistogramBounds...))
 	handleErr(err)
 
 	server.requestDurationHistogram, err = httpconv.NewServerRequestDuration(
@@ -176,7 +181,8 @@ func NewHTTPClient(meter metric.Meter) HTTPClient {
 	client := HTTPClient{}
 
 	var err error
-	client.requestBodySize, err = httpconv.NewClientRequestBodySize(meter)
+	client.requestBodySize, err = httpconv.NewClientRequestBodySize(meter,
+		metric.WithExplicitBucketBoundaries(defaultByteHistogramBounds...))
 	handleErr(err)
 
 	client.requestDuration, err = httpconv.NewClientRequestDuration(

--- a/instrumentation/net/http/otelhttp/internal/semconv/env.go
+++ b/instrumentation/net/http/otelhttp/internal/semconv/env.go
@@ -121,6 +121,9 @@ var (
 			return &[]metric.RecordOption{}
 		},
 	}
+
+	// defaultByteHistogramBounds defines the default By unit explicit bucket bounds: [0, 50MB].
+	defaultByteHistogramBounds = []float64{100_000, 500_000, 1000_000, 1500_000, 2000_000, 2500_000, 3000_000, 3500_000, 4000_000, 8000_000, 10000_000, 2000_0000, 30000_000, 40000_000, 50000_000}
 )
 
 func (s HTTPServer) RecordMetrics(ctx context.Context, md ServerMetricData) {
@@ -150,10 +153,12 @@ func NewHTTPServer(meter metric.Meter) HTTPServer {
 	server := HTTPServer{}
 
 	var err error
-	server.requestBodySizeHistogram, err = httpconv.NewServerRequestBodySize(meter)
+	server.requestBodySizeHistogram, err = httpconv.NewServerRequestBodySize(meter,
+		metric.WithExplicitBucketBoundaries(defaultByteHistogramBounds...))
 	handleErr(err)
 
-	server.responseBodySizeHistogram, err = httpconv.NewServerResponseBodySize(meter)
+	server.responseBodySizeHistogram, err = httpconv.NewServerResponseBodySize(meter,
+		metric.WithExplicitBucketBoundaries(defaultByteHistogramBounds...))
 	handleErr(err)
 
 	server.requestDurationHistogram, err = httpconv.NewServerRequestDuration(
@@ -176,7 +181,8 @@ func NewHTTPClient(meter metric.Meter) HTTPClient {
 	client := HTTPClient{}
 
 	var err error
-	client.requestBodySize, err = httpconv.NewClientRequestBodySize(meter)
+	client.requestBodySize, err = httpconv.NewClientRequestBodySize(meter,
+		metric.WithExplicitBucketBoundaries(defaultByteHistogramBounds...))
 	handleErr(err)
 
 	client.requestDuration, err = httpconv.NewClientRequestDuration(

--- a/internal/shared/semconv/env.go.tmpl
+++ b/internal/shared/semconv/env.go.tmpl
@@ -121,6 +121,9 @@ var (
 			return &[]metric.RecordOption{}
 		},
 	}
+
+	// defaultByteHistogramBounds defines the default By unit explicit bucket bounds: [0, 50MB].
+	defaultByteHistogramBounds = []float64{100_000, 500_000, 1000_000, 1500_000, 2000_000, 2500_000, 3000_000, 3500_000, 4000_000, 8000_000, 10000_000, 2000_0000, 30000_000, 40000_000, 50000_000}
 )
 
 func (s HTTPServer) RecordMetrics(ctx context.Context, md ServerMetricData) {
@@ -150,10 +153,12 @@ func NewHTTPServer(meter metric.Meter) HTTPServer {
 	server := HTTPServer{}
 
 	var err error
-	server.requestBodySizeHistogram, err = httpconv.NewServerRequestBodySize(meter)
+    server.requestBodySizeHistogram, err = httpconv.NewServerRequestBodySize(meter,
+        metric.WithExplicitBucketBoundaries(defaultByteHistogramBounds...))
 	handleErr(err)
 
-	server.responseBodySizeHistogram, err = httpconv.NewServerResponseBodySize(meter)
+	server.responseBodySizeHistogram, err = httpconv.NewServerResponseBodySize(meter,
+		metric.WithExplicitBucketBoundaries(defaultByteHistogramBounds...))
 	handleErr(err)
 
 	server.requestDurationHistogram, err = httpconv.NewServerRequestDuration(
@@ -176,7 +181,8 @@ func NewHTTPClient(meter metric.Meter) HTTPClient {
 	client := HTTPClient{}
 
 	var err error
-	client.requestBodySize, err = httpconv.NewClientRequestBodySize(meter)
+	client.requestBodySize, err = httpconv.NewClientRequestBodySize(meter,
+		metric.WithExplicitBucketBoundaries(defaultByteHistogramBounds...))
 	handleErr(err)
 
 	client.requestDuration, err = httpconv.NewClientRequestDuration(


### PR DESCRIPTION
The default  explicit bucket bounds are:
```
[]float64{0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000}
```

It's not suitable for a byte-unit histogram. I reset it: [0, 50MB).