### PR TITLE
Add DBOperationName attribute to DynamoDB operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The resource created by `go.opentelemetry.io/contrib/otelconf` now includes [default SDK attributes](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/resource#Default). (#8990)
 - Add support for the `aws.eks` resource detector in `go.opentelemetry.io/contrib/otelconf/x`. (#9138)
 - Add `azurecontainerapps` resource detector for Azure Container Apps. (#8939)
+- `db.operation.name` attribute for DynamoDB in default attribute builder. (#8295)
 
 ### Changed
 

--- a/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/dynamodbattributes.go
+++ b/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/dynamodbattributes.go
@@ -19,7 +19,7 @@ func DynamoDBAttributeBuilder(_ context.Context, in middleware.InitializeInput, 
 
 	switch v := in.Parameters.(type) {
 	case *dynamodb.GetItemInput:
-		dynamodbAttributes = append(dynamodbAttributes, semconv.AWSDynamoDBTableNames(*v.TableName))
+		dynamodbAttributes = append(dynamodbAttributes, semconv.AWSDynamoDBTableNames(*v.TableName), semconv.DBOperationName("GetItem"))
 
 		if v.ConsistentRead != nil {
 			dynamodbAttributes = append(dynamodbAttributes, semconv.AWSDynamoDBConsistentRead(*v.ConsistentRead))
@@ -34,17 +34,17 @@ func DynamoDBAttributeBuilder(_ context.Context, in middleware.InitializeInput, 
 		for k := range v.RequestItems {
 			tableNames = append(tableNames, k)
 		}
-		dynamodbAttributes = append(dynamodbAttributes, semconv.AWSDynamoDBTableNames(tableNames...))
+		dynamodbAttributes = append(dynamodbAttributes, semconv.AWSDynamoDBTableNames(tableNames...), semconv.DBOperationName("BatchGetItem"))
 
 	case *dynamodb.BatchWriteItemInput:
 		tableNames := make([]string, 0, len(v.RequestItems))
 		for k := range v.RequestItems {
 			tableNames = append(tableNames, k)
 		}
-		dynamodbAttributes = append(dynamodbAttributes, semconv.AWSDynamoDBTableNames(tableNames...))
+		dynamodbAttributes = append(dynamodbAttributes, semconv.AWSDynamoDBTableNames(tableNames...), semconv.DBOperationName("BatchWriteItem"))
 
 	case *dynamodb.CreateTableInput:
-		dynamodbAttributes = append(dynamodbAttributes, semconv.AWSDynamoDBTableNames(*v.TableName))
+		dynamodbAttributes = append(dynamodbAttributes, semconv.AWSDynamoDBTableNames(*v.TableName), semconv.DBOperationName("CreateTable"))
 
 		if v.GlobalSecondaryIndexes != nil {
 			idx := make([]string, 0, len(v.GlobalSecondaryIndexes))
@@ -72,15 +72,16 @@ func DynamoDBAttributeBuilder(_ context.Context, in middleware.InitializeInput, 
 		}
 
 	case *dynamodb.DeleteItemInput:
-		dynamodbAttributes = append(dynamodbAttributes, semconv.AWSDynamoDBTableNames(*v.TableName))
+		dynamodbAttributes = append(dynamodbAttributes, semconv.AWSDynamoDBTableNames(*v.TableName), semconv.DBOperationName("DeleteItem"))
 
 	case *dynamodb.DeleteTableInput:
-		dynamodbAttributes = append(dynamodbAttributes, semconv.AWSDynamoDBTableNames(*v.TableName))
+		dynamodbAttributes = append(dynamodbAttributes, semconv.AWSDynamoDBTableNames(*v.TableName), semconv.DBOperationName("DeleteTable"))
 
 	case *dynamodb.DescribeTableInput:
-		dynamodbAttributes = append(dynamodbAttributes, semconv.AWSDynamoDBTableNames(*v.TableName))
+		dynamodbAttributes = append(dynamodbAttributes, semconv.AWSDynamoDBTableNames(*v.TableName), semconv.DBOperationName("DescribeTable"))
 
 	case *dynamodb.ListTablesInput:
+		dynamodbAttributes = append(dynamodbAttributes, semconv.DBOperationName("ListTables"))
 		if v.ExclusiveStartTableName != nil {
 			dynamodbAttributes = append(dynamodbAttributes, semconv.AWSDynamoDBExclusiveStartTable(*v.ExclusiveStartTableName))
 		}
@@ -90,10 +91,10 @@ func DynamoDBAttributeBuilder(_ context.Context, in middleware.InitializeInput, 
 		}
 
 	case *dynamodb.PutItemInput:
-		dynamodbAttributes = append(dynamodbAttributes, semconv.AWSDynamoDBTableNames(*v.TableName))
+		dynamodbAttributes = append(dynamodbAttributes, semconv.AWSDynamoDBTableNames(*v.TableName), semconv.DBOperationName("PutItem"))
 
 	case *dynamodb.QueryInput:
-		dynamodbAttributes = append(dynamodbAttributes, semconv.AWSDynamoDBTableNames(*v.TableName))
+		dynamodbAttributes = append(dynamodbAttributes, semconv.AWSDynamoDBTableNames(*v.TableName), semconv.DBOperationName("Query"))
 
 		if v.ConsistentRead != nil {
 			dynamodbAttributes = append(dynamodbAttributes, semconv.AWSDynamoDBConsistentRead(*v.ConsistentRead))
@@ -118,7 +119,7 @@ func DynamoDBAttributeBuilder(_ context.Context, in middleware.InitializeInput, 
 		dynamodbAttributes = append(dynamodbAttributes, semconv.AWSDynamoDBSelect(string(v.Select)))
 
 	case *dynamodb.ScanInput:
-		dynamodbAttributes = append(dynamodbAttributes, semconv.AWSDynamoDBTableNames(*v.TableName))
+		dynamodbAttributes = append(dynamodbAttributes, semconv.AWSDynamoDBTableNames(*v.TableName), semconv.DBOperationName("Scan"))
 
 		if v.ConsistentRead != nil {
 			dynamodbAttributes = append(dynamodbAttributes, semconv.AWSDynamoDBConsistentRead(*v.ConsistentRead))
@@ -147,10 +148,10 @@ func DynamoDBAttributeBuilder(_ context.Context, in middleware.InitializeInput, 
 		}
 
 	case *dynamodb.UpdateItemInput:
-		dynamodbAttributes = append(dynamodbAttributes, semconv.AWSDynamoDBTableNames(*v.TableName))
+		dynamodbAttributes = append(dynamodbAttributes, semconv.AWSDynamoDBTableNames(*v.TableName), semconv.DBOperationName("UpdateItem"))
 
 	case *dynamodb.UpdateTableInput:
-		dynamodbAttributes = append(dynamodbAttributes, semconv.AWSDynamoDBTableNames(*v.TableName))
+		dynamodbAttributes = append(dynamodbAttributes, semconv.AWSDynamoDBTableNames(*v.TableName), semconv.DBOperationName("UpdateTable"))
 
 		if v.AttributeDefinitions != nil {
 			def := make([]string, 0, len(v.AttributeDefinitions))

--- a/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/dynamodbattributestest_test.go
+++ b/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/dynamodbattributestest_test.go
@@ -94,6 +94,8 @@ func TestDynamodbTags(t *testing.T) {
 		assert.Equal(t, trace.SpanKindClient, span.SpanKind())
 		attrs := span.Attributes()
 		assert.Contains(t, attrs, attribute.Int("http.response.status_code", cases.expectedStatusCode))
+		assert.Contains(t, attrs, attribute.String("db.operation.name", "GetItem"))
+		assert.Contains(t, attrs, attribute.String("rpc.service", "DynamoDB"))
 		assert.Contains(t, attrs, attribute.String("aws.region", cases.expectedRegion))
 		assert.Contains(t, attrs, attribute.String("rpc.method", "DynamoDB/GetItem"))
 		assert.Contains(t, attrs, attribute.String("rpc.system.name", "aws-api"))

--- a/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/dynamodbattributestest_test.go
+++ b/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/dynamodbattributestest_test.go
@@ -95,7 +95,6 @@ func TestDynamodbTags(t *testing.T) {
 		attrs := span.Attributes()
 		assert.Contains(t, attrs, attribute.Int("http.response.status_code", cases.expectedStatusCode))
 		assert.Contains(t, attrs, attribute.String("db.operation.name", "GetItem"))
-		assert.Contains(t, attrs, attribute.String("rpc.service", "DynamoDB"))
 		assert.Contains(t, attrs, attribute.String("aws.region", cases.expectedRegion))
 		assert.Contains(t, attrs, attribute.String("rpc.method", "DynamoDB/GetItem"))
 		assert.Contains(t, attrs, attribute.String("rpc.system.name", "aws-api"))


### PR DESCRIPTION
According to the [Semantic Convention for Databases](https://opentelemetry.io/docs/specs/semconv/database/database-spans/), db.operation.name should be included for DynamoDB operations. Currently, this attribute is missing from the default DynamoDBAttributeBuilder.
This implementation adopts an approach equivalent to the JS version of the AWS instrumentation:
https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/packages/instrumentation-aws-sdk/src/services/dynamodb.ts#L76