### PR TITLE
otelgin: update error handling to set attributes instead of recording errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The `Version()` function in `go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin` has been replaced by `const Version`. (#8341)
 - Set `error.type` attribute instead of adding `exception` span events in `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp`. (#8386)
 - Set `error.type` attribute instead of adding `exception` span events in `go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws`. (#8386)
+- Set `error.type` attribute instead of adding `exception` span events in `go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin`. (#8441)
 - The `Version()` function in `go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo` hae been replaced by `const Version`. (#8340)
 - The `Version()` function in `go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc` has been replaced by `const Version`. (#8317)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The `Version()` function in `go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin` has been replaced by `const Version`. (#8341)
 - Set `error.type` attribute instead of adding `exception` span events in `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp`. (#8386)
 - Set `error.type` attribute instead of adding `exception` span events in `go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws`. (#8386)
-- Set `error.type` attribute instead of adding `exception` span events in `go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin`. (#8441)
+- Set `error.type` attribute instead of adding `exception` span events in `go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin`. (#8456)
 - The `Version()` function in `go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo` hae been replaced by `const Version`. (#8340)
 - The `Version()` function in `go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc` has been replaced by `const Version`. (#8317)
 

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/gin_test.go
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/gin_test.go
@@ -203,7 +203,6 @@ func TestError(t *testing.T) {
 	assert.Contains(t, attr, attribute.String("server.address", "foobar"))
 	assert.Contains(t, attr, attribute.Int("http.response.status_code", http.StatusInternalServerError))
 
-	// verify the error.type attribute is set (using first error)
 	firstErr := errors.New("oh no one")
 	assert.Contains(t, attr, semconv.ErrorType(firstErr))
 
@@ -256,7 +255,6 @@ func TestSpanStatus(t *testing.T) {
 
 		require.Len(t, sr.Ended(), 1)
 		assert.Equal(t, codes.Error, sr.Ended()[0].Status().Code)
-		// verify the error.type attribute is set
 		err := errors.New("something went wrong")
 		assert.Contains(t, sr.Ended()[0].Attributes(), semconv.ErrorType(err))
 	})


### PR DESCRIPTION
## Changes

- `gin.go`: 
  - Added import for `go.opentelemetry.io/otel/semconv/v1.37.0`
  - Replaced `span.RecordError()` loop with `span.SetAttributes(otelsemconv.ErrorType(c.Errors[0].Err))`
  - Set `error.type` attribute for the first error when `c.Errors` is not empty
  - Multiple errors are still captured in the status description via `c.Errors.String()`

- `gin_test.go`:
  - Added import for `go.opentelemetry.io/otel/semconv/v1.37.0`
  - Updated `TestError` to verify `error.type` attribute instead of span events
  - Updated `TestSpanStatus` subtest to verify `error.type` attribute instead of span events

## Rationale

According to the [instrumentation README guidelines](https://github.com/open-telemetry/opentelemetry-go-contrib/blob/main/instrumentation/README.md#recording-errors), when an instrumented operation returns a non-nil error:

1. MUST set the span status to `codes.Error` with a description
2. SHOULD also set the `error.type` attribute
3. SHOULD NOT use `span.RecordError(err)` for this purpose

This change provides better consistency across OpenTelemetry instrumentation packages and and follows the semantic conventions for error handling.
