### PR TITLE
zpages: deflake TestSpanProcessorFuzzer by aggregating latency samples

### DIFF
--- a/zpages/spanprocessor_test.go
+++ b/zpages/spanprocessor_test.go
@@ -104,11 +104,21 @@ func TestSpanProcessorFuzzer(t *testing.T) {
 
 	assert.Empty(t, zsp.activeSpans("testSpan1"))
 	assert.GreaterOrEqual(t, len(zsp.errorSpans("testSpan1")), 1)
-	assert.GreaterOrEqual(t, len(zsp.spansByLatency("testSpan1", 1)), 1)
+	// Count latency samples across all buckets instead of a single bucket to avoid flakes
+	numLatencySamples1 := 0
+	for i := range defaultBoundaries.numBuckets() {
+		numLatencySamples1 += len(zsp.spansByLatency("testSpan1", i))
+	}
+	assert.GreaterOrEqual(t, numLatencySamples1, 1)
 
 	assert.Empty(t, zsp.activeSpans("testSpan2"))
 	assert.GreaterOrEqual(t, len(zsp.errorSpans("testSpan2")), 1)
-	assert.GreaterOrEqual(t, len(zsp.spansByLatency("testSpan2", 1)), 1)
+	// Count latency samples across all buckets instead of a single bucket to avoid flakes
+	numLatencySamples2 := 0
+	for i := range defaultBoundaries.numBuckets() {
+		numLatencySamples2 += len(zsp.spansByLatency("testSpan2", i))
+	}
+	assert.GreaterOrEqual(t, numLatencySamples2, 1)
 }
 
 func TestSpanProcessorNegativeLatency(t *testing.T) {


### PR DESCRIPTION
## What
- Deflake `TestSpanProcessorFuzzer` by asserting on the aggregate count of latency samples across all buckets for testSpan1 and testSpan2, instead of checking a specific bucket index.
- Test-only change; no production code modified.
- Fixes #7819 

## Why
- Span durations are highly non-deterministic due to scheduling/timing variance. Asserting a particular bucket (e.g., index 1) is brittle and can be empty even when sampling is correct, causing flakes.
  - Rationale for aggregating across all buckets:
    - The fuzzer’s purpose is to stress concurrency and basic sampling behavior (start/end paths, active span cleanup, and that some non-error spans are sampled), not to verify distribution across specific latency buckets.
    - Detailed bucket-boundary behavior should be validated by separate, deterministic tests that control span duration (synthetic start/end times), not by this concurrency fuzzer.