### PR TITLE
otelconf: fix fuzzing test

### DIFF
--- a/otelconf/v0.3.0/fuzz_test.go
+++ b/otelconf/v0.3.0/fuzz_test.go
@@ -23,7 +23,7 @@ func FuzzJSON(f *testing.F) {
 		t.Log("JSON:\n" + string(data))
 
 		var cfg OpenTelemetryConfiguration
-		err := json.Unmarshal(b, &cfg)
+		err := json.Unmarshal(data, &cfg)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
The fix here was pointed out in the PR to add fuzzing to the 1.0.0-rc2 candidate: https://github.com/open-telemetry/opentelemetry-go-contrib/pull/8026/files/d5d3fc2ce91d306ddf4d6d4076da189236ea27b8#r2548353903 by @XSAM 