### PR TITLE
otelgrpc: avoid error status for client NotFound

### DIFF
--- a/instrumentation/google.golang.org/grpc/otelgrpc/stats_handler.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/stats_handler.go
@@ -238,9 +238,7 @@ func (h *clientHandler) HandleRPC(ctx context.Context, rs stats.RPCStats) {
 		h.duration.Inst(),
 		h.inSize,
 		h.outSize,
-		func(s *status.Status) (codes.Code, string) {
-			return codes.Error, s.Message()
-		},
+		clientStatus,
 	)
 }
 
@@ -353,4 +351,11 @@ func (c *config) handleRPC(
 	default:
 		return
 	}
+}
+
+func clientStatus(grpcStatus *status.Status) (codes.Code, string) {
+	if grpcStatus.Code() == grpc_codes.NotFound {
+		return codes.Unset, ""
+	}
+	return codes.Error, grpcStatus.Message()
 }


### PR DESCRIPTION
## Summary
- Treat gRPC status NotFound as span status Unset for client stats handlers (the status code attribute is still recorded).
- Add client stats handler tests for NotFound and error cases.

## Rationale
NotFound is frequently used for expected misses (e.g., content-addressable storage, lookup APIs, cache checks). Marking every miss as a span error inflates error rates and makes true failures harder to spot. The RPC response status code attribute and metrics are still recorded, so NotFound remains fully observable without forcing error status.

## Testing
- `go test ./...` (in `instrumentation/google.golang.org/grpc/otelgrpc`)
