### PR TITLE
Fix `messaging.system` attr for AWS SNS

### DIFF
--- a/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/snsattributes.go
+++ b/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/snsattributes.go
@@ -15,7 +15,7 @@ import (
 
 // SNSAttributeBuilder sets SNS specific attributes depending on the SNS operation is being performed.
 func SNSAttributeBuilder(_ context.Context, in middleware.InitializeInput, _ middleware.InitializeOutput) []attribute.KeyValue {
-	snsAttributes := []attribute.KeyValue{semconv.MessagingSystemKey.String("aws_sns")}
+	snsAttributes := []attribute.KeyValue{semconv.MessagingSystemAWSSNS}
 
 	switch v := in.Parameters.(type) {
 	case *sns.PublishBatchInput:

--- a/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/snsattributes_test.go
+++ b/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/snsattributes_test.go
@@ -23,7 +23,7 @@ func TestPublishInput(t *testing.T) {
 
 	attributes := SNSAttributeBuilder(t.Context(), input, middleware.InitializeOutput{})
 
-	assert.Contains(t, attributes, semconv.MessagingSystemKey.String("aws_sns"))
+	assert.Contains(t, attributes, semconv.MessagingSystemAWSSNS)
 	assert.Contains(t, attributes, semconv.MessagingDestinationName("my-topic"))
 	assert.Contains(t, attributes, semconv.MessagingOperationName("publish_input"))
 	assert.Contains(t, attributes, semconv.MessagingOperationTypeSend)
@@ -36,7 +36,7 @@ func TestPublishInputWithNoDestination(t *testing.T) {
 
 	attributes := SNSAttributeBuilder(t.Context(), input, middleware.InitializeOutput{})
 
-	assert.Contains(t, attributes, semconv.MessagingSystemKey.String("aws_sns"))
+	assert.Contains(t, attributes, semconv.MessagingSystemAWSSNS)
 	assert.Contains(t, attributes, semconv.MessagingDestinationName(""))
 	assert.Contains(t, attributes, semconv.MessagingOperationName("publish_input"))
 	assert.Contains(t, attributes, semconv.MessagingOperationTypeSend)
@@ -52,7 +52,7 @@ func TestPublishBatchInput(t *testing.T) {
 
 	attributes := SNSAttributeBuilder(t.Context(), input, middleware.InitializeOutput{})
 
-	assert.Contains(t, attributes, semconv.MessagingSystemKey.String("aws_sns"))
+	assert.Contains(t, attributes, semconv.MessagingSystemAWSSNS)
 	assert.Contains(t, attributes, semconv.MessagingDestinationName("my-topic-batch"))
 	assert.Contains(t, attributes, semconv.MessagingOperationName("publish_batch_input"))
 	assert.Contains(t, attributes, semconv.MessagingOperationTypeSend)


### PR DESCRIPTION
~~No idea why the semconv committee decided to go with `aws_sqs` and `aws.sns`, but either the semconv is wrong or the instrumentation is, so figured I'd start with a PR here and see what others think.~~ _edit: see https://github.com/open-telemetry/opentelemetry-go-contrib/pull/8322#issuecomment-3677637681 for context on this^ discrepancy, as well as plans to eventually rename `aws{_ => .}sqs`._

From the [OTel semantic conventions docs for `messaging.system`](https://opentelemetry.io/docs/specs/semconv/registry/attributes/messaging/#messaging-system):

> `messaging.system` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
> 
> | Value | Description | Stability |
> | --- | --- | --- |
> | `activemq` | Apache ActiveMQ | ![Development](https://img.shields.io/badge/-development-blue) |
> | `aws.sns` | Amazon Simple Notification Service (SNS) | ![Development](https://img.shields.io/badge/-development-blue) |
> | `aws_sqs` | Amazon Simple Queue Service (SQS) | ![Development](https://img.shields.io/badge/-development-blue) |
> | `eventgrid` | Azure Event Grid | ![Development](https://img.shields.io/badge/-development-blue) |
> | `eventhubs` | Azure Event Hubs | ![Development](https://img.shields.io/badge/-development-blue) |
> | `gcp_pubsub` | Google Cloud Pub/Sub | ![Development](https://img.shields.io/badge/-development-blue) |
> | `jms` | Java Message Service | ![Development](https://img.shields.io/badge/-development-blue) |
> | `kafka` | Apache Kafka | ![Development](https://img.shields.io/badge/-development-blue) |
> | `pulsar` | Apache Pulsar | ![Development](https://img.shields.io/badge/-development-blue) |
> | `rabbitmq` | RabbitMQ | ![Development](https://img.shields.io/badge/-development-blue) |
> | `rocketmq` | Apache RocketMQ | ![Development](https://img.shields.io/badge/-development-blue) |
> | `servicebus` | Azure Service Bus | ![Development](https://img.shields.io/badge/-development-blue) |

## Related 
- #8321