### PR TITLE
fix: propagators/aws/xray: handle ALB headers missing Parent field (#8024)

### DIFF
--- a/propagators/aws/xray/propagator.go
+++ b/propagators/aws/xray/propagator.go
@@ -37,7 +37,7 @@ const (
 
 var (
 	empty                    = trace.SpanContext{}
-	errInvalidTraceHeader    = errors.New("invalid X-Amzn-Trace-Id header value, should contain 3 different part separated by ;")
+	errInvalidTraceHeader    = errors.New("invalid X-Amzn-Trace-Id header value, each field must be a key=value pair separated by ;")
 	errMalformedTraceID      = errors.New("cannot decode trace ID from header")
 	errLengthTraceIDHeader   = errors.New("incorrect length of X-Ray trace ID found, 35 character length expected")
 	errInvalidTraceIDVersion = errors.New("invalid X-Ray trace ID header found, does not have valid trace ID version")
@@ -81,7 +81,8 @@ func (Propagator) Extract(ctx context.Context, carrier propagation.TextMapCarrie
 	// extract tracing information
 	if header := carrier.Get(traceHeaderKey); header != "" {
 		sc, err := extract(header)
-		if err == nil && sc.IsValid() {
+		// AWS ALB may inject a header containing only the Root field without a Parent
+		if err == nil && sc.TraceID().IsValid() {
 			return trace.ContextWithRemoteSpanContext(ctx, sc)
 		}
 	}

--- a/propagators/aws/xray/propagator_test.go
+++ b/propagators/aws/xray/propagator_test.go
@@ -113,6 +113,24 @@ func TestExtract(t *testing.T) {
 			wantSpanID:  "1234567890abcdef",
 			wantSampled: true,
 		},
+		{
+			name:        "ALB header - Root only, no Parent or Sampled",
+			headerVal:   "Root=1-68ef9936-5f4df7cb590e654d2f659b2c",
+			wantValid:   false,
+			wantTraceID: "68ef99365f4df7cb590e654d2f659b2c",
+		},
+		{
+			name:        "ALB header - Root and Sampled, no Parent",
+			headerVal:   "Root=1-68ef9933-777af7c96b4ea44b68a0dca6;Sampled=1",
+			wantValid:   false,
+			wantTraceID: "68ef9933777af7c96b4ea44b68a0dca6",
+		},
+		{
+			name:        "ALB header - Root and Sampled=0, no Parent",
+			headerVal:   "Root=1-68ef992d-214de1ac64b26cc315325ee1;Sampled=0",
+			wantValid:   false,
+			wantTraceID: "68ef992d214de1ac64b26cc315325ee1",
+		},
 	}
 
 	for _, tc := range tests {
@@ -131,15 +149,19 @@ func TestExtract(t *testing.T) {
 				t.Fatalf("expected valid=%v, got %v", tc.wantValid, sc.IsValid())
 			}
 
-			if tc.wantValid {
+			// Check TraceID independently: ALB headers carry only Root (no Parent),
+			// so IsValid() is false but the TraceID must still be propagated.
+			if tc.wantTraceID != "" {
 				if got := sc.TraceID().String(); got != tc.wantTraceID {
 					t.Errorf("expected TraceID %q, got %q", tc.wantTraceID, got)
 				}
+			}
+
+			if tc.wantValid {
 				if got := sc.SpanID().String(); got != tc.wantSpanID {
 					t.Errorf("expected SpanID %q, got %q", tc.wantSpanID, got)
 				}
 				if got := sc.IsSampled(); got != tc.wantSampled {
-					t.Log("name-->> ", tc.name)
 					t.Errorf("expected sampled=%v, got %v", tc.wantSampled, got)
 				}
 			}


### PR DESCRIPTION
AWS ALB injects X-Amzn-Trace-Id with only a Root field when it is the first node in the request chain — no Parent span exists yet.For Example :
 X-Amzn-Trace-Id: Root=1-68ef9936-5f4df7cb590e654d2f659b2c

**Before**
The Extract() method guarded context propagation with sc.IsValid(), which is defined in the OTel SDK as:
`func (sc SpanContext) IsValid() bool {    return sc.HasTraceID() && sc.HasSpanID()  // both must be non-zero}`
Since there is no Parent field in the ALB header, SpanID stays all-zeros after parsing. sc.IsValid() returned false, so the trace context was silently dropped and the downstream service started a completely new unrelated trace — breaking trace continuity.
**After**
Changed the guard to sc.TraceID().IsValid(), which only requires the TraceID to be non-zero:
`if err == nil && sc.TraceID().IsValid() {    return trace.ContextWithRemoteSpanContext(ctx, sc)}`
Now a header carrying only Root is accepted and the TraceID is correctly propagated into the context. The downstream service creates a root span that belongs to the existing ALB-originated trace instead of starting a new one.
**Tests**
Added three test cases covering:
Root only (no Parent, no Sampled)
Root + Sampled=1 (no Parent)
Root + Sampled=0 (no Parent)