### PR TITLE
Use the actual subtest's context rather than the main test one

### DIFF
--- a/otelconf/log_test.go
+++ b/otelconf/log_test.go
@@ -834,7 +834,7 @@ func Test_otlpGRPCLogExporter(t *testing.T) {
 
 			startGRPCLogsCollector(t, n, serverOpts)
 
-			exporter, err := otlpGRPCLogExporter(t.Context(), tt.config)
+			exporter, err := otlpGRPCLogExporter(context.Background(), tt.config) //nolint:usetesting // required to avoid getting a canceled context.
 			require.NoError(t, err)
 
 			logFactory := sdklogtest.RecordFactory{
@@ -842,7 +842,7 @@ func Test_otlpGRPCLogExporter(t *testing.T) {
 			}
 
 			assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-				assert.NoError(collect, exporter.Export(t.Context(), []sdklog.Record{
+				assert.NoError(collect, exporter.Export(context.Background(), []sdklog.Record{ //nolint:usetesting // required to avoid getting a canceled context.
 					logFactory.NewRecord(),
 				}))
 			}, 10*time.Second, 1*time.Second)

--- a/otelconf/metric_test.go
+++ b/otelconf/metric_test.go
@@ -1536,7 +1536,7 @@ func Test_otlpGRPCMetricExporter(t *testing.T) {
 
 			startGRPCMetricCollector(t, n, serverOpts)
 
-			exporter, err := otlpGRPCMetricExporter(t.Context(), tt.config)
+			exporter, err := otlpGRPCMetricExporter(context.Background(), tt.config) //nolint:usetesting // required to avoid getting a canceled context.
 			require.NoError(t, err)
 
 			res, err := resource.New(t.Context())

--- a/otelconf/trace_test.go
+++ b/otelconf/trace_test.go
@@ -998,7 +998,7 @@ func Test_otlpGRPCTraceExporter(t *testing.T) {
 
 			startGRPCTraceCollector(t, n, serverOpts)
 
-			exporter, err := otlpGRPCSpanExporter(t.Context(), tt.config)
+			exporter, err := otlpGRPCSpanExporter(context.Background(), tt.config) //nolint:usetesting // required to avoid getting a canceled context.
 			require.NoError(t, err)
 
 			input := tracetest.SpanStubs{

--- a/otelconf/v0.3.0/log_test.go
+++ b/otelconf/v0.3.0/log_test.go
@@ -854,7 +854,7 @@ func Test_otlpGRPCLogExporter(t *testing.T) {
 
 			startGRPCLogsCollector(t, n, serverOpts)
 
-			exporter, err := otlpGRPCLogExporter(t.Context(), tt.config)
+			exporter, err := otlpGRPCLogExporter(context.Background(), tt.config) //nolint:usetesting // required to avoid getting a canceled context.
 			require.NoError(t, err)
 
 			logFactory := sdklogtest.RecordFactory{

--- a/otelconf/v0.3.0/metric_test.go
+++ b/otelconf/v0.3.0/metric_test.go
@@ -1683,7 +1683,7 @@ func Test_otlpGRPCMetricExporter(t *testing.T) {
 
 			startGRPCMetricCollector(t, n, serverOpts)
 
-			exporter, err := otlpGRPCMetricExporter(t.Context(), tt.config)
+			exporter, err := otlpGRPCMetricExporter(context.Background(), tt.config) //nolint:usetesting // required to avoid getting a canceled context.
 			require.NoError(t, err)
 
 			res, err := resource.New(t.Context())

--- a/otelconf/v0.3.0/trace_test.go
+++ b/otelconf/v0.3.0/trace_test.go
@@ -1003,7 +1003,7 @@ func Test_otlpGRPCTraceExporter(t *testing.T) {
 
 			startGRPCTraceCollector(t, n, serverOpts)
 
-			exporter, err := otlpGRPCSpanExporter(t.Context(), tt.config)
+			exporter, err := otlpGRPCSpanExporter(context.Background(), tt.config) //nolint:usetesting // required to avoid getting a canceled context.
 			require.NoError(t, err)
 
 			input := tracetest.SpanStubs{


### PR DESCRIPTION
Those tests share a context, which is passed as the subtest's arguments.
We really don't need to do that, as we always use `t.Context()` anyway.

Also, using the main test's context could be the reason we're seeing the flaky failures described in https://github.com/open-telemetry/opentelemetry-go-contrib/issues/8115, as if another subtest canceled the context, all the remaining ones wouldn't be able to use it.
With this change, each subtest gets its own context.

This also force-stops the collector that gracefully doing so. This is a test environment, we don't really care about finishing ongoing requests, and would rather stop the server quickly.