### PR TITLE
ci: add govulncheck job to CI workflow and update lint target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       with:
         path: .tools
         key: ${{ runner.os }}-${{ env.cache-name }}-${{ env.DEFAULT_GO_VERSION }}-${{ hashFiles('./tools/**') }}
-      # The step below is needed to not rebuild all the build tools.
+    # The step below is needed to not rebuild all the build tools.
     - name: Set tools/go.mod timestamp
       run: |
         filename="tools/go.mod"
@@ -54,6 +54,37 @@ jobs:
       run: make build
     - name: Check clean repository
       run: make check-clean-work-tree
+
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        fetch-depth: 0 ## Needed for "Set tools/go.mod timestamp" step.
+    - name: Install Go
+      uses: actions/setup-go@v6
+      with:
+        go-version: ${{ env.DEFAULT_GO_VERSION }}
+        check-latest: true
+        cache-dependency-path: "**/go.sum"
+    - name: Tools cache
+      uses: actions/cache@v5
+      env:
+        cache-name: go-tools-cache
+      with:
+        path: .tools
+        key: ${{ runner.os }}-${{ env.cache-name }}-${{ env.DEFAULT_GO_VERSION }}-${{ hashFiles('./tools/**') }}
+    # The step below is needed to not rebuild all the build tools.
+    - name: Set tools/go.mod timestamp
+      run: |
+        filename="tools/go.mod"
+        unixtime=$(git log -1 --format="%at" -- "${filename}")
+        touchtime=$(date -d @$unixtime +'%Y%m%d%H%M.%S')
+        touch -t ${touchtime} "${filename}"
+        ls -la --time-style=full-iso "${filename}"
+    - name: Run govulncheck
+      run: make govulncheck
 
   test-race:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ vanity-import-check: | $(PORTO)
 	@$(PORTO) --include-internal -l . || ( echo "(run: make vanity-import-fix)"; exit 1 )
 
 .PHONY: lint
-lint: go-mod-tidy golangci-lint misspell govulncheck
+lint: go-mod-tidy golangci-lint misspell
 
 .PHONY: toolchain-check
 toolchain-check:


### PR DESCRIPTION
Move govulncheck as a seperate job so that it does not block critical PRs and releasing.