### PR TITLE
feat: add MetricAttributesFn and SpanAttributesFn for dynamic attributes

### DIFF
--- a/instrumentation/google.golang.org/grpc/otelgrpc/stats_handler_test.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/stats_handler_test.go
@@ -14,6 +14,8 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/embedded"
 	"go.opentelemetry.io/otel/propagation"
+	metricSdk "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
@@ -198,6 +200,97 @@ func TestNilInstruments(t *testing.T) {
 		assert.NotPanics(t, func() { h.inMsg.Record(ctx, 0) }, "inMsg")
 		assert.NotPanics(t, func() { h.outMsg.Record(ctx, 0) }, "outMsg")
 	})
+}
+
+func TestServerHandler_SpanAttributesFn_And_MetricAttributesFn(t *testing.T) {
+	const ctxKey = "test-key"
+	const ctxVal = "test-value"
+
+	mr := metricSdk.NewManualReader()
+	meterProvider := metricSdk.NewMeterProvider(metricSdk.WithReader(mr))
+
+	spanRecorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(spanRecorder),
+	)
+	remoteSpan := trace.SpanContextConfig{
+		TraceID:    trace.TraceID{0x01},
+		SpanID:     trace.SpanID{0x01},
+		TraceFlags: trace.FlagsSampled,
+	}
+	prop := propagation.TraceContext{}
+
+	sc := trace.NewSpanContext(remoteSpan)
+	ctx := context.WithValue(t.Context(), ctxKey, ctxVal)
+	ctx = trace.ContextWithSpanContext(ctx, sc)
+
+	handler := NewServerHandler(
+		WithPropagators(prop),
+		WithTracerProvider(provider),
+		WithMeterProvider(meterProvider),
+		WithSpanAttributes(attribute.String("static", "attr")),
+		WithSpanAttributesFn(func(ctx context.Context, ri *stats.RPCTagInfo) []attribute.KeyValue {
+			val, _ := ctx.Value(ctxKey).(string)
+			return []attribute.KeyValue{attribute.String("dynamic", val)}
+		}),
+		WithMetricAttributes(attribute.Bool("static", true)),
+		WithMetricAttributesFn(func(ctx context.Context, ri *stats.RPCTagInfo) []attribute.KeyValue {
+			return []attribute.KeyValue{attribute.Bool("dynamic", true)}
+		}),
+	)
+
+	info := &stats.RPCTagInfo{FullMethodName: "/foo.bar/Baz", FailFast: true}
+
+	ctx = handler.TagRPC(ctx, info)
+
+	handler.HandleRPC(ctx, &stats.Begin{
+		Client:                    false,
+		BeginTime:                 time.Time{},
+		FailFast:                  true,
+		IsClientStream:            false,
+		IsServerStream:            false,
+		IsTransparentRetryAttempt: false,
+	})
+
+	handler.HandleRPC(ctx, &stats.End{
+		Client:    false,
+		BeginTime: time.Time{},
+		EndTime:   time.Time{},
+		Trailer:   metadata.MD{},
+		Error:     nil,
+	})
+
+	// Test span attributes
+	assert.NoError(t, spanRecorder.ForceFlush(t.Context()))
+	spans := spanRecorder.Ended()
+
+	assert.Contains(t, spans[0].Attributes(), attribute.String("static", "attr"))
+	assert.Contains(t, spans[0].Attributes(), attribute.String("dynamic", ctxVal))
+
+	// Test metric attributes
+	rm := metricdata.ResourceMetrics{}
+	assert.NoError(t, mr.Collect(t.Context(), &rm))
+
+	checkAttrs := func(attrs attribute.Set) {
+		val, _ := attrs.Value("static")
+		assert.True(t, val.AsBool(), "static attribute should be true")
+
+		val, _ = attrs.Value("dynamic")
+		assert.True(t, val.AsBool(), "dynamic attribute should be true")
+	}
+
+	for _, mm := range rm.ScopeMetrics[0].Metrics {
+		switch data := mm.Data.(type) {
+		case metricdata.Histogram[float64]:
+			for _, dp := range data.DataPoints {
+				checkAttrs(dp.Attributes)
+			}
+		case metricdata.Histogram[int64]:
+			for _, dp := range data.DataPoints {
+				checkAttrs(dp.Attributes)
+			}
+		}
+	}
 }
 
 type meterProvider struct {


### PR DESCRIPTION
Add support for dynamic span and metric attributes in `otelgrpc` via `WithSpanAttributesFn` and `WithMetricAttributesFn`.
These options allow extracting attributes from the context per request, enabling propagation of values injected by interceptors or middleware.