### PR TITLE
Switch version from function to string in consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The `Version()` function in `go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws` has been replaced by `const Version`. (#8356)
 - The `Version()` function in `go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful` has been replaced by `const Version`. (#8360)
 - The `Version()` function in `go.opentelemetry.io/contrib/propagators/opencensus` has been replaced by `const Version`. (#8361)
+- The `Version()` function in `go.opentelemetry.io/contrib/samplers/probability/consistent` has been replaced by `const Version`. (#8366)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/samplers/probability/consistent/version.go
+++ b/samplers/probability/consistent/version.go
@@ -5,7 +5,4 @@ package consistent // import "go.opentelemetry.io/contrib/samplers/probability/c
 
 // Version is the current release version of the consistent probability
 // sampler.
-func Version() string {
-	return "0.33.0"
-	// This string is updated by the pre_release.sh script during release
-}
+const Version = "0.33.0"

--- a/samplers/probability/consistent/version_test.go
+++ b/samplers/probability/consistent/version_test.go
@@ -19,6 +19,6 @@ var versionRegex = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)
 	`(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
 
 func TestVersionSemver(t *testing.T) {
-	v := consistent.Version()
+	v := consistent.Version
 	assert.NotNil(t, versionRegex.FindStringSubmatch(v), "version is not semver: %s", v)
 }


### PR DESCRIPTION
Change `Version()` func to `const Version` string in consistent

Part of https://github.com/open-telemetry/opentelemetry-go-contrib/issues/8272