### PR TITLE
Fix: flaky gRPC exporter tests in otelconf

### DIFF
--- a/otelconf/log_test.go
+++ b/otelconf/log_test.go
@@ -891,14 +891,13 @@ func startGRPCLogsCollector(t *testing.T, listener net.Listener, serverOptions [
 
 	// Wait for the gRPC server to start accepting connections
 	// to avoid race-related test flakiness.
-	require.Eventually(t, func() bool {
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
 		conn, err := net.DialTimeout("tcp", listener.Addr().String(), 100*time.Millisecond)
-		if err == nil {
-			_ = conn.Close()
-			return true
+		if !assert.NoError(collect, err, "failed to dial gRPC server") {
+			return
 		}
-		return false
-	}, 5*time.Second, 50*time.Millisecond)
+		_ = conn.Close()
+	}, 10*time.Second, 1*time.Second)
 
 	t.Cleanup(func() {
 		srv.GracefulStop()

--- a/otelconf/metric_test.go
+++ b/otelconf/metric_test.go
@@ -1608,14 +1608,13 @@ func startGRPCMetricCollector(t *testing.T, listener net.Listener, serverOptions
 
 	// Wait for the gRPC server to start accepting connections
 	// to avoid race-related test flakiness.
-	require.Eventually(t, func() bool {
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
 		conn, err := net.DialTimeout("tcp", listener.Addr().String(), 100*time.Millisecond)
-		if err == nil {
-			_ = conn.Close()
-			return true
+		if !assert.NoError(collect, err, "failed to dial gRPC server") {
+			return
 		}
-		return false
-	}, 5*time.Second, 50*time.Millisecond)
+		_ = conn.Close()
+	}, 10*time.Second, 1*time.Second)
 
 	t.Cleanup(func() {
 		srv.GracefulStop()

--- a/otelconf/trace_test.go
+++ b/otelconf/trace_test.go
@@ -1050,14 +1050,13 @@ func startGRPCTraceCollector(t *testing.T, listener net.Listener, serverOptions 
 
 	// Wait for the gRPC server to start accepting connections
 	// to avoid race-related test flakiness.
-	require.Eventually(t, func() bool {
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
 		conn, err := net.DialTimeout("tcp", listener.Addr().String(), 100*time.Millisecond)
-		if err == nil {
-			_ = conn.Close()
-			return true
+		if !assert.NoError(collect, err, "failed to dial gRPC server") {
+			return
 		}
-		return false
-	}, 5*time.Second, 50*time.Millisecond)
+		_ = conn.Close()
+	}, 10*time.Second, 1*time.Second)
 
 	t.Cleanup(func() {
 		srv.GracefulStop()

--- a/otelconf/v0.3.0/log_test.go
+++ b/otelconf/v0.3.0/log_test.go
@@ -911,14 +911,13 @@ func startGRPCLogsCollector(t *testing.T, listener net.Listener, serverOptions [
 
 	// Wait for the gRPC server to start accepting connections
 	// to avoid race-related test flakiness.
-	require.Eventually(t, func() bool {
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
 		conn, err := net.DialTimeout("tcp", listener.Addr().String(), 100*time.Millisecond)
-		if err == nil {
-			_ = conn.Close()
-			return true
+		if !assert.NoError(collect, err, "failed to dial gRPC server") {
+			return
 		}
-		return false
-	}, 5*time.Second, 50*time.Millisecond)
+		_ = conn.Close()
+	}, 10*time.Second, 1*time.Second)
 
 	t.Cleanup(func() {
 		srv.GracefulStop()

--- a/otelconf/v0.3.0/metric_test.go
+++ b/otelconf/v0.3.0/metric_test.go
@@ -1755,14 +1755,13 @@ func startGRPCMetricCollector(t *testing.T, listener net.Listener, serverOptions
 
 	// Wait for the gRPC server to start accepting connections
 	// to avoid race-related test flakiness.
-	require.Eventually(t, func() bool {
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
 		conn, err := net.DialTimeout("tcp", listener.Addr().String(), 100*time.Millisecond)
-		if err == nil {
-			_ = conn.Close()
-			return true
+		if !assert.NoError(collect, err, "failed to dial gRPC server") {
+			return
 		}
-		return false
-	}, 5*time.Second, 50*time.Millisecond)
+		_ = conn.Close()
+	}, 10*time.Second, 1*time.Second)
 
 	t.Cleanup(func() {
 		srv.GracefulStop()

--- a/otelconf/v0.3.0/trace_test.go
+++ b/otelconf/v0.3.0/trace_test.go
@@ -1055,14 +1055,13 @@ func startGRPCTraceCollector(t *testing.T, listener net.Listener, serverOptions 
 
 	// Wait for the gRPC server to start accepting connections
 	// to avoid race-related test flakiness.
-	require.Eventually(t, func() bool {
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
 		conn, err := net.DialTimeout("tcp", listener.Addr().String(), 100*time.Millisecond)
-		if err == nil {
-			_ = conn.Close()
-			return true
+		if !assert.NoError(collect, err, "failed to dial gRPC server") {
+			return
 		}
-		return false
-	}, 5*time.Second, 50*time.Millisecond)
+		_ = conn.Close()
+	}, 10*time.Second, 1*time.Second)
 
 	t.Cleanup(func() {
 		srv.GracefulStop()


### PR DESCRIPTION
### Summary

Fix a race condition in the gRPC test helpers (`startGRPCLogsCollector`, `startGRPCTraceCollector`, and `startGRPCMetricCollector`)

The helpers started `srv.Serve` in a goroutine and returned immediately, allowing exporters to attempt connections before the server was ready, leading to intermittent `context deadline exceeded` failures in CI.

### Changes

Add a TCP dial readiness check (`net.DialTimeout` with `require.Eventually`) to ensure the server is accepting connections before returning from the helper.

Fixes #8115
