### PR TITLE
chore: enable rangeValCopy rule from go-critic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,7 +59,6 @@ linters:
         - exitAfterDefer
         - exposedSyncMutex
         - hugeParam
-        - rangeValCopy
         - unnamedResult
         - whyNoLint
       enable-all: true

--- a/propagators/b3/b3_benchmark_test.go
+++ b/propagators/b3/b3_benchmark_test.go
@@ -64,7 +64,8 @@ func BenchmarkInjectB3(b *testing.B) {
 	}
 
 	for _, tg := range testGroup {
-		for _, tt := range tg.tests {
+		for i := range tg.tests {
+			tt := &tg.tests[i]
 			propagator := b3.New(b3.WithInjectEncoding(tt.encoding))
 			traceBenchmark(tg.name+"/"+tt.name, b, func(b *testing.B) {
 				req, _ := http.NewRequest("GET", "http://example.com", http.NoBody)

--- a/propagators/b3/b3_data_test.go
+++ b/propagators/b3/b3_data_test.go
@@ -1023,7 +1023,8 @@ func init() {
 		b3Context,
 	}
 	// Nothing should be set for any header regardless of encoding.
-	for _, t := range injectInvalidHeaderGenerator {
+	for i := range injectInvalidHeaderGenerator {
+		t := &injectInvalidHeaderGenerator[i]
 		injectInvalidHeader = append(
 			injectInvalidHeader,
 			injectTest{

--- a/samplers/probability/consistent/statistical_test.go
+++ b/samplers/probability/consistent/statistical_test.go
@@ -219,8 +219,10 @@ func sampleTrials(t *testing.T, prob float64, degrees testDegrees, upperP pValue
 	var minP, maxP pValue
 
 	counts := map[pValue]int64{}
+	spans := recorder.GetSpans()
 
-	for idx, r := range recorder.GetSpans() {
+	for idx := range spans {
+		r := &spans[idx]
 		ts := r.SpanContext.TraceState()
 		p, _ := parsePR(ts.Get("ot"))
 


### PR DESCRIPTION
#### Description

Enable and fixes more rules from go-critic:

* https://go-critic.com/overview.html#rangevalcopy