### PR TITLE
Skip flaky test on macos too

### DIFF
--- a/otelconf/log_test.go
+++ b/otelconf/log_test.go
@@ -737,9 +737,9 @@ func TestLoggerProviderOptions(t *testing.T) {
 }
 
 func Test_otlpGRPCLogExporter(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		// TODO (#7446): Fix the flakiness on Windows.
-		t.Skip("Test is flaky on Windows.")
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		// TODO (#8115): Fix the flakiness on Windows and MacOS.
+		t.Skip("Test is flaky on Windows and MacOS.")
 	}
 	type args struct {
 		ctx        context.Context

--- a/otelconf/metric_test.go
+++ b/otelconf/metric_test.go
@@ -1439,9 +1439,9 @@ func TestPrometheusIPv6(t *testing.T) {
 }
 
 func Test_otlpGRPCMetricExporter(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		// TODO (#7446): Fix the flakiness on Windows.
-		t.Skip("Test is flaky on Windows.")
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		// TODO (#8115): Fix the flakiness on Windows and MacOS.
+		t.Skip("Test is flaky on Windows and MacOS.")
 	}
 	type args struct {
 		ctx        context.Context

--- a/otelconf/trace_test.go
+++ b/otelconf/trace_test.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 	"time"
 
@@ -900,6 +901,10 @@ func TestSampler(t *testing.T) {
 }
 
 func Test_otlpGRPCTraceExporter(t *testing.T) {
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		// TODO (#8115): Fix the flakiness on Windows and MacOS.
+		t.Skip("Test is flaky on Windows and MacOS.")
+	}
 	type args struct {
 		ctx        context.Context
 		otlpConfig *OTLPGrpcExporter

--- a/otelconf/v0.3.0/log_test.go
+++ b/otelconf/v0.3.0/log_test.go
@@ -760,9 +760,9 @@ func TestLoggerProviderOptions(t *testing.T) {
 }
 
 func Test_otlpGRPCLogExporter(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		// TODO (#7446): Fix the flakiness on Windows.
-		t.Skip("Test is flaky on Windows.")
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		// TODO (#8115): Fix the flakiness on Windows and MacOS.
+		t.Skip("Test is flaky on Windows and MacOS.")
 	}
 	type args struct {
 		ctx        context.Context

--- a/otelconf/v0.3.0/metric_test.go
+++ b/otelconf/v0.3.0/metric_test.go
@@ -1589,9 +1589,9 @@ func TestPrometheusReaderConfigurationOptions(t *testing.T) {
 }
 
 func Test_otlpGRPCMetricExporter(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		// TODO (#7446): Fix the flakiness on Windows.
-		t.Skip("Test is flaky on Windows.")
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		// TODO (#8115): Fix the flakiness on Windows and MacOS.
+		t.Skip("Test is flaky on Windows and MacOS.")
 	}
 	type args struct {
 		ctx        context.Context

--- a/otelconf/v0.3.0/trace_test.go
+++ b/otelconf/v0.3.0/trace_test.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 	"time"
 
@@ -908,6 +909,10 @@ func TestSampler(t *testing.T) {
 }
 
 func Test_otlpGRPCTraceExporter(t *testing.T) {
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		// TODO (#8115): Fix the flakiness on Windows and MacOS.
+		t.Skip("Test is flaky on Windows and MacOS.")
+	}
 	type args struct {
 		ctx        context.Context
 		otlpConfig *OTLP


### PR DESCRIPTION
Doing this makes me 😢 , but those flaky tests are really getting out of hand (I've just had to rerun a renovate test suite 10 times).
I see they always fail on macos. So this adds darwin to the skipped OSes.

Very poor man's fix to #8115