### PR TITLE
fix(otelecho): rename serviceName -> serverName to reflect parsed value

### DIFF
--- a/instrumentation/github.com/labstack/echo/otelecho/echo.go
+++ b/instrumentation/github.com/labstack/echo/otelecho/echo.go
@@ -27,7 +27,7 @@ const (
 )
 
 // Middleware returns echo middleware which will trace incoming requests.
-func Middleware(service string, opts ...Option) echo.MiddlewareFunc {
+func Middleware(serverName string, opts ...Option) echo.MiddlewareFunc {
 	cfg := config{}
 	for _, opt := range opts {
 		opt.apply(&cfg)
@@ -73,7 +73,7 @@ func Middleware(service string, opts ...Option) echo.MiddlewareFunc {
 			ctx := cfg.Propagators.Extract(savedCtx, propagation.HeaderCarrier(request.Header))
 			opts := []oteltrace.SpanStartOption{
 				oteltrace.WithAttributes(
-					semconvSrv.RequestTraceAttrs(service, request, semconv.RequestTraceAttrsOpts{})...,
+					semconvSrv.RequestTraceAttrs(serverName, request, semconv.RequestTraceAttrsOpts{})...,
 				),
 				oteltrace.WithSpanKind(oteltrace.SpanKindServer),
 			}
@@ -117,7 +117,7 @@ func Middleware(service string, opts ...Option) echo.MiddlewareFunc {
 			}
 
 			semconvSrv.RecordMetrics(ctx, semconv.ServerMetricData{
-				ServerName:   service,
+				ServerName:   serverName,
 				ResponseSize: c.Response().Size,
 				MetricAttributes: semconv.MetricAttributes{
 					Req:                  request,


### PR DESCRIPTION
The code in `instrumentation/github.com/labstack/echo/otelecho/internal/semconv/server.go` parses and uses a primary server identifier (host/header/default virtual host and optional port), not an OpenTelemetry `service.name`. Using `serviceName` was misleading and caused confusion between the HTTP server host and the OTEL service semantic attribute.

This change renames the parameter/field to `serverName` (and related symbols) to:
- accurately describe the value being parsed (server host/port),
- avoid accidental conflation with OTEL `service.name`,
- improve readability and maintainability.

No behavioral changes intended