### PR TITLE
Change otelmux version to constant

### DIFF
--- a/instrumentation/github.com/gorilla/mux/otelmux/mux.go
+++ b/instrumentation/github.com/gorilla/mux/otelmux/mux.go
@@ -38,7 +38,7 @@ func Middleware(service string, opts ...Option) mux.MiddlewareFunc {
 	}
 	tracer := cfg.TracerProvider.Tracer(
 		ScopeName,
-		trace.WithInstrumentationVersion(Version()),
+		trace.WithInstrumentationVersion(Version),
 	)
 	if cfg.Propagators == nil {
 		cfg.Propagators = otel.GetTextMapPropagator()
@@ -51,7 +51,7 @@ func Middleware(service string, opts ...Option) mux.MiddlewareFunc {
 	}
 	meter := cfg.MeterProvider.Meter(
 		ScopeName,
-		metric.WithInstrumentationVersion(Version()),
+		metric.WithInstrumentationVersion(Version),
 	)
 	return func(handler http.Handler) http.Handler {
 		return traceware{

--- a/instrumentation/github.com/gorilla/mux/otelmux/version.go
+++ b/instrumentation/github.com/gorilla/mux/otelmux/version.go
@@ -4,7 +4,6 @@
 package otelmux // import "go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux"
 
 // Version is the current release version of the gorilla/mux instrumentation.
-func Version() string {
-	return "0.64.0"
-	// This string is updated by the pre_release.sh script during release
-}
+const Version = "0.64.0"
+
+// This string is updated by the pre_release.sh script during release

--- a/instrumentation/github.com/gorilla/mux/otelmux/version_test.go
+++ b/instrumentation/github.com/gorilla/mux/otelmux/version_test.go
@@ -19,6 +19,5 @@ var versionRegex = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)
 	`(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
 
 func TestVersionSemver(t *testing.T) {
-	v := otelmux.Version()
-	assert.NotNil(t, versionRegex.FindStringSubmatch(v), "version is not semver: %s", v)
+	assert.NotNil(t, versionRegex.FindStringSubmatch(otelmux.Version), "version is not semver: %s", otelmux.Version)
 }


### PR DESCRIPTION
## Summary
- change otelmux instrumentation version from a function to a string constant
- update usage sites to pass the constant directly to instrumentation options
- adjust version test to read the constant

## Testing
- gofmt -w instrumentation/github.com/gorilla/mux/otelmux/{version.go,mux.go,version_test.go}

Part of #8272.