### PR TITLE
Clarifies what the dice example demonstrates

### DIFF
--- a/examples/dice/README.md
+++ b/examples/dice/README.md
@@ -4,6 +4,10 @@ This is the foundation example for [Getting Started](https://opentelemetry.io/do
 
 Below, you will see instructions on how to run this application, either with or without instrumentation.
 
+## What can you learn from this example?
+
+This example primarily focuses on **Metrics instrumentation** using OpenTelemetry.
+
 ## Usage
 
 The `run.sh` script accepts one argument to determine which example to run:


### PR DESCRIPTION
## Background

Dice example README didn't clearly state what users can learn from this example.
As a result, first-time users may be unsure about the learning focus of the dice example.

## What

This change adds a short description to clarify what this example demonstrates.
