### PR TITLE
test(otelconf): replace expiring TLS fixtures with runtime certs

### DIFF
--- a/otelconf/internal/testtls/testtls.go
+++ b/otelconf/internal/testtls/testtls.go
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package testtls provides runtime-generated TLS materials for tests.
-package testtls
+package testtls // import "go.opentelemetry.io/contrib/otelconf/internal/testtls"
 
 import (
 	"crypto/rand"

--- a/otelconf/internal/testtls/testtls.go
+++ b/otelconf/internal/testtls/testtls.go
@@ -1,0 +1,149 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package testtls provides runtime-generated TLS materials for tests.
+package testtls
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Material contains generated CA, server, and client cert file paths.
+type Material struct {
+	CACertPath     string
+	CAKeyPath      string
+	ServerCertPath string
+	ServerKeyPath  string
+	ClientCertPath string
+	ClientKeyPath  string
+}
+
+// TB is the minimal testing surface needed by this helper.
+type TB interface {
+	Helper()
+	TempDir() string
+	Fatalf(format string, args ...any)
+}
+
+// Write generates mTLS assets under t.TempDir so tests do not depend on expiring fixtures.
+func Write(t TB) Material {
+	t.Helper()
+
+	dir := t.TempDir()
+	now := time.Now().UTC()
+
+	caKey := mustRSAKey(t)
+	caTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Country:      []string{"US"},
+			Province:     []string{"California"},
+			Locality:     []string{"San Francisco"},
+			Organization: []string{"OpenTelemetry Test CA"},
+			CommonName:   "otelconf test ca",
+		},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.AddDate(10, 0, 0),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER := mustCertificate(t, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+
+	serverKey := mustRSAKey(t)
+	serverTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(now.UnixNano()),
+		Subject: pkix.Name{
+			Country:      []string{"US"},
+			Province:     []string{"California"},
+			Locality:     []string{"San Francisco"},
+			Organization: []string{"OpenTelemetry Tests"},
+			CommonName:   "localhost",
+		},
+		DNSNames:              []string{"localhost"},
+		IPAddresses:           []net.IP{net.IPv4(127, 0, 0, 1)},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.AddDate(2, 0, 0),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+	serverDER := mustCertificate(t, serverTemplate, caTemplate, &serverKey.PublicKey, caKey)
+
+	clientKey := mustRSAKey(t)
+	clientTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(now.UnixNano() + 1),
+		Subject: pkix.Name{
+			Country:      []string{"US"},
+			Province:     []string{"California"},
+			Locality:     []string{"San Francisco"},
+			Organization: []string{"OpenTelemetry Tests"},
+			CommonName:   "otelconf test client",
+		},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.AddDate(2, 0, 0),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+	}
+	clientDER := mustCertificate(t, clientTemplate, caTemplate, &clientKey.PublicKey, caKey)
+
+	m := Material{
+		CACertPath:     filepath.Join(dir, "ca.crt"),
+		CAKeyPath:      filepath.Join(dir, "ca.key"),
+		ServerCertPath: filepath.Join(dir, "server.crt"),
+		ServerKeyPath:  filepath.Join(dir, "server.key"),
+		ClientCertPath: filepath.Join(dir, "client.crt"),
+		ClientKeyPath:  filepath.Join(dir, "client.key"),
+	}
+	writeCert(t, m.CACertPath, caDER)
+	writeKey(t, m.CAKeyPath, caKey)
+	writeCert(t, m.ServerCertPath, serverDER)
+	writeKey(t, m.ServerKeyPath, serverKey)
+	writeCert(t, m.ClientCertPath, clientDER)
+	writeKey(t, m.ClientKeyPath, clientKey)
+	return m
+}
+
+func mustRSAKey(t TB) *rsa.PrivateKey {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate rsa key: %v", err)
+	}
+	return key
+}
+
+func mustCertificate(t TB, template, parent *x509.Certificate, publicKey *rsa.PublicKey, signer *rsa.PrivateKey) []byte {
+	t.Helper()
+	der, err := x509.CreateCertificate(rand.Reader, template, parent, publicKey, signer)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	return der
+}
+
+func writeCert(t TB, path string, der []byte) {
+	t.Helper()
+	block := &pem.Block{Type: "CERTIFICATE", Bytes: der}
+	if err := os.WriteFile(path, pem.EncodeToMemory(block), 0o600); err != nil {
+		t.Fatalf("write cert %s: %v", path, err)
+	}
+}
+
+func writeKey(t TB, path string, key *rsa.PrivateKey) {
+	t.Helper()
+	block := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}
+	if err := os.WriteFile(path, pem.EncodeToMemory(block), 0o600); err != nil {
+		t.Fatalf("write key %s: %v", path, err)
+	}
+}

--- a/otelconf/internal/testtls/testtls_test.go
+++ b/otelconf/internal/testtls/testtls_test.go
@@ -1,0 +1,69 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package testtls
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"net"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWrite(t *testing.T) {
+	material := Write(t)
+
+	caCert := readCertificate(t, material.CACertPath)
+	serverCert := readCertificate(t, material.ServerCertPath)
+	clientCert := readCertificate(t, material.ClientCertPath)
+
+	_, err := tls.LoadX509KeyPair(material.ServerCertPath, material.ServerKeyPath)
+	require.NoError(t, err)
+
+	_, err = tls.LoadX509KeyPair(material.ClientCertPath, material.ClientKeyPath)
+	require.NoError(t, err)
+
+	require.True(t, caCert.IsCA)
+	require.Equal(t, "otelconf test ca", caCert.Subject.CommonName)
+	require.Equal(t, "localhost", serverCert.Subject.CommonName)
+	require.Equal(t, "otelconf test client", clientCert.Subject.CommonName)
+	require.Equal(t, []string{"localhost"}, serverCert.DNSNames)
+	require.Len(t, serverCert.IPAddresses, 1)
+	require.True(t, serverCert.IPAddresses[0].Equal(net.IPv4(127, 0, 0, 1)))
+	require.Equal(t, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}, serverCert.ExtKeyUsage)
+	require.Equal(t, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}, clientCert.ExtKeyUsage)
+
+	roots := x509.NewCertPool()
+	roots.AddCert(caCert)
+
+	_, err = serverCert.Verify(x509.VerifyOptions{
+		DNSName: "localhost",
+		Roots:   roots,
+	})
+	require.NoError(t, err)
+
+	_, err = clientCert.Verify(x509.VerifyOptions{
+		Roots:     roots,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	})
+	require.NoError(t, err)
+}
+
+func readCertificate(t *testing.T, path string) *x509.Certificate {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	block, _ := pem.Decode(data)
+	require.NotNil(t, block)
+	require.Equal(t, "CERTIFICATE", block.Type)
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err)
+	return cert
+}

--- a/otelconf/log_test.go
+++ b/otelconf/log_test.go
@@ -33,6 +33,8 @@ import (
 	collogpb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+
+	"go.opentelemetry.io/contrib/otelconf/internal/testtls"
 )
 
 func TestLoggerProvider(t *testing.T) {
@@ -820,6 +822,7 @@ func Test_otlpGRPCLogExporter(t *testing.T) {
 		// TODO (#8115): Fix the flakiness on Windows and MacOS.
 		t.Skip("Test is flaky on Windows and MacOS.")
 	}
+	material := testtls.Write(t)
 	type args struct {
 		ctx        context.Context
 		otlpConfig *OTLPGrpcExporter
@@ -856,7 +859,7 @@ func Test_otlpGRPCLogExporter(t *testing.T) {
 					Compression: ptr("gzip"),
 					Timeout:     ptr(5000),
 					Tls: &GrpcTls{
-						CaFile: ptr("testdata/server-certs/server.crt"),
+						CaFile: ptr(material.CACertPath),
 					},
 					Headers: []NameStringValuePair{
 						{Name: "test", Value: ptr("test1")},
@@ -865,7 +868,7 @@ func Test_otlpGRPCLogExporter(t *testing.T) {
 			},
 			grpcServerOpts: func() ([]grpc.ServerOption, error) {
 				opts := []grpc.ServerOption{}
-				tlsCreds, err := credentials.NewServerTLSFromFile("testdata/server-certs/server.crt", "testdata/server-certs/server.key")
+				tlsCreds, err := credentials.NewServerTLSFromFile(material.ServerCertPath, material.ServerKeyPath)
 				if err != nil {
 					return nil, err
 				}
@@ -881,9 +884,9 @@ func Test_otlpGRPCLogExporter(t *testing.T) {
 					Compression: ptr("gzip"),
 					Timeout:     ptr(5000),
 					Tls: &GrpcTls{
-						CaFile:   ptr("testdata/server-certs/server.crt"),
-						KeyFile:  ptr("testdata/client-certs/client.key"),
-						CertFile: ptr("testdata/client-certs/client.crt"),
+						CaFile:   ptr(material.CACertPath),
+						KeyFile:  ptr(material.ClientKeyPath),
+						CertFile: ptr(material.ClientCertPath),
 					},
 					Headers: []NameStringValuePair{
 						{Name: "test", Value: ptr("test1")},
@@ -892,11 +895,11 @@ func Test_otlpGRPCLogExporter(t *testing.T) {
 			},
 			grpcServerOpts: func() ([]grpc.ServerOption, error) {
 				opts := []grpc.ServerOption{}
-				cert, err := tls.LoadX509KeyPair("testdata/server-certs/server.crt", "testdata/server-certs/server.key")
+				cert, err := tls.LoadX509KeyPair(material.ServerCertPath, material.ServerKeyPath)
 				if err != nil {
 					return nil, err
 				}
-				caCert, err := os.ReadFile("testdata/ca.crt")
+				caCert, err := os.ReadFile(material.CACertPath)
 				if err != nil {
 					return nil, err
 				}

--- a/otelconf/metric_test.go
+++ b/otelconf/metric_test.go
@@ -35,6 +35,8 @@ import (
 	v1 "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+
+	"go.opentelemetry.io/contrib/otelconf/internal/testtls"
 )
 
 func TestMeterProvider(t *testing.T) {
@@ -1294,6 +1296,7 @@ func Test_otlpGRPCMetricExporter(t *testing.T) {
 		// TODO (#8115): Fix the flakiness on Windows and MacOS.
 		t.Skip("Test is flaky on Windows and MacOS.")
 	}
+	material := testtls.Write(t)
 	type args struct {
 		ctx        context.Context
 		otlpConfig *OTLPGrpcMetricExporter
@@ -1330,7 +1333,7 @@ func Test_otlpGRPCMetricExporter(t *testing.T) {
 					Compression: ptr("gzip"),
 					Timeout:     ptr(5000),
 					Tls: &GrpcTls{
-						CaFile: ptr("testdata/server-certs/server.crt"),
+						CaFile: ptr(material.CACertPath),
 					},
 					Headers: []NameStringValuePair{
 						{Name: "test", Value: ptr("test1")},
@@ -1339,7 +1342,7 @@ func Test_otlpGRPCMetricExporter(t *testing.T) {
 			},
 			grpcServerOpts: func() ([]grpc.ServerOption, error) {
 				opts := []grpc.ServerOption{}
-				tlsCreds, err := credentials.NewServerTLSFromFile("testdata/server-certs/server.crt", "testdata/server-certs/server.key")
+				tlsCreds, err := credentials.NewServerTLSFromFile(material.ServerCertPath, material.ServerKeyPath)
 				if err != nil {
 					return nil, err
 				}
@@ -1355,9 +1358,9 @@ func Test_otlpGRPCMetricExporter(t *testing.T) {
 					Compression: ptr("gzip"),
 					Timeout:     ptr(5000),
 					Tls: &GrpcTls{
-						CaFile:   ptr("testdata/server-certs/server.crt"),
-						KeyFile:  ptr("testdata/client-certs/client.key"),
-						CertFile: ptr("testdata/client-certs/client.crt"),
+						CaFile:   ptr(material.CACertPath),
+						KeyFile:  ptr(material.ClientKeyPath),
+						CertFile: ptr(material.ClientCertPath),
 					},
 					Headers: []NameStringValuePair{
 						{Name: "test", Value: ptr("test1")},
@@ -1366,11 +1369,11 @@ func Test_otlpGRPCMetricExporter(t *testing.T) {
 			},
 			grpcServerOpts: func() ([]grpc.ServerOption, error) {
 				opts := []grpc.ServerOption{}
-				cert, err := tls.LoadX509KeyPair("testdata/server-certs/server.crt", "testdata/server-certs/server.key")
+				cert, err := tls.LoadX509KeyPair(material.ServerCertPath, material.ServerKeyPath)
 				if err != nil {
 					return nil, err
 				}
-				caCert, err := os.ReadFile("testdata/ca.crt")
+				caCert, err := os.ReadFile(material.CACertPath)
 				if err != nil {
 					return nil, err
 				}

--- a/otelconf/trace_test.go
+++ b/otelconf/trace_test.go
@@ -33,6 +33,8 @@ import (
 	v1 "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+
+	"go.opentelemetry.io/contrib/otelconf/internal/testtls"
 )
 
 func TestTracerProvider(t *testing.T) {
@@ -984,6 +986,7 @@ func Test_otlpGRPCTraceExporter(t *testing.T) {
 		// TODO (#8115): Fix the flakiness on Windows and MacOS.
 		t.Skip("Test is flaky on Windows and MacOS.")
 	}
+	material := testtls.Write(t)
 	type args struct {
 		ctx        context.Context
 		otlpConfig *OTLPGrpcExporter
@@ -1020,7 +1023,7 @@ func Test_otlpGRPCTraceExporter(t *testing.T) {
 					Compression: ptr("gzip"),
 					Timeout:     ptr(5000),
 					Tls: &GrpcTls{
-						CaFile: ptr("testdata/server-certs/server.crt"),
+						CaFile: ptr(material.CACertPath),
 					},
 					Headers: []NameStringValuePair{
 						{Name: "test", Value: ptr("test1")},
@@ -1029,7 +1032,7 @@ func Test_otlpGRPCTraceExporter(t *testing.T) {
 			},
 			grpcServerOpts: func() ([]grpc.ServerOption, error) {
 				opts := []grpc.ServerOption{}
-				tlsCreds, err := credentials.NewServerTLSFromFile("testdata/server-certs/server.crt", "testdata/server-certs/server.key")
+				tlsCreds, err := credentials.NewServerTLSFromFile(material.ServerCertPath, material.ServerKeyPath)
 				if err != nil {
 					return nil, err
 				}
@@ -1045,9 +1048,9 @@ func Test_otlpGRPCTraceExporter(t *testing.T) {
 					Compression: ptr("gzip"),
 					Timeout:     ptr(5000),
 					Tls: &GrpcTls{
-						CaFile:   ptr("testdata/server-certs/server.crt"),
-						KeyFile:  ptr("testdata/client-certs/client.key"),
-						CertFile: ptr("testdata/client-certs/client.crt"),
+						CaFile:   ptr(material.CACertPath),
+						KeyFile:  ptr(material.ClientKeyPath),
+						CertFile: ptr(material.ClientCertPath),
 					},
 					Headers: []NameStringValuePair{
 						{Name: "test", Value: ptr("test1")},
@@ -1056,11 +1059,11 @@ func Test_otlpGRPCTraceExporter(t *testing.T) {
 			},
 			grpcServerOpts: func() ([]grpc.ServerOption, error) {
 				opts := []grpc.ServerOption{}
-				cert, err := tls.LoadX509KeyPair("testdata/server-certs/server.crt", "testdata/server-certs/server.key")
+				cert, err := tls.LoadX509KeyPair(material.ServerCertPath, material.ServerKeyPath)
 				if err != nil {
 					return nil, err
 				}
-				caCert, err := os.ReadFile("testdata/ca.crt")
+				caCert, err := os.ReadFile(material.CACertPath)
 				if err != nil {
 					return nil, err
 				}

--- a/otelconf/v0.3.0/log_test.go
+++ b/otelconf/v0.3.0/log_test.go
@@ -33,6 +33,8 @@ import (
 	collogpb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+
+	"go.opentelemetry.io/contrib/otelconf/internal/testtls"
 )
 
 func TestLoggerProvider(t *testing.T) {
@@ -764,6 +766,7 @@ func Test_otlpGRPCLogExporter(t *testing.T) {
 		// TODO (#8115): Fix the flakiness on Windows and MacOS.
 		t.Skip("Test is flaky on Windows and MacOS.")
 	}
+	material := testtls.Write(t)
 	type args struct {
 		ctx        context.Context
 		otlpConfig *OTLP
@@ -799,7 +802,7 @@ func Test_otlpGRPCLogExporter(t *testing.T) {
 					Protocol:    ptr("grpc"),
 					Compression: ptr("gzip"),
 					Timeout:     ptr(5000),
-					Certificate: ptr("testdata/server-certs/server.crt"),
+					Certificate: ptr(material.CACertPath),
 					Headers: []NameStringValuePair{
 						{Name: "test", Value: ptr("test1")},
 					},
@@ -807,7 +810,7 @@ func Test_otlpGRPCLogExporter(t *testing.T) {
 			},
 			grpcServerOpts: func() ([]grpc.ServerOption, error) {
 				opts := []grpc.ServerOption{}
-				tlsCreds, err := credentials.NewServerTLSFromFile("testdata/server-certs/server.crt", "testdata/server-certs/server.key")
+				tlsCreds, err := credentials.NewServerTLSFromFile(material.ServerCertPath, material.ServerKeyPath)
 				if err != nil {
 					return nil, err
 				}
@@ -823,9 +826,9 @@ func Test_otlpGRPCLogExporter(t *testing.T) {
 					Protocol:          ptr("grpc"),
 					Compression:       ptr("gzip"),
 					Timeout:           ptr(5000),
-					Certificate:       ptr("testdata/server-certs/server.crt"),
-					ClientKey:         ptr("testdata/client-certs/client.key"),
-					ClientCertificate: ptr("testdata/client-certs/client.crt"),
+					Certificate:       ptr(material.CACertPath),
+					ClientKey:         ptr(material.ClientKeyPath),
+					ClientCertificate: ptr(material.ClientCertPath),
 					Headers: []NameStringValuePair{
 						{Name: "test", Value: ptr("test1")},
 					},
@@ -833,11 +836,11 @@ func Test_otlpGRPCLogExporter(t *testing.T) {
 			},
 			grpcServerOpts: func() ([]grpc.ServerOption, error) {
 				opts := []grpc.ServerOption{}
-				cert, err := tls.LoadX509KeyPair("testdata/server-certs/server.crt", "testdata/server-certs/server.key")
+				cert, err := tls.LoadX509KeyPair(material.ServerCertPath, material.ServerKeyPath)
 				if err != nil {
 					return nil, err
 				}
-				caCert, err := os.ReadFile("testdata/ca.crt")
+				caCert, err := os.ReadFile(material.CACertPath)
 				if err != nil {
 					return nil, err
 				}

--- a/otelconf/v0.3.0/metric_test.go
+++ b/otelconf/v0.3.0/metric_test.go
@@ -37,6 +37,8 @@ import (
 	v1 "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+
+	"go.opentelemetry.io/contrib/otelconf/internal/testtls"
 )
 
 func TestMeterProvider(t *testing.T) {
@@ -1641,6 +1643,7 @@ func Test_otlpGRPCMetricExporter(t *testing.T) {
 		// TODO (#8115): Fix the flakiness on Windows and MacOS.
 		t.Skip("Test is flaky on Windows and MacOS.")
 	}
+	material := testtls.Write(t)
 	type args struct {
 		ctx        context.Context
 		otlpConfig *OTLPMetric
@@ -1676,7 +1679,7 @@ func Test_otlpGRPCMetricExporter(t *testing.T) {
 					Protocol:    ptr("grpc"),
 					Compression: ptr("gzip"),
 					Timeout:     ptr(5000),
-					Certificate: ptr("testdata/server-certs/server.crt"),
+					Certificate: ptr(material.CACertPath),
 					Headers: []NameStringValuePair{
 						{Name: "test", Value: ptr("test1")},
 					},
@@ -1684,7 +1687,7 @@ func Test_otlpGRPCMetricExporter(t *testing.T) {
 			},
 			grpcServerOpts: func() ([]grpc.ServerOption, error) {
 				opts := []grpc.ServerOption{}
-				tlsCreds, err := credentials.NewServerTLSFromFile("testdata/server-certs/server.crt", "testdata/server-certs/server.key")
+				tlsCreds, err := credentials.NewServerTLSFromFile(material.ServerCertPath, material.ServerKeyPath)
 				if err != nil {
 					return nil, err
 				}
@@ -1700,9 +1703,9 @@ func Test_otlpGRPCMetricExporter(t *testing.T) {
 					Protocol:          ptr("grpc"),
 					Compression:       ptr("gzip"),
 					Timeout:           ptr(5000),
-					Certificate:       ptr("testdata/server-certs/server.crt"),
-					ClientKey:         ptr("testdata/client-certs/client.key"),
-					ClientCertificate: ptr("testdata/client-certs/client.crt"),
+					Certificate:       ptr(material.CACertPath),
+					ClientKey:         ptr(material.ClientKeyPath),
+					ClientCertificate: ptr(material.ClientCertPath),
 					Headers: []NameStringValuePair{
 						{Name: "test", Value: ptr("test1")},
 					},
@@ -1710,11 +1713,11 @@ func Test_otlpGRPCMetricExporter(t *testing.T) {
 			},
 			grpcServerOpts: func() ([]grpc.ServerOption, error) {
 				opts := []grpc.ServerOption{}
-				cert, err := tls.LoadX509KeyPair("testdata/server-certs/server.crt", "testdata/server-certs/server.key")
+				cert, err := tls.LoadX509KeyPair(material.ServerCertPath, material.ServerKeyPath)
 				if err != nil {
 					return nil, err
 				}
-				caCert, err := os.ReadFile("testdata/ca.crt")
+				caCert, err := os.ReadFile(material.CACertPath)
 				if err != nil {
 					return nil, err
 				}

--- a/otelconf/v0.3.0/trace_test.go
+++ b/otelconf/v0.3.0/trace_test.go
@@ -33,6 +33,8 @@ import (
 	v1 "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+
+	"go.opentelemetry.io/contrib/otelconf/internal/testtls"
 )
 
 func TestTracerProvider(t *testing.T) {
@@ -913,6 +915,7 @@ func Test_otlpGRPCTraceExporter(t *testing.T) {
 		// TODO (#8115): Fix the flakiness on Windows and MacOS.
 		t.Skip("Test is flaky on Windows and MacOS.")
 	}
+	material := testtls.Write(t)
 	type args struct {
 		ctx        context.Context
 		otlpConfig *OTLP
@@ -948,7 +951,7 @@ func Test_otlpGRPCTraceExporter(t *testing.T) {
 					Protocol:    ptr("grpc"),
 					Compression: ptr("gzip"),
 					Timeout:     ptr(5000),
-					Certificate: ptr("testdata/server-certs/server.crt"),
+					Certificate: ptr(material.CACertPath),
 					Headers: []NameStringValuePair{
 						{Name: "test", Value: ptr("test1")},
 					},
@@ -956,7 +959,7 @@ func Test_otlpGRPCTraceExporter(t *testing.T) {
 			},
 			grpcServerOpts: func() ([]grpc.ServerOption, error) {
 				opts := []grpc.ServerOption{}
-				tlsCreds, err := credentials.NewServerTLSFromFile("testdata/server-certs/server.crt", "testdata/server-certs/server.key")
+				tlsCreds, err := credentials.NewServerTLSFromFile(material.ServerCertPath, material.ServerKeyPath)
 				if err != nil {
 					return nil, err
 				}
@@ -972,9 +975,9 @@ func Test_otlpGRPCTraceExporter(t *testing.T) {
 					Protocol:          ptr("grpc"),
 					Compression:       ptr("gzip"),
 					Timeout:           ptr(5000),
-					Certificate:       ptr("testdata/server-certs/server.crt"),
-					ClientKey:         ptr("testdata/client-certs/client.key"),
-					ClientCertificate: ptr("testdata/client-certs/client.crt"),
+					Certificate:       ptr(material.CACertPath),
+					ClientKey:         ptr(material.ClientKeyPath),
+					ClientCertificate: ptr(material.ClientCertPath),
 					Headers: []NameStringValuePair{
 						{Name: "test", Value: ptr("test1")},
 					},
@@ -982,11 +985,11 @@ func Test_otlpGRPCTraceExporter(t *testing.T) {
 			},
 			grpcServerOpts: func() ([]grpc.ServerOption, error) {
 				opts := []grpc.ServerOption{}
-				cert, err := tls.LoadX509KeyPair("testdata/server-certs/server.crt", "testdata/server-certs/server.key")
+				cert, err := tls.LoadX509KeyPair(material.ServerCertPath, material.ServerKeyPath)
 				if err != nil {
 					return nil, err
 				}
-				caCert, err := os.ReadFile("testdata/ca.crt")
+				caCert, err := os.ReadFile(material.CACertPath)
 				if err != nil {
 					return nil, err
 				}

--- a/otelconf/x/log_test.go
+++ b/otelconf/x/log_test.go
@@ -33,6 +33,8 @@ import (
 	collogpb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+
+	"go.opentelemetry.io/contrib/otelconf/internal/testtls"
 )
 
 func TestLoggerProvider(t *testing.T) {
@@ -759,6 +761,7 @@ func Test_otlpGRPCLogExporter(t *testing.T) {
 		// TODO (#7446): Fix the flakiness on Windows.
 		t.Skip("Test is flaky on Windows.")
 	}
+	material := testtls.Write(t)
 	type args struct {
 		ctx        context.Context
 		otlpConfig *OTLPGrpcExporter
@@ -795,7 +798,7 @@ func Test_otlpGRPCLogExporter(t *testing.T) {
 					Compression: ptr("gzip"),
 					Timeout:     ptr(5000),
 					Tls: &GrpcTls{
-						CaFile: ptr("../testdata/server-certs/server.crt"),
+						CaFile: ptr(material.CACertPath),
 					},
 					Headers: []NameStringValuePair{
 						{Name: "test", Value: ptr("test1")},
@@ -804,7 +807,7 @@ func Test_otlpGRPCLogExporter(t *testing.T) {
 			},
 			grpcServerOpts: func() ([]grpc.ServerOption, error) {
 				opts := []grpc.ServerOption{}
-				tlsCreds, err := credentials.NewServerTLSFromFile("../testdata/server-certs/server.crt", "../testdata/server-certs/server.key")
+				tlsCreds, err := credentials.NewServerTLSFromFile(material.ServerCertPath, material.ServerKeyPath)
 				if err != nil {
 					return nil, err
 				}
@@ -820,9 +823,9 @@ func Test_otlpGRPCLogExporter(t *testing.T) {
 					Compression: ptr("gzip"),
 					Timeout:     ptr(5000),
 					Tls: &GrpcTls{
-						CaFile:   ptr("../testdata/server-certs/server.crt"),
-						KeyFile:  ptr("../testdata/client-certs/client.key"),
-						CertFile: ptr("../testdata/client-certs/client.crt"),
+						CaFile:   ptr(material.CACertPath),
+						KeyFile:  ptr(material.ClientKeyPath),
+						CertFile: ptr(material.ClientCertPath),
 					},
 					Headers: []NameStringValuePair{
 						{Name: "test", Value: ptr("test1")},
@@ -831,11 +834,11 @@ func Test_otlpGRPCLogExporter(t *testing.T) {
 			},
 			grpcServerOpts: func() ([]grpc.ServerOption, error) {
 				opts := []grpc.ServerOption{}
-				cert, err := tls.LoadX509KeyPair("../testdata/server-certs/server.crt", "../testdata/server-certs/server.key")
+				cert, err := tls.LoadX509KeyPair(material.ServerCertPath, material.ServerKeyPath)
 				if err != nil {
 					return nil, err
 				}
-				caCert, err := os.ReadFile("../testdata/ca.crt")
+				caCert, err := os.ReadFile(material.CACertPath)
 				if err != nil {
 					return nil, err
 				}

--- a/otelconf/x/metric_test.go
+++ b/otelconf/x/metric_test.go
@@ -37,6 +37,8 @@ import (
 	v1 "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+
+	"go.opentelemetry.io/contrib/otelconf/internal/testtls"
 )
 
 func TestMeterProvider(t *testing.T) {
@@ -1460,6 +1462,7 @@ func Test_otlpGRPCMetricExporter(t *testing.T) {
 		// TODO (#7446): Fix the flakiness on Windows.
 		t.Skip("Test is flaky on Windows.")
 	}
+	material := testtls.Write(t)
 	type args struct {
 		ctx        context.Context
 		otlpConfig *OTLPGrpcMetricExporter
@@ -1496,7 +1499,7 @@ func Test_otlpGRPCMetricExporter(t *testing.T) {
 					Compression: ptr("gzip"),
 					Timeout:     ptr(5000),
 					Tls: &GrpcTls{
-						CaFile: ptr("../testdata/server-certs/server.crt"),
+						CaFile: ptr(material.CACertPath),
 					},
 					Headers: []NameStringValuePair{
 						{Name: "test", Value: ptr("test1")},
@@ -1505,7 +1508,7 @@ func Test_otlpGRPCMetricExporter(t *testing.T) {
 			},
 			grpcServerOpts: func() ([]grpc.ServerOption, error) {
 				opts := []grpc.ServerOption{}
-				tlsCreds, err := credentials.NewServerTLSFromFile("../testdata/server-certs/server.crt", "../testdata/server-certs/server.key")
+				tlsCreds, err := credentials.NewServerTLSFromFile(material.ServerCertPath, material.ServerKeyPath)
 				if err != nil {
 					return nil, err
 				}
@@ -1521,9 +1524,9 @@ func Test_otlpGRPCMetricExporter(t *testing.T) {
 					Compression: ptr("gzip"),
 					Timeout:     ptr(5000),
 					Tls: &GrpcTls{
-						CaFile:   ptr("../testdata/server-certs/server.crt"),
-						KeyFile:  ptr("../testdata/client-certs/client.key"),
-						CertFile: ptr("../testdata/client-certs/client.crt"),
+						CaFile:   ptr(material.CACertPath),
+						KeyFile:  ptr(material.ClientKeyPath),
+						CertFile: ptr(material.ClientCertPath),
 					},
 					Headers: []NameStringValuePair{
 						{Name: "test", Value: ptr("test1")},
@@ -1532,11 +1535,11 @@ func Test_otlpGRPCMetricExporter(t *testing.T) {
 			},
 			grpcServerOpts: func() ([]grpc.ServerOption, error) {
 				opts := []grpc.ServerOption{}
-				cert, err := tls.LoadX509KeyPair("../testdata/server-certs/server.crt", "../testdata/server-certs/server.key")
+				cert, err := tls.LoadX509KeyPair(material.ServerCertPath, material.ServerKeyPath)
 				if err != nil {
 					return nil, err
 				}
-				caCert, err := os.ReadFile("../testdata/ca.crt")
+				caCert, err := os.ReadFile(material.CACertPath)
 				if err != nil {
 					return nil, err
 				}

--- a/otelconf/x/trace_test.go
+++ b/otelconf/x/trace_test.go
@@ -32,6 +32,8 @@ import (
 	v1 "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+
+	"go.opentelemetry.io/contrib/otelconf/internal/testtls"
 )
 
 func TestTracerProvider(t *testing.T) {
@@ -918,6 +920,7 @@ func TestSampler(t *testing.T) {
 }
 
 func Test_otlpGRPCTraceExporter(t *testing.T) {
+	material := testtls.Write(t)
 	type args struct {
 		ctx        context.Context
 		otlpConfig *OTLPGrpcExporter
@@ -954,7 +957,7 @@ func Test_otlpGRPCTraceExporter(t *testing.T) {
 					Compression: ptr("gzip"),
 					Timeout:     ptr(5000),
 					Tls: &GrpcTls{
-						CaFile: ptr("../testdata/server-certs/server.crt"),
+						CaFile: ptr(material.CACertPath),
 					},
 					Headers: []NameStringValuePair{
 						{Name: "test", Value: ptr("test1")},
@@ -963,7 +966,7 @@ func Test_otlpGRPCTraceExporter(t *testing.T) {
 			},
 			grpcServerOpts: func() ([]grpc.ServerOption, error) {
 				opts := []grpc.ServerOption{}
-				tlsCreds, err := credentials.NewServerTLSFromFile("../testdata/server-certs/server.crt", "../testdata/server-certs/server.key")
+				tlsCreds, err := credentials.NewServerTLSFromFile(material.ServerCertPath, material.ServerKeyPath)
 				if err != nil {
 					return nil, err
 				}
@@ -979,9 +982,9 @@ func Test_otlpGRPCTraceExporter(t *testing.T) {
 					Compression: ptr("gzip"),
 					Timeout:     ptr(5000),
 					Tls: &GrpcTls{
-						CaFile:   ptr("../testdata/server-certs/server.crt"),
-						KeyFile:  ptr("../testdata/client-certs/client.key"),
-						CertFile: ptr("../testdata/client-certs/client.crt"),
+						CaFile:   ptr(material.CACertPath),
+						KeyFile:  ptr(material.ClientKeyPath),
+						CertFile: ptr(material.ClientCertPath),
 					},
 					Headers: []NameStringValuePair{
 						{Name: "test", Value: ptr("test1")},
@@ -990,11 +993,11 @@ func Test_otlpGRPCTraceExporter(t *testing.T) {
 			},
 			grpcServerOpts: func() ([]grpc.ServerOption, error) {
 				opts := []grpc.ServerOption{}
-				cert, err := tls.LoadX509KeyPair("../testdata/server-certs/server.crt", "../testdata/server-certs/server.key")
+				cert, err := tls.LoadX509KeyPair(material.ServerCertPath, material.ServerKeyPath)
 				if err != nil {
 					return nil, err
 				}
-				caCert, err := os.ReadFile("../testdata/ca.crt")
+				caCert, err := os.ReadFile(material.CACertPath)
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
## Summary
This fixes the repo-wide CI failures caused by expired `otelconf` TLS test certificates.

The failing gRPC exporter tests in `otelconf`, `otelconf/x`, and `otelconf/v0.3.0` were using static PEM fixtures that expired on April 15, 2026, which caused `main` and unrelated PRs to start failing with x509 certificate validity errors.

This change replaces those expiring test fixtures with runtime-generated CA, server, and client certificates created under `t.TempDir()`.

## Changes
- add a shared `otelconf/internal/testtls` helper to generate fresh test-only TLS materials at runtime
- update the gRPC log, metric, and trace exporter TLS tests in `otelconf`
- update the same TLS tests in `otelconf/x`
- update the same TLS tests in `otelconf/v0.3.0`

## Why this approach
Refreshing the checked-in PEM files would only defer the outage until the next expiry date. Generating certificates during the test run removes the calendar dependency while preserving the TLS and mTLS coverage those tests are meant to exercise.

## Verification
- `go test ./... -run "^Test_otlpGRPC(Log|Metric|Trace)Exporter$"` from `otelconf/`
- reran the same focused exporter suite with `GOARCH=386`

Both focused runs passed after the change.