### PR TITLE
Check instrument enabled in deprecatedruntime

### DIFF
--- a/instrumentation/runtime/internal/deprecatedruntime/runtime.go
+++ b/instrumentation/runtime/internal/deprecatedruntime/runtime.go
@@ -290,6 +290,9 @@ func recordGCPauses(
 	recorder metric.Int64Histogram,
 	pauses []uint64,
 ) {
+	if !recorder.Enabled(ctx) {
+		return
+	}
 	for _, pause := range pauses {
 		recorder.Record(ctx, clampUint64(pause))
 	}


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-go/issues/7800

There is only one synchronous instrument in deprecatedruntime (and none in runtime). Don't call record if it isn't enabled.

We don't have tests for the deprecatedruntime package, so this change doesn't have test coverage.  But it probably isn't worth it for this change.