### PR TITLE
Add YAML aware variable substitution

### DIFF
--- a/otelconf/config_test.go
+++ b/otelconf/config_test.go
@@ -974,7 +974,7 @@ var v100OpenTelemetryConfigEnvParsing = OpenTelemetryConfiguration{
 			{Name: "quoted_float_value", Type: ptr(AttributeTypeString), Value: "1.1"},
 			{Name: "quoted_hex_value", Type: ptr(AttributeTypeString), Value: "0xbeef"},
 			{Name: "alternative_env_syntax", Type: ptr(AttributeTypeString), Value: "value"},
-			{Name: "invalid_map_value", Type: ptr(AttributeTypeString), Value: "value\nkey:value"},
+			{Name: "invalid_map_value", Type: ptr(AttributeTypeString), Value: "value\\nkey:value"},
 			{Name: "multiple_references_inject", Type: ptr(AttributeTypeString), Value: "foo value 1.1"},
 			{Name: "undefined_key", Type: ptr(AttributeTypeString), Value: nil},
 			{Name: "undefined_key_fallback", Type: ptr(AttributeTypeString), Value: "fallback"},

--- a/otelconf/internal/provider/envprovider_test.go
+++ b/otelconf/internal/provider/envprovider_test.go
@@ -351,7 +351,7 @@ func TestSpecExamples(t *testing.T) {
 		},
 		{ // 17
 			yamlInput:  "key: ${UNDEFINED_KEY:-${STRING_VALUE}}",
-			yamlOutput: `key: ${STRING_VALUE}`, // added missing key:
+			yamlOutput: `key: ${STRING_VALUE}`,
 			tagURI:     "tag:yaml.org,2002:str",
 			notes:      `Undefined env var results in substitution of default value ${STRING_VALUE}, and is not substituted recursively`,
 		},
@@ -382,13 +382,13 @@ func TestSpecExamples(t *testing.T) {
 		},
 		{ // 22
 			yamlInput:  "key: $${STRING_VALUE:-fallback}",
-			yamlOutput: `key: ${STRING_VALUE:-fallback}`, // added missing key:
+			yamlOutput: `key: ${STRING_VALUE:-fallback}`,
 			tagURI:     "tag:yaml.org,2002:str",
 			notes:      `$$ escape sequence is replaced with $, {STRING_VALUE:-fallback} does not match substitution syntax`,
 		},
 		{ // 23
 			yamlInput:  "key: $${STRING_VALUE:-${STRING_VALUE}}",
-			yamlOutput: `key: ${STRING_VALUE:-value}`, // added missing key:
+			yamlOutput: `key: ${STRING_VALUE:-value}`,
 			tagURI:     "tag:yaml.org,2002:str",
 			notes:      `$$ escape sequence is replaced with $, leaving {STRING_VALUE:-${STRING_VALUE}}, ${STRING_VALUE} is replaced with value`,
 		},
@@ -400,15 +400,15 @@ func TestSpecExamples(t *testing.T) {
 			// 2. encounter $$ and substitute with $
 			// 3. then reading {UNDEFINED_KEY
 			// 4. encounter }, that will conclude the env substitution, thus we have ${UNDEFINED_KEY:-${UNDEFINED_KEY}
-			//    that is perfectly valid and will result int ${UNDEFINED_KEY
+			//    that is perfectly valid and will result in ${UNDEFINED_KEY
 			// 5. encounter an unrelated }, that is just printed
-			yamlOutput: `key: ${UNDEFINED_KEY}`, // added missing key:
+			yamlOutput: `key: ${UNDEFINED_KEY}`,
 			tagURI:     "tag:yaml.org,2002:str",
 			notes:      `$$ escape sequence is replaced with $, leaving ${UNDEFINED_KEY:- before and ${UNDEFINED_KEY}} after which do not match substitution syntax`,
 		},
 		{ // 25
 			yamlInput:  "key: ${VALUE_WITH_ESCAPE}",
-			yamlOutput: `key: value$$`, // added missing key:
+			yamlOutput: `key: value$$`,
 			tagURI:     "tag:yaml.org,2002:str",
 			notes:      `Value of env var VALUE_WITH_ESCAPE is value$$, which is substituted without escaping`,
 		},

--- a/otelconf/internal/provider/envprovider_test.go
+++ b/otelconf/internal/provider/envprovider_test.go
@@ -5,10 +5,13 @@ package provider // import "go.opentelemetry.io/contrib/otelconf/internal/provid
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestInvalidEnvVarName(t *testing.T) {
@@ -44,7 +47,7 @@ func TestReplaceEnvVar(t *testing.T) {
 		{
 			name:  "undefined environment variable",
 			input: "key: ${UNDEFINED_VAR}",
-			want:  "key: ",
+			want:  "key:",
 		},
 		{
 			name:  "environment variable with default value",
@@ -83,7 +86,7 @@ func TestReplaceEnvVar(t *testing.T) {
 			name:  "environment variable in key position",
 			input: "${KEY_VAR}: value",
 			env:   map[string]string{"KEY_VAR": "dynamic_key"},
-			want:  "dynamic_key: value",
+			want:  "${KEY_VAR}: value",
 		},
 		{
 			name:  "multiple environment variables in same line",
@@ -154,21 +157,21 @@ func TestReplaceEnvVar(t *testing.T) {
 		{
 			name: "complex YAML with multiple substitutions",
 			input: `service:
-		  name: ${SERVICE_NAME:-default-service}
-		  version: ${SERVICE_VERSION}
-		config:
-		  endpoint: ${ENDPOINT}
-		  escaped: $${NOT_REPLACED}`,
+    name: ${SERVICE_NAME:-default-service}
+    version: ${SERVICE_VERSION}
+config:
+    endpoint: ${ENDPOINT}
+    escaped: $${NOT_REPLACED}`,
 			env: map[string]string{
 				"SERVICE_VERSION": "1.0.0",
 				"ENDPOINT":        "http://localhost:8080",
 			},
 			want: `service:
-		  name: default-service
-		  version: 1.0.0
-		config:
-		  endpoint: http://localhost:8080
-		  escaped: ${NOT_REPLACED}`,
+    name: default-service
+    version: 1.0.0
+config:
+    endpoint: http://localhost:8080
+    escaped: ${NOT_REPLACED}`,
 		},
 		{
 			name:    "YAML injection causes error",
@@ -221,6 +224,236 @@ func TestReplaceEnvVar(t *testing.T) {
 				require.NoError(t, err)
 			}
 			assert.Equal(t, tt.want, string(got))
+		})
+	}
+}
+
+// Tests of https://opentelemetry.io/docs/specs/otel/configuration/data-model/ with some corrections.
+func TestSpecExamples(t *testing.T) {
+	t.Setenv("STRING_VALUE", "value")
+	t.Setenv("BOOL_VALUE", "true")
+	t.Setenv("INT_VALUE", "1")
+	t.Setenv("FLOAT_VALUE", "1.1")
+	t.Setenv("HEX_VALUE", "0xdeadbeef")                   // A valid integer value (i.e. 3735928559) written in hexadecimal
+	t.Setenv("INVALID_MAP_VALUE", "value\nkey:value")     // An invalid attempt to inject a map key into the YAML
+	t.Setenv("DO_NOT_REPLACE_ME", "Never use this value") // An unused environment variable
+	t.Setenv("REPLACE_ME", "${DO_NOT_REPLACE_ME}")        // A valid replacement text, used verbatim, not replaced with "Never use this value"
+	t.Setenv("VALUE_WITH_ESCAPE", "value$$")
+
+	tests := []struct {
+		yamlInput  string
+		yamlOutput string
+		tagURI     string
+		notes      string
+		wantErr    bool
+	}{
+		{ // 0
+			yamlInput:  "key: ${STRING_VALUE}",
+			yamlOutput: "key: value",
+			tagURI:     "tag:yaml.org,2002:str",
+			notes:      "YAML parser resolves to string",
+		},
+		{ // 1
+			yamlInput:  "key: ${BOOL_VALUE}",
+			yamlOutput: "key: true",
+			tagURI:     "tag:yaml.org,2002:bool",
+			notes:      "YAML parser resolves to true",
+		},
+		{ // 2
+			yamlInput:  "key: ${INT_VALUE}",
+			yamlOutput: "key: 1",
+			tagURI:     "tag:yaml.org,2002:int",
+			notes:      "YAML parser resolves to int",
+		},
+		{ // 3
+			yamlInput:  "key: ${FLOAT_VALUE}",
+			yamlOutput: "key: 1.1",
+			tagURI:     "tag:yaml.org,2002:float",
+			notes:      "YAML parser resolves to float",
+		},
+		{ // 4
+			yamlInput:  "key: ${HEX_VALUE}",
+			yamlOutput: "key: 0xdeadbeef",
+			tagURI:     "tag:yaml.org,2002:int",
+			notes:      "YAML parser resolves to int 3735928559",
+		},
+		{ // 5
+			yamlInput:  `key: "${STRING_VALUE}"`,
+			yamlOutput: `key: "value"`,
+			tagURI:     "tag:yaml.org,2002:str",
+			notes:      `Double quoted to force coercion to string "value"`,
+		},
+		{ // 6
+			yamlInput:  `key: "${BOOL_VALUE}"`,
+			yamlOutput: `key: "true"`,
+			tagURI:     "tag:yaml.org,2002:str",
+			notes:      `Double quoted to force coercion to string "true"`,
+		},
+		{ // 7
+			yamlInput:  `key: "${INT_VALUE}"`,
+			yamlOutput: `key: "1"`,
+			tagURI:     `tag:yaml.org,2002:str`,
+			notes:      `Double quoted to force coercion to string "1"`,
+		},
+		{ // 8
+			yamlInput:  `key: "${FLOAT_VALUE}"`,
+			yamlOutput: `key: "1.1"`,
+			tagURI:     "tag:yaml.org,2002:str",
+			notes:      `Double quoted to force coercion to string "1.1"`,
+		},
+		{ // 9
+			yamlInput:  `key: "${HEX_VALUE}"`,
+			yamlOutput: `key: "0xdeadbeef"`,
+			tagURI:     "tag:yaml.org,2002:str",
+			notes:      `Double quoted to force coercion to string "0xdeadbeef"`,
+		},
+		{ // 10
+			yamlInput:  "key: ${env:STRING_VALUE}",
+			yamlOutput: `key: value`,
+			tagURI:     "tag:yaml.org,2002:str",
+			notes:      "Alternative env: syntax",
+		},
+		{ // 11
+			yamlInput:  "key: ${INVALID_MAP_VALUE}",
+			yamlOutput: "key: |-\n    value\n    key:value",
+			tagURI:     "tag:yaml.org,2002:str",
+			notes:      "Map structure resolves to string and not expanded",
+		},
+		{ // 12
+			yamlInput:  "key: foo ${STRING_VALUE} ${FLOAT_VALUE}",
+			yamlOutput: `key: foo value 1.1`,
+			tagURI:     "tag:yaml.org,2002:str",
+			notes:      `Multiple references are injected and resolved to string`,
+		},
+		{ // 13
+			yamlInput:  "key: ${UNDEFINED_KEY}",
+			yamlOutput: `key:`,
+			tagURI:     "tag:yaml.org,2002:null",
+			notes:      `Undefined env var is replaced with "" and resolves to null`,
+		},
+		{ // 14
+			yamlInput:  "key: ${UNDEFINED_KEY:-fallback}",
+			yamlOutput: `key: fallback`,
+			tagURI:     "tag:yaml.org,2002:str",
+			notes:      `Undefined env var results in substitution of default value fallback`,
+		},
+		{ // 15
+			yamlInput:  "${STRING_VALUE}: value",
+			yamlOutput: `${STRING_VALUE}: value`,
+			tagURI:     "tag:yaml.org,2002:str",
+			notes:      `Usage of substitution syntax in keys is ignored`,
+		},
+		{ // 16
+			yamlInput:  "key: ${REPLACE_ME}",
+			yamlOutput: `key: ${DO_NOT_REPLACE_ME}`,
+			tagURI:     "tag:yaml.org,2002:str",
+			notes:      `Value of env var REPLACE_ME is ${DO_NOT_REPLACE_ME}, and is not substituted recursively`,
+		},
+		{ // 17
+			yamlInput:  "key: ${UNDEFINED_KEY:-${STRING_VALUE}}",
+			yamlOutput: `key: ${STRING_VALUE}`, // added missing key:
+			tagURI:     "tag:yaml.org,2002:str",
+			notes:      `Undefined env var results in substitution of default value ${STRING_VALUE}, and is not substituted recursively`,
+		},
+		{ // 18
+			yamlInput:  "key: ${STRING_VALUE:?error}",
+			yamlOutput: "",
+			tagURI:     "",
+			notes:      `Invalid substitution reference produces parse error`,
+			wantErr:    true,
+		},
+		{ // 19
+			yamlInput:  "key: $${STRING_VALUE}",
+			yamlOutput: `key: ${STRING_VALUE}`,
+			tagURI:     "tag:yaml.org,2002:str",
+			notes:      `$$ escape sequence is replaced with $, {STRING_VALUE} does not match substitution syntax`,
+		},
+		{ // 20
+			yamlInput:  "key: $$${STRING_VALUE}",
+			yamlOutput: `key: $value`,
+			tagURI:     "tag:yaml.org,2002:str",
+			notes:      `$$ escape sequence is replaced with $, ${STRING_VALUE} is replaced with value`,
+		},
+		{ // 21
+			yamlInput:  "key: $$$${STRING_VALUE}",
+			yamlOutput: `key: $${STRING_VALUE}`,
+			tagURI:     "tag:yaml.org,2002:str",
+			notes:      `$$ escape sequence is replaced with $, $$ escape sequence is replaced with $, {STRING_VALUE} does not match substitution syntax`,
+		},
+		{ // 22
+			yamlInput:  "key: $${STRING_VALUE:-fallback}",
+			yamlOutput: `key: ${STRING_VALUE:-fallback}`, // added missing key:
+			tagURI:     "tag:yaml.org,2002:str",
+			notes:      `$$ escape sequence is replaced with $, {STRING_VALUE:-fallback} does not match substitution syntax`,
+		},
+		{ // 23
+			yamlInput:  "key: $${STRING_VALUE:-${STRING_VALUE}}",
+			yamlOutput: `key: ${STRING_VALUE:-value}`, // added missing key:
+			tagURI:     "tag:yaml.org,2002:str",
+			notes:      `$$ escape sequence is replaced with $, leaving {STRING_VALUE:-${STRING_VALUE}}, ${STRING_VALUE} is replaced with value`,
+		},
+		{ // 24
+			yamlInput: "key: ${UNDEFINED_KEY:-$${UNDEFINED_KEY}}",
+			// yamlOutput: `key: ${UNDEFINED_KEY:-${UNDEFINED_KEY}}`,
+			// this is what the spec tells, but I object,
+			// 1. we read until :-
+			// 2. encounter $$ and substitute with $
+			// 3. then reading {UNDEFINED_KEY
+			// 4. encounter }, that will conclude the env substitution, thus we have ${UNDEFINED_KEY:-${UNDEFINED_KEY}
+			//    that is perfectly valid and will result int ${UNDEFINED_KEY
+			// 5. encounter an unrelated }, that is just printed
+			yamlOutput: `key: ${UNDEFINED_KEY}`, // added missing key:
+			tagURI:     "tag:yaml.org,2002:str",
+			notes:      `$$ escape sequence is replaced with $, leaving ${UNDEFINED_KEY:- before and ${UNDEFINED_KEY}} after which do not match substitution syntax`,
+		},
+		{ // 25
+			yamlInput:  "key: ${VALUE_WITH_ESCAPE}",
+			yamlOutput: `key: value$$`, // added missing key:
+			tagURI:     "tag:yaml.org,2002:str",
+			notes:      `Value of env var VALUE_WITH_ESCAPE is value$$, which is substituted without escaping`,
+		},
+		{ // 26
+			yamlInput:  "key: a $$ b",
+			yamlOutput: `key: a $ b`,
+			tagURI:     "tag:yaml.org,2002:str",
+			notes:      `$$ escape sequence is replaced with $`,
+		},
+		{ // 27
+			yamlInput:  "key: a $ b",
+			yamlOutput: `key: a $ b`,
+			tagURI:     "tag:yaml.org,2002:str",
+			notes:      `No escape sequence, no substitution references, value is left unchanged`,
+		},
+	}
+
+	for idx, tt := range tests {
+		t.Run(fmt.Sprintf("SpecExample-%d", idx), func(t *testing.T) {
+			got, err := ReplaceEnvVars([]byte(tt.yamlInput))
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.yamlOutput, string(got), tt.notes)
+
+			if tt.wantErr {
+				return
+			}
+
+			// checking the resulting type
+			var node yaml.Node
+			require.NoError(t, yaml.Unmarshal(got, &node))
+
+			require.True(t,
+				len(node.Content) == 1 && len(node.Content[0].Content) == 2,
+				"type check node wrong structure")
+
+			// the YAML library tags are with !! instead of the long version
+			wantType := strings.ReplaceAll(tt.tagURI, "tag:yaml.org,2002:", "!!")
+
+			assert.Equal(t, wantType, node.Content[0].Content[1].Tag)
 		})
 	}
 }

--- a/otelconf/v0.3.0/config_test.go
+++ b/otelconf/v0.3.0/config_test.go
@@ -410,7 +410,7 @@ var v03OpenTelemetryConfigEnvParsing = OpenTelemetryConfiguration{
 			{Name: "quoted_float_value", Type: &AttributeNameValueType{Value: "string"}, Value: "1.1"},
 			{Name: "quoted_hex_value", Type: &AttributeNameValueType{Value: "string"}, Value: "0xbeef"},
 			{Name: "alternative_env_syntax", Type: &AttributeNameValueType{Value: "string"}, Value: "value"},
-			{Name: "invalid_map_value", Type: &AttributeNameValueType{Value: "string"}, Value: "value\nkey:value"},
+			{Name: "invalid_map_value", Type: &AttributeNameValueType{Value: "string"}, Value: "value\\nkey:value"},
 			{Name: "multiple_references_inject", Type: &AttributeNameValueType{Value: "string"}, Value: "foo value 1.1"},
 			{Name: "undefined_key", Type: &AttributeNameValueType{Value: "string"}, Value: nil},
 			{Name: "undefined_key_fallback", Type: &AttributeNameValueType{Value: "string"}, Value: "fallback"},


### PR DESCRIPTION
In the current implementation the environment variable substitution does not follow the specification found in https://opentelemetry.io/docs/specs/otel/configuration/data-model/. Specifically it does not obey the rule that substitution can only occur in YAML values. Further, according to the published specification examples, injected YAML-structured content leads to errors rather than correctly escaped/formatted strings.
This pull request solves these issues by using the yaml.Node structure of the yaml library to operate on already parsed YAML content. Further the redacted examples of the specification are included as further tests.