### PR TITLE
Deprecate the go.opentelemetry.io/contrib/detectors/aws/ec2 module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   It is only used by the deprecated interceptor, and is unused by `NewClientHandler` and `NewServerHandler`. (#7601)
 - `Extract` and `Inject` in `go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc` are deprecated.
   These functions were initially exposed in the public API, but are now considered unnecessary. (#7689)
+- The `go.opentelemetry.io/contrib/detectors/aws/ec2` package is deprecated, use `go.opentelemetry.io/contrib/detectors/aws/ec2/v2` instead. (#7725)
 
 ### Removed
 

--- a/detectors/aws/ec2/ec2.go
+++ b/detectors/aws/ec2/ec2.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package ec2 provides a resource detector for EC2 instances.
+//
 // Deprecated: use go.opentelemetry.io/contrib/detectors/aws/ec2/v2 instead.
 package ec2 // import "go.opentelemetry.io/contrib/detectors/aws/ec2"
 

--- a/detectors/aws/ec2/ec2.go
+++ b/detectors/aws/ec2/ec2.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package ec2 provides a resource detector for EC2 instances.
+// Deprecated: use go.opentelemetry.io/contrib/detectors/aws/ec2/v2 instead.
 package ec2 // import "go.opentelemetry.io/contrib/detectors/aws/ec2"
 
 import (

--- a/detectors/aws/ec2/go.mod
+++ b/detectors/aws/ec2/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: use go.opentelemetry.io/contrib/detectors/aws/ec2/v2 instead.
 module go.opentelemetry.io/contrib/detectors/aws/ec2
 
 go 1.23.0


### PR DESCRIPTION
Deprecate the go.opentelemetry.io/contrib/detectors/aws/ec2 module and added changelog.

Resolves https://github.com/open-telemetry/opentelemetry-go-contrib/issues/7684