### PR TITLE
Fix AWS SQS semconv attrs

### DIFF
--- a/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/attributes_test.go
+++ b/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/attributes_test.go
@@ -6,6 +6,7 @@ package otelaws
 import (
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	awsMiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/aws/smithy-go/middleware"
@@ -52,15 +53,18 @@ func TestDefaultAttributeBuilderNotSupportedService(t *testing.T) {
 
 func TestDefaultAttributeBuilderOnSupportedService(t *testing.T) {
 	testCtx := awsMiddleware.SetServiceID(t.Context(), sqs.ServiceID)
-	testQueueURL := "test-queue-url"
 
 	attr := DefaultAttributeBuilder(testCtx, middleware.InitializeInput{
 		Parameters: &sqs.SendMessageInput{
-			QueueUrl: &testQueueURL,
+			MessageBody: aws.String(""),
+			QueueUrl:    &queueUrl,
 		},
 	}, middleware.InitializeOutput{})
-	assert.ElementsMatch(t, []attribute.KeyValue{
-		semconv.MessagingSystemAWSSQS,
-		semconv.ServerAddress(testQueueURL),
-	}, attr)
+
+	assert.Contains(t, attr, semconv.AWSSQSQueueURL(queueUrl))
+	assert.Contains(t, attr, semconv.MessagingDestinationName(queueName))
+	assert.Contains(t, attr, semconv.MessagingMessageBodySize(0))
+	assert.Contains(t, attr, semconv.MessagingOperationTypeSend)
+	assert.Contains(t, attr, semconv.MessagingSystemAWSSQS)
+	assert.Contains(t, attr, semconv.ServerAddress(serverAddress))
 }

--- a/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/sqsattributes.go
+++ b/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/sqsattributes.go
@@ -5,6 +5,10 @@ package otelaws // import "go.opentelemetry.io/contrib/instrumentation/github.co
 
 import (
 	"context"
+	"net"
+	"net/url"
+	"strconv"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/aws/smithy-go/middleware"
@@ -18,34 +22,71 @@ func SQSAttributeBuilder(_ context.Context, in middleware.InitializeInput, _ mid
 
 	switch v := in.Parameters.(type) {
 	case *sqs.DeleteMessageBatchInput:
-		sqsAttributes = append(sqsAttributes, semconv.ServerAddress(*v.QueueUrl))
+		sqsAttributes = append(sqsAttributes, semconv.AWSSQSQueueURL(*v.QueueUrl), semconv.MessagingOperationTypeSettle, semconv.MessagingBatchMessageCount(len(v.Entries)))
+		sqsAttributes = append(sqsAttributes, queueUrlAttrs(*v.QueueUrl)...)
 	case *sqs.DeleteMessageInput:
-		sqsAttributes = append(sqsAttributes, semconv.ServerAddress(*v.QueueUrl))
+		sqsAttributes = append(sqsAttributes, semconv.AWSSQSQueueURL(*v.QueueUrl), semconv.MessagingOperationTypeSettle)
+		sqsAttributes = append(sqsAttributes, queueUrlAttrs(*v.QueueUrl)...)
 	case *sqs.DeleteQueueInput:
-		sqsAttributes = append(sqsAttributes, semconv.ServerAddress(*v.QueueUrl))
+		sqsAttributes = append(sqsAttributes, semconv.AWSSQSQueueURL(*v.QueueUrl))
+		sqsAttributes = append(sqsAttributes, queueUrlAttrs(*v.QueueUrl)...)
 	case *sqs.GetQueueAttributesInput:
-		sqsAttributes = append(sqsAttributes, semconv.ServerAddress(*v.QueueUrl))
+		sqsAttributes = append(sqsAttributes, semconv.AWSSQSQueueURL(*v.QueueUrl))
+		sqsAttributes = append(sqsAttributes, queueUrlAttrs(*v.QueueUrl)...)
 	case *sqs.ListDeadLetterSourceQueuesInput:
-		sqsAttributes = append(sqsAttributes, semconv.ServerAddress(*v.QueueUrl))
+		sqsAttributes = append(sqsAttributes, semconv.AWSSQSQueueURL(*v.QueueUrl))
+		sqsAttributes = append(sqsAttributes, queueUrlAttrs(*v.QueueUrl)...)
 	case *sqs.ListQueueTagsInput:
-		sqsAttributes = append(sqsAttributes, semconv.ServerAddress(*v.QueueUrl))
+		sqsAttributes = append(sqsAttributes, semconv.AWSSQSQueueURL(*v.QueueUrl))
+		sqsAttributes = append(sqsAttributes, queueUrlAttrs(*v.QueueUrl)...)
 	case *sqs.PurgeQueueInput:
-		sqsAttributes = append(sqsAttributes, semconv.ServerAddress(*v.QueueUrl))
+		sqsAttributes = append(sqsAttributes, semconv.AWSSQSQueueURL(*v.QueueUrl))
+		sqsAttributes = append(sqsAttributes, queueUrlAttrs(*v.QueueUrl)...)
 	case *sqs.ReceiveMessageInput:
-		sqsAttributes = append(sqsAttributes, semconv.ServerAddress(*v.QueueUrl))
+		sqsAttributes = append(sqsAttributes, semconv.AWSSQSQueueURL(*v.QueueUrl), semconv.MessagingOperationTypeReceive)
+		sqsAttributes = append(sqsAttributes, queueUrlAttrs(*v.QueueUrl)...)
 	case *sqs.RemovePermissionInput:
-		sqsAttributes = append(sqsAttributes, semconv.ServerAddress(*v.QueueUrl))
+		sqsAttributes = append(sqsAttributes, semconv.AWSSQSQueueURL(*v.QueueUrl))
+		sqsAttributes = append(sqsAttributes, queueUrlAttrs(*v.QueueUrl)...)
 	case *sqs.SendMessageBatchInput:
-		sqsAttributes = append(sqsAttributes, semconv.ServerAddress(*v.QueueUrl))
+		sqsAttributes = append(sqsAttributes, semconv.AWSSQSQueueURL(*v.QueueUrl), semconv.MessagingOperationTypeSend, semconv.MessagingBatchMessageCount(len(v.Entries)))
+		sqsAttributes = append(sqsAttributes, queueUrlAttrs(*v.QueueUrl)...)
 	case *sqs.SendMessageInput:
-		sqsAttributes = append(sqsAttributes, semconv.ServerAddress(*v.QueueUrl))
+		sqsAttributes = append(sqsAttributes, semconv.AWSSQSQueueURL(*v.QueueUrl), semconv.MessagingOperationTypeSend, semconv.MessagingMessageBodySize(len(*v.MessageBody)))
+		sqsAttributes = append(sqsAttributes, queueUrlAttrs(*v.QueueUrl)...)
 	case *sqs.SetQueueAttributesInput:
-		sqsAttributes = append(sqsAttributes, semconv.ServerAddress(*v.QueueUrl))
+		sqsAttributes = append(sqsAttributes, semconv.AWSSQSQueueURL(*v.QueueUrl))
+		sqsAttributes = append(sqsAttributes, queueUrlAttrs(*v.QueueUrl)...)
 	case *sqs.TagQueueInput:
-		sqsAttributes = append(sqsAttributes, semconv.ServerAddress(*v.QueueUrl))
+		sqsAttributes = append(sqsAttributes, semconv.AWSSQSQueueURL(*v.QueueUrl))
+		sqsAttributes = append(sqsAttributes, queueUrlAttrs(*v.QueueUrl)...)
 	case *sqs.UntagQueueInput:
-		sqsAttributes = append(sqsAttributes, semconv.ServerAddress(*v.QueueUrl))
+		sqsAttributes = append(sqsAttributes, semconv.AWSSQSQueueURL(*v.QueueUrl))
+		sqsAttributes = append(sqsAttributes, queueUrlAttrs(*v.QueueUrl)...)
 	}
 
 	return sqsAttributes
+}
+
+func queueUrlAttrs(queueUrl string) []attribute.KeyValue {
+	var attrs []attribute.KeyValue
+
+	parts, err := url.Parse(queueUrl)
+	if err != nil {
+		return nil
+	}
+
+	if addr, port, err := net.SplitHostPort(parts.Host); err == nil {
+		if port, err := strconv.Atoi(port); err == nil {
+			attrs = append(attrs, semconv.ServerAddress(addr), semconv.ServerPort(port))
+		}
+	} else {
+		attrs = append(attrs, semconv.ServerAddress(parts.Host))
+	}
+
+	if _, queuename, found := strings.Cut(strings.TrimPrefix(parts.Path, "/"), "/"); found {
+		attrs = append(attrs, semconv.MessagingDestinationName(queuename))
+	}
+
+	return attrs
 }

--- a/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/sqsattributes_test.go
+++ b/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/sqsattributes_test.go
@@ -4,6 +4,7 @@
 package otelaws
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -13,170 +14,227 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
 )
 
+var (
+	serverAddress = "sqs.us-east-1.amazonaws.com"
+	queueName     = "some_queue_name"
+	queueUrl      = fmt.Sprintf("https://%s/000000000000/%s", serverAddress, queueName)
+)
+
 func TestSQSDeleteMessageBatchInput(t *testing.T) {
 	input := middleware.InitializeInput{
 		Parameters: &sqs.DeleteMessageBatchInput{
-			QueueUrl: aws.String("test-queue-url"),
+			QueueUrl: &queueUrl,
 		},
 	}
 
 	attributes := SQSAttributeBuilder(t.Context(), input, middleware.InitializeOutput{})
 
-	assert.Contains(t, attributes, semconv.ServerAddress("test-queue-url"))
+	assert.Contains(t, attributes, semconv.AWSSQSQueueURL(queueUrl))
+	assert.Contains(t, attributes, semconv.MessagingBatchMessageCount(0))
+	assert.Contains(t, attributes, semconv.MessagingDestinationName(queueName))
+	assert.Contains(t, attributes, semconv.MessagingOperationTypeSettle)
+	assert.Contains(t, attributes, semconv.MessagingSystemAWSSQS)
+	assert.Contains(t, attributes, semconv.ServerAddress(serverAddress))
 }
 
 func TestSQSDeleteMessageInput(t *testing.T) {
 	input := middleware.InitializeInput{
 		Parameters: &sqs.DeleteMessageInput{
-			QueueUrl: aws.String("test-queue-url"),
+			QueueUrl: &queueUrl,
 		},
 	}
 
 	attributes := SQSAttributeBuilder(t.Context(), input, middleware.InitializeOutput{})
 
-	assert.Contains(t, attributes, semconv.ServerAddress("test-queue-url"))
+	assert.Contains(t, attributes, semconv.AWSSQSQueueURL(queueUrl))
+	assert.Contains(t, attributes, semconv.MessagingDestinationName(queueName))
+	assert.Contains(t, attributes, semconv.MessagingOperationTypeSettle)
+	assert.Contains(t, attributes, semconv.MessagingSystemAWSSQS)
+	assert.Contains(t, attributes, semconv.ServerAddress(serverAddress))
 }
 
 func TestSQSDeleteQueueInput(t *testing.T) {
 	input := middleware.InitializeInput{
 		Parameters: &sqs.DeleteQueueInput{
-			QueueUrl: aws.String("test-queue-url"),
+			QueueUrl: &queueUrl,
 		},
 	}
 
 	attributes := SQSAttributeBuilder(t.Context(), input, middleware.InitializeOutput{})
 
-	assert.Contains(t, attributes, semconv.ServerAddress("test-queue-url"))
+	assert.Contains(t, attributes, semconv.AWSSQSQueueURL(queueUrl))
+	assert.Contains(t, attributes, semconv.MessagingDestinationName(queueName))
+	assert.Contains(t, attributes, semconv.MessagingSystemAWSSQS)
+	assert.Contains(t, attributes, semconv.ServerAddress(serverAddress))
 }
 
 func TestSQSGetQueueAttributesInput(t *testing.T) {
 	input := middleware.InitializeInput{
 		Parameters: &sqs.GetQueueAttributesInput{
-			QueueUrl: aws.String("test-queue-url"),
+			QueueUrl: &queueUrl,
 		},
 	}
 
 	attributes := SQSAttributeBuilder(t.Context(), input, middleware.InitializeOutput{})
 
-	assert.Contains(t, attributes, semconv.ServerAddress("test-queue-url"))
+	assert.Contains(t, attributes, semconv.AWSSQSQueueURL(queueUrl))
+	assert.Contains(t, attributes, semconv.MessagingDestinationName(queueName))
+	assert.Contains(t, attributes, semconv.MessagingSystemAWSSQS)
+	assert.Contains(t, attributes, semconv.ServerAddress(serverAddress))
 }
 
 func TestSQSListDeadLetterSourceQueuesInput(t *testing.T) {
 	input := middleware.InitializeInput{
 		Parameters: &sqs.ListDeadLetterSourceQueuesInput{
-			QueueUrl: aws.String("test-queue-url"),
+			QueueUrl: &queueUrl,
 		},
 	}
 
 	attributes := SQSAttributeBuilder(t.Context(), input, middleware.InitializeOutput{})
 
-	assert.Contains(t, attributes, semconv.ServerAddress("test-queue-url"))
+	assert.Contains(t, attributes, semconv.AWSSQSQueueURL(queueUrl))
+	assert.Contains(t, attributes, semconv.MessagingDestinationName(queueName))
+	assert.Contains(t, attributes, semconv.MessagingSystemAWSSQS)
+	assert.Contains(t, attributes, semconv.ServerAddress(serverAddress))
 }
 
 func TestSQSListQueueTagsInput(t *testing.T) {
 	input := middleware.InitializeInput{
 		Parameters: &sqs.ListQueueTagsInput{
-			QueueUrl: aws.String("test-queue-url"),
+			QueueUrl: &queueUrl,
 		},
 	}
 
 	attributes := SQSAttributeBuilder(t.Context(), input, middleware.InitializeOutput{})
 
-	assert.Contains(t, attributes, semconv.ServerAddress("test-queue-url"))
+	assert.Contains(t, attributes, semconv.AWSSQSQueueURL(queueUrl))
+	assert.Contains(t, attributes, semconv.MessagingDestinationName(queueName))
+	assert.Contains(t, attributes, semconv.MessagingSystemAWSSQS)
+	assert.Contains(t, attributes, semconv.ServerAddress(serverAddress))
 }
 
 func TestSQSPurgeQueueInput(t *testing.T) {
 	input := middleware.InitializeInput{
 		Parameters: &sqs.PurgeQueueInput{
-			QueueUrl: aws.String("test-queue-url"),
+			QueueUrl: &queueUrl,
 		},
 	}
 
 	attributes := SQSAttributeBuilder(t.Context(), input, middleware.InitializeOutput{})
 
-	assert.Contains(t, attributes, semconv.ServerAddress("test-queue-url"))
+	assert.Contains(t, attributes, semconv.AWSSQSQueueURL(queueUrl))
+	assert.Contains(t, attributes, semconv.MessagingDestinationName(queueName))
+	assert.Contains(t, attributes, semconv.MessagingSystemAWSSQS)
+	assert.Contains(t, attributes, semconv.ServerAddress(serverAddress))
 }
 
 func TestSQSReceiveMessageInput(t *testing.T) {
 	input := middleware.InitializeInput{
 		Parameters: &sqs.ReceiveMessageInput{
-			QueueUrl: aws.String("test-queue-url"),
+			QueueUrl: &queueUrl,
 		},
 	}
 
 	attributes := SQSAttributeBuilder(t.Context(), input, middleware.InitializeOutput{})
 
-	assert.Contains(t, attributes, semconv.ServerAddress("test-queue-url"))
+	assert.Contains(t, attributes, semconv.AWSSQSQueueURL(queueUrl))
+	assert.Contains(t, attributes, semconv.MessagingDestinationName(queueName))
+	assert.Contains(t, attributes, semconv.MessagingOperationTypeReceive)
+	assert.Contains(t, attributes, semconv.MessagingSystemAWSSQS)
+	assert.Contains(t, attributes, semconv.ServerAddress(serverAddress))
 }
 
 func TestSQSRemovePermissionInput(t *testing.T) {
 	input := middleware.InitializeInput{
 		Parameters: &sqs.RemovePermissionInput{
-			QueueUrl: aws.String("test-queue-url"),
+			QueueUrl: &queueUrl,
 		},
 	}
 
 	attributes := SQSAttributeBuilder(t.Context(), input, middleware.InitializeOutput{})
 
-	assert.Contains(t, attributes, semconv.ServerAddress("test-queue-url"))
+	assert.Contains(t, attributes, semconv.AWSSQSQueueURL(queueUrl))
+	assert.Contains(t, attributes, semconv.MessagingDestinationName(queueName))
+	assert.Contains(t, attributes, semconv.MessagingSystemAWSSQS)
+	assert.Contains(t, attributes, semconv.ServerAddress(serverAddress))
 }
 
 func TestSQSSendMessageBatchInput(t *testing.T) {
 	input := middleware.InitializeInput{
 		Parameters: &sqs.SendMessageBatchInput{
-			QueueUrl: aws.String("test-queue-url"),
+			QueueUrl: &queueUrl,
 		},
 	}
 
 	attributes := SQSAttributeBuilder(t.Context(), input, middleware.InitializeOutput{})
 
-	assert.Contains(t, attributes, semconv.ServerAddress("test-queue-url"))
+	assert.Contains(t, attributes, semconv.AWSSQSQueueURL(queueUrl))
+	assert.Contains(t, attributes, semconv.MessagingBatchMessageCount(0))
+	assert.Contains(t, attributes, semconv.MessagingDestinationName(queueName))
+	assert.Contains(t, attributes, semconv.MessagingOperationTypeSend)
+	assert.Contains(t, attributes, semconv.MessagingSystemAWSSQS)
+	assert.Contains(t, attributes, semconv.ServerAddress(serverAddress))
 }
 
 func TestSQSSendMessageInput(t *testing.T) {
 	input := middleware.InitializeInput{
 		Parameters: &sqs.SendMessageInput{
-			QueueUrl: aws.String("test-queue-url"),
+			MessageBody: aws.String(""),
+			QueueUrl:    &queueUrl,
 		},
 	}
 
 	attributes := SQSAttributeBuilder(t.Context(), input, middleware.InitializeOutput{})
 
-	assert.Contains(t, attributes, semconv.ServerAddress("test-queue-url"))
+	assert.Contains(t, attributes, semconv.AWSSQSQueueURL(queueUrl))
+	assert.Contains(t, attributes, semconv.MessagingDestinationName(queueName))
+	assert.Contains(t, attributes, semconv.MessagingMessageBodySize(0))
+	assert.Contains(t, attributes, semconv.MessagingOperationTypeSend)
+	assert.Contains(t, attributes, semconv.MessagingSystemAWSSQS)
+	assert.Contains(t, attributes, semconv.ServerAddress(serverAddress))
 }
 
 func TestSQSSetQueueAttributesInput(t *testing.T) {
 	input := middleware.InitializeInput{
 		Parameters: &sqs.SetQueueAttributesInput{
-			QueueUrl: aws.String("test-queue-url"),
+			QueueUrl: &queueUrl,
 		},
 	}
 
 	attributes := SQSAttributeBuilder(t.Context(), input, middleware.InitializeOutput{})
 
-	assert.Contains(t, attributes, semconv.ServerAddress("test-queue-url"))
+	assert.Contains(t, attributes, semconv.AWSSQSQueueURL(queueUrl))
+	assert.Contains(t, attributes, semconv.MessagingDestinationName(queueName))
+	assert.Contains(t, attributes, semconv.MessagingSystemAWSSQS)
+	assert.Contains(t, attributes, semconv.ServerAddress(serverAddress))
 }
 
 func TestSQSTagQueueInput(t *testing.T) {
 	input := middleware.InitializeInput{
 		Parameters: &sqs.TagQueueInput{
-			QueueUrl: aws.String("test-queue-url"),
+			QueueUrl: &queueUrl,
 		},
 	}
 
 	attributes := SQSAttributeBuilder(t.Context(), input, middleware.InitializeOutput{})
 
-	assert.Contains(t, attributes, semconv.ServerAddress("test-queue-url"))
+	assert.Contains(t, attributes, semconv.AWSSQSQueueURL(queueUrl))
+	assert.Contains(t, attributes, semconv.MessagingDestinationName(queueName))
+	assert.Contains(t, attributes, semconv.MessagingSystemAWSSQS)
+	assert.Contains(t, attributes, semconv.ServerAddress(serverAddress))
 }
 
 func TestSQSUntagQueueInput(t *testing.T) {
 	input := middleware.InitializeInput{
 		Parameters: &sqs.UntagQueueInput{
-			QueueUrl: aws.String("test-queue-url"),
+			QueueUrl: &queueUrl,
 		},
 	}
 
 	attributes := SQSAttributeBuilder(t.Context(), input, middleware.InitializeOutput{})
 
-	assert.Contains(t, attributes, semconv.ServerAddress("test-queue-url"))
+	assert.Contains(t, attributes, semconv.AWSSQSQueueURL(queueUrl))
+	assert.Contains(t, attributes, semconv.MessagingDestinationName(queueName))
+	assert.Contains(t, attributes, semconv.MessagingSystemAWSSQS)
+	assert.Contains(t, attributes, semconv.ServerAddress(serverAddress))
 }


### PR DESCRIPTION
## `aws.sqs.*`

From the [OTel semantic conventions docs for `aws.sqs.*`](https://opentelemetry.io/docs/specs/semconv/registry/attributes/aws/#amazon-sqs-attributes):

> ## Amazon SQS Attributes
> 
> This document defines attributes for AWS SQS.
> 
> **Attributes:**
> 
> | Key | Stability | Value Type | Description | Example Values |
> | --- | --- | --- | --- | --- |
> | <a id="aws-sqs-queue-url" href="#aws-sqs-queue-url">`aws.sqs.queue.url`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The URL of the AWS SQS Queue. It's a unique identifier for a queue in Amazon Simple Queue Service (SQS) and is used to access the queue and perform actions on it. | `https://sqs.us-east-1.amazonaws.com/123456789012/MyQueue` |

## `messaging.*`

From the [OTel semantic conventions docs for `messaging.*`](https://opentelemetry.io/docs/specs/semconv/registry/attributes/messaging/):

> ## General Messaging Attributes
> 
> Attributes describing telemetry around messaging systems and messaging activities.
> 
> **Attributes:**
> 
> | Key | Stability | Value Type | Description | Example Values |
> | --- | --- | --- | --- | --- |
> | <a id="messaging-batch-message-count" href="#messaging-batch-message-count">`messaging.batch.message_count`</a> | ![Development](https://img.shields.io/badge/-development-blue) | int | The number of messages sent, received, or processed in the scope of the batching operation. [1] | `0`; `1`; `2` |
> | <a id="messaging-client-id" href="#messaging-client-id">`messaging.client.id`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | A unique identifier for the client that consumes or produces a message. | `client-5`; `myhost@8742@s8083jm` |
> | <a id="messaging-consumer-group-name" href="#messaging-consumer-group-name">`messaging.consumer.group.name`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The name of the consumer group with which a consumer is associated. [2] | `my-group`; `indexer` |
> | <a id="messaging-destination-anonymous" href="#messaging-destination-anonymous">`messaging.destination.anonymous`</a> | ![Development](https://img.shields.io/badge/-development-blue) | boolean | A boolean that is true if the message destination is anonymous (could be unnamed or have auto-generated name). | |
> | <a id="messaging-destination-name" href="#messaging-destination-name">`messaging.destination.name`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The message destination name [3] | `MyQueue`; `MyTopic` |
> | <a id="messaging-destination-partition-id" href="#messaging-destination-partition-id">`messaging.destination.partition.id`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The identifier of the partition messages are sent to or received from, unique within the `messaging.destination.name`. | `1` |
> | <a id="messaging-destination-subscription-name" href="#messaging-destination-subscription-name">`messaging.destination.subscription.name`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The name of the destination subscription from which a message is consumed. [4] | `subscription-a` |
> | <a id="messaging-destination-template" href="#messaging-destination-template">`messaging.destination.template`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | Low cardinality representation of the messaging destination name [5] | `/customers/{customerId}` |
> | <a id="messaging-destination-temporary" href="#messaging-destination-temporary">`messaging.destination.temporary`</a> | ![Development](https://img.shields.io/badge/-development-blue) | boolean | A boolean that is true if the message destination is temporary and might not exist anymore after messages are processed. | |
> | <a id="messaging-message-body-size" href="#messaging-message-body-size">`messaging.message.body.size`</a> | ![Development](https://img.shields.io/badge/-development-blue) | int | The size of the message body in bytes. [6] | `1439` |
> | <a id="messaging-message-conversation-id" href="#messaging-message-conversation-id">`messaging.message.conversation_id`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The conversation ID identifying the conversation to which the message belongs, represented as a string. Sometimes called "Correlation ID". | `MyConversationId` |
> | <a id="messaging-message-envelope-size" href="#messaging-message-envelope-size">`messaging.message.envelope.size`</a> | ![Development](https://img.shields.io/badge/-development-blue) | int | The size of the message body and metadata in bytes. [7] | `2738` |
> | <a id="messaging-message-id" href="#messaging-message-id">`messaging.message.id`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | A value used by the messaging system as an identifier for the message, represented as a string. | `452a7c7c7c7048c2f887f61572b18fc2` |
> | <a id="messaging-operation-name" href="#messaging-operation-name">`messaging.operation.name`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The system-specific name of the messaging operation. | `ack`; `nack`; `send` |
> | <a id="messaging-operation-type" href="#messaging-operation-type">`messaging.operation.type`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | A string identifying the type of the messaging operation. [8] | `create`; `send`; `receive` |
> | <a id="messaging-system" href="#messaging-system">`messaging.system`</a> | ![Development](https://img.shields.io/badge/-development-blue) | string | The messaging system as identified by the client instrumentation. [9] | `activemq`; `aws.sns`; `aws_sqs` |
> 
> **[1] `messaging.batch.message_count`:** Instrumentations SHOULD NOT set `messaging.batch.message_count` on spans that operate with a single message. When a messaging client library supports both batch and single-message API for the same operation, instrumentations SHOULD use `messaging.batch.message_count` for batching APIs and SHOULD NOT use it for single-message APIs.
> 
> **[2] `messaging.consumer.group.name`:** Semantic conventions for individual messaging systems SHOULD document whether `messaging.consumer.group.name` is applicable and what it means in the context of that system.
> 
> **[3] `messaging.destination.name`:** Destination name SHOULD uniquely identify a specific queue, topic or other entity within the broker. If
> the broker doesn't have such notion, the destination name SHOULD uniquely identify the broker.
> 
> **[4] `messaging.destination.subscription.name`:** Semantic conventions for individual messaging systems SHOULD document whether `messaging.destination.subscription.name` is applicable and what it means in the context of that system.
> 
> **[5] `messaging.destination.template`:** Destination names could be constructed from templates. An example would be a destination name involving a user name or product id. Although the destination name in this case is of high cardinality, the underlying template is of low cardinality and can be effectively used for grouping and aggregation.
> 
> **[6] `messaging.message.body.size`:** This can refer to both the compressed or uncompressed body size. If both sizes are known, the uncompressed
> body size should be used.
> 
> **[7] `messaging.message.envelope.size`:** This can refer to both the compressed or uncompressed size. If both sizes are known, the uncompressed
> size should be used.
> 
> **[8] `messaging.operation.type`:** If a custom value is used, it MUST be of low cardinality.
> 
> **[9] `messaging.system`:** The actual messaging system may differ from the one known by the client. For example, when using Kafka client libraries to communicate with Azure Event Hubs, the `messaging.system` is set to `kafka` based on the instrumentation's best knowledge.
> 
> ---
> 
> `messaging.operation.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
> 
> | Value | Description | Stability |
> | --- | --- | --- |
> | `create` | A message is created. "Create" spans always refer to a single message and are used to provide a unique creation context for messages in batch sending scenarios. | ![Development](https://img.shields.io/badge/-development-blue) |
> | `process` | One or more messages are processed by a consumer. | ![Development](https://img.shields.io/badge/-development-blue) |
> | `receive` | One or more messages are requested by a consumer. This operation refers to pull-based scenarios, where consumers explicitly call methods of messaging SDKs to receive messages. | ![Development](https://img.shields.io/badge/-development-blue) |
> | `send` | One or more messages are provided for sending to an intermediary. If a single message is sent, the context of the "Send" span can be used as the creation context and no "Create" span needs to be created. | ![Development](https://img.shields.io/badge/-development-blue) |
> | `settle` | One or more messages are settled. | ![Development](https://img.shields.io/badge/-development-blue) |
> 
> ---
> 
> `messaging.system` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
> 
> | Value | Description | Stability |
> | --- | --- | --- |
> | `activemq` | Apache ActiveMQ | ![Development](https://img.shields.io/badge/-development-blue) |
> | `aws.sns` | Amazon Simple Notification Service (SNS) | ![Development](https://img.shields.io/badge/-development-blue) |
> | `aws_sqs` | Amazon Simple Queue Service (SQS) | ![Development](https://img.shields.io/badge/-development-blue) |
> | `eventgrid` | Azure Event Grid | ![Development](https://img.shields.io/badge/-development-blue) |
> | `eventhubs` | Azure Event Hubs | ![Development](https://img.shields.io/badge/-development-blue) |
> | `gcp_pubsub` | Google Cloud Pub/Sub | ![Development](https://img.shields.io/badge/-development-blue) |
> | `jms` | Java Message Service | ![Development](https://img.shields.io/badge/-development-blue) |
> | `kafka` | Apache Kafka | ![Development](https://img.shields.io/badge/-development-blue) |
> | `pulsar` | Apache Pulsar | ![Development](https://img.shields.io/badge/-development-blue) |
> | `rabbitmq` | RabbitMQ | ![Development](https://img.shields.io/badge/-development-blue) |
> | `rocketmq` | Apache RocketMQ | ![Development](https://img.shields.io/badge/-development-blue) |
> | `servicebus` | Azure Service Bus | ![Development](https://img.shields.io/badge/-development-blue) |

## `server.*` 

From the [OTel semantic conventions docs for `server.*`](https://opentelemetry.io/docs/specs/semconv/registry/attributes/server/):

> # Server
> 
> ## Server Attributes
> 
> These attributes may be used to describe the server in a connection-based network interaction where there is one side that initiates the connection (the client is the side that initiates the connection). This covers all TCP network interactions since TCP is connection-based and one side initiates the connection (an exception is made for peer-to-peer communication over TCP where the "user-facing" surface of the protocol / API doesn't expose a clear notion of client and server). This also covers UDP network interactions where one side initiates the interaction, e.g. QUIC (HTTP/3) and DNS.
> 
> **Attributes:**
> 
> | Key | Stability | Value Type | Description | Example Values |
> | --- | --- | --- | --- | --- |
> | <a id="server-address" href="#server-address">`server.address`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | string | Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name. [1] | `example.com`; `10.1.2.80`; `/tmp/my.sock` |
> | <a id="server-port" href="#server-port">`server.port`</a> | ![Stable](https://img.shields.io/badge/-stable-lightgreen) | int | Server port number. [2] | `80`; `8080`; `443` |
> 
> **[1] `server.address`:** When observed from the client side, and when communicating through an intermediary, `server.address` SHOULD represent the server address behind any intermediaries, for example proxies, if it's available.
> 
> **[2] `server.port`:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries, for example proxies, if it's available.


## Related

- valkey-io/valkey-go#94
- valkey-io/valkey-go#95