### PR TITLE
feat(instrumentation): http server span supports url query

### DIFF
--- a/instrumentation/github.com/emicklei/go-restful/otelrestful/internal/semconv/httpconvtest_test.go
+++ b/instrumentation/github.com/emicklei/go-restful/otelrestful/internal/semconv/httpconvtest_test.go
@@ -40,6 +40,7 @@ func TestNewTraceRequest(t *testing.T) {
 			attribute.String("client.address", req.clientIP),
 			attribute.String("network.protocol.version", "1.1"),
 			attribute.String("url.path", "/"),
+			attribute.String("url.query", ""),
 		}
 	}
 	testTraceRequest(t, serv, want)

--- a/instrumentation/github.com/emicklei/go-restful/otelrestful/internal/semconv/server.go
+++ b/instrumentation/github.com/emicklei/go-restful/otelrestful/internal/semconv/server.go
@@ -201,6 +201,24 @@ func (n HTTPServer) RequestTraceAttrs(server string, req *http.Request, opts Req
 	if req.URL != nil && req.URL.Path != "" {
 		attrs = append(attrs, semconv.URLPath(req.URL.Path))
 	}
+	
+	if req.URL != nil && req.URL.Query() != nil {
+		query := req.URL.Query()
+		sensitiveKeys := map[string]struct{}{
+			"AWSAccessKeyId":   {},
+			"Signature":        {},
+			"sig":              {},
+			"X-Goog-Signature": {},
+		}
+
+		for key := range query {
+			if _, isSensitive := sensitiveKeys[key]; isSensitive {
+				query.Set(key, "REDACTED")
+			}
+		}
+
+		attrs = append(attrs, semconv.URLQuery(query.Encode()))
+	}
 
 	if protoName != "" && protoName != "http" {
 		attrs = append(attrs, semconv.NetworkProtocolName(protoName))

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/internal/semconv/httpconvtest_test.go
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/internal/semconv/httpconvtest_test.go
@@ -40,6 +40,7 @@ func TestNewTraceRequest(t *testing.T) {
 			attribute.String("client.address", req.clientIP),
 			attribute.String("network.protocol.version", "1.1"),
 			attribute.String("url.path", "/"),
+			attribute.String("url.query", ""),
 		}
 	}
 	testTraceRequest(t, serv, want)

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/internal/semconv/server.go
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/internal/semconv/server.go
@@ -201,6 +201,24 @@ func (n HTTPServer) RequestTraceAttrs(server string, req *http.Request, opts Req
 	if req.URL != nil && req.URL.Path != "" {
 		attrs = append(attrs, semconv.URLPath(req.URL.Path))
 	}
+	
+	if req.URL != nil && req.URL.Query() != nil {
+		query := req.URL.Query()
+		sensitiveKeys := map[string]struct{}{
+			"AWSAccessKeyId":   {},
+			"Signature":        {},
+			"sig":              {},
+			"X-Goog-Signature": {},
+		}
+
+		for key := range query {
+			if _, isSensitive := sensitiveKeys[key]; isSensitive {
+				query.Set(key, "REDACTED")
+			}
+		}
+
+		attrs = append(attrs, semconv.URLQuery(query.Encode()))
+	}
 
 	if protoName != "" && protoName != "http" {
 		attrs = append(attrs, semconv.NetworkProtocolName(protoName))

--- a/instrumentation/github.com/gorilla/mux/otelmux/internal/semconv/httpconvtest_test.go
+++ b/instrumentation/github.com/gorilla/mux/otelmux/internal/semconv/httpconvtest_test.go
@@ -40,6 +40,7 @@ func TestNewTraceRequest(t *testing.T) {
 			attribute.String("client.address", req.clientIP),
 			attribute.String("network.protocol.version", "1.1"),
 			attribute.String("url.path", "/"),
+			attribute.String("url.query", ""),
 		}
 	}
 	testTraceRequest(t, serv, want)

--- a/instrumentation/github.com/gorilla/mux/otelmux/internal/semconv/server.go
+++ b/instrumentation/github.com/gorilla/mux/otelmux/internal/semconv/server.go
@@ -201,6 +201,24 @@ func (n HTTPServer) RequestTraceAttrs(server string, req *http.Request, opts Req
 	if req.URL != nil && req.URL.Path != "" {
 		attrs = append(attrs, semconv.URLPath(req.URL.Path))
 	}
+	
+	if req.URL != nil && req.URL.Query() != nil {
+		query := req.URL.Query()
+		sensitiveKeys := map[string]struct{}{
+			"AWSAccessKeyId":   {},
+			"Signature":        {},
+			"sig":              {},
+			"X-Goog-Signature": {},
+		}
+
+		for key := range query {
+			if _, isSensitive := sensitiveKeys[key]; isSensitive {
+				query.Set(key, "REDACTED")
+			}
+		}
+
+		attrs = append(attrs, semconv.URLQuery(query.Encode()))
+	}
 
 	if protoName != "" && protoName != "http" {
 		attrs = append(attrs, semconv.NetworkProtocolName(protoName))

--- a/instrumentation/github.com/labstack/echo/otelecho/internal/semconv/httpconvtest_test.go
+++ b/instrumentation/github.com/labstack/echo/otelecho/internal/semconv/httpconvtest_test.go
@@ -40,6 +40,7 @@ func TestNewTraceRequest(t *testing.T) {
 			attribute.String("client.address", req.clientIP),
 			attribute.String("network.protocol.version", "1.1"),
 			attribute.String("url.path", "/"),
+			attribute.String("url.query", ""),
 		}
 	}
 	testTraceRequest(t, serv, want)

--- a/instrumentation/github.com/labstack/echo/otelecho/internal/semconv/server.go
+++ b/instrumentation/github.com/labstack/echo/otelecho/internal/semconv/server.go
@@ -201,6 +201,24 @@ func (n HTTPServer) RequestTraceAttrs(server string, req *http.Request, opts Req
 	if req.URL != nil && req.URL.Path != "" {
 		attrs = append(attrs, semconv.URLPath(req.URL.Path))
 	}
+	
+	if req.URL != nil && req.URL.Query() != nil {
+		query := req.URL.Query()
+		sensitiveKeys := map[string]struct{}{
+			"AWSAccessKeyId":   {},
+			"Signature":        {},
+			"sig":              {},
+			"X-Goog-Signature": {},
+		}
+
+		for key := range query {
+			if _, isSensitive := sensitiveKeys[key]; isSensitive {
+				query.Set(key, "REDACTED")
+			}
+		}
+
+		attrs = append(attrs, semconv.URLQuery(query.Encode()))
+	}
 
 	if protoName != "" && protoName != "http" {
 		attrs = append(attrs, semconv.NetworkProtocolName(protoName))

--- a/instrumentation/net/http/httptrace/otelhttptrace/httptrace_test.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/httptrace_test.go
@@ -80,6 +80,7 @@ func TestRoundtrip(t *testing.T) {
 		"server.address":           "127.0.0.1",
 		"server.port":              hp[1],
 		"url.path":                 "/",
+		"url.query":                "",
 		"url.scheme":               "http",
 		"user_agent.original":      "Go-http-client/1.1",
 	}

--- a/instrumentation/net/http/httptrace/otelhttptrace/internal/semconv/httpconvtest_test.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/internal/semconv/httpconvtest_test.go
@@ -40,6 +40,7 @@ func TestNewTraceRequest(t *testing.T) {
 			attribute.String("client.address", req.clientIP),
 			attribute.String("network.protocol.version", "1.1"),
 			attribute.String("url.path", "/"),
+			attribute.String("url.query", ""),
 		}
 	}
 	testTraceRequest(t, serv, want)

--- a/instrumentation/net/http/httptrace/otelhttptrace/internal/semconv/server.go
+++ b/instrumentation/net/http/httptrace/otelhttptrace/internal/semconv/server.go
@@ -201,6 +201,24 @@ func (n HTTPServer) RequestTraceAttrs(server string, req *http.Request, opts Req
 	if req.URL != nil && req.URL.Path != "" {
 		attrs = append(attrs, semconv.URLPath(req.URL.Path))
 	}
+	
+	if req.URL != nil && req.URL.Query() != nil {
+		query := req.URL.Query()
+		sensitiveKeys := map[string]struct{}{
+			"AWSAccessKeyId":   {},
+			"Signature":        {},
+			"sig":              {},
+			"X-Goog-Signature": {},
+		}
+
+		for key := range query {
+			if _, isSensitive := sensitiveKeys[key]; isSensitive {
+				query.Set(key, "REDACTED")
+			}
+		}
+
+		attrs = append(attrs, semconv.URLQuery(query.Encode()))
+	}
 
 	if protoName != "" && protoName != "http" {
 		attrs = append(attrs, semconv.NetworkProtocolName(protoName))

--- a/instrumentation/net/http/otelhttp/internal/semconv/httpconvtest_test.go
+++ b/instrumentation/net/http/otelhttp/internal/semconv/httpconvtest_test.go
@@ -40,6 +40,7 @@ func TestNewTraceRequest(t *testing.T) {
 			attribute.String("client.address", req.clientIP),
 			attribute.String("network.protocol.version", "1.1"),
 			attribute.String("url.path", "/"),
+			attribute.String("url.query", ""),
 		}
 	}
 	testTraceRequest(t, serv, want)

--- a/instrumentation/net/http/otelhttp/internal/semconv/server.go
+++ b/instrumentation/net/http/otelhttp/internal/semconv/server.go
@@ -201,6 +201,24 @@ func (n HTTPServer) RequestTraceAttrs(server string, req *http.Request, opts Req
 	if req.URL != nil && req.URL.Path != "" {
 		attrs = append(attrs, semconv.URLPath(req.URL.Path))
 	}
+	
+	if req.URL != nil && req.URL.Query() != nil {
+		query := req.URL.Query()
+		sensitiveKeys := map[string]struct{}{
+			"AWSAccessKeyId":   {},
+			"Signature":        {},
+			"sig":              {},
+			"X-Goog-Signature": {},
+		}
+
+		for key := range query {
+			if _, isSensitive := sensitiveKeys[key]; isSensitive {
+				query.Set(key, "REDACTED")
+			}
+		}
+
+		attrs = append(attrs, semconv.URLQuery(query.Encode()))
+	}
 
 	if protoName != "" && protoName != "http" {
 		attrs = append(attrs, semconv.NetworkProtocolName(protoName))

--- a/internal/shared/semconv/httpconvtest_test.go.tmpl
+++ b/internal/shared/semconv/httpconvtest_test.go.tmpl
@@ -40,6 +40,7 @@ func TestNewTraceRequest(t *testing.T) {
 			attribute.String("client.address", req.clientIP),
 			attribute.String("network.protocol.version", "1.1"),
 			attribute.String("url.path", "/"),
+			attribute.String("url.query", ""),
 		}
 	}
 	testTraceRequest(t, serv, want)

--- a/internal/shared/semconv/server.go.tmpl
+++ b/internal/shared/semconv/server.go.tmpl
@@ -201,6 +201,24 @@ func (n HTTPServer) RequestTraceAttrs(server string, req *http.Request, opts Req
 	if req.URL != nil && req.URL.Path != "" {
 		attrs = append(attrs, semconv.URLPath(req.URL.Path))
 	}
+	
+	if req.URL != nil && req.URL.Query() != nil {
+		query := req.URL.Query()
+		sensitiveKeys := map[string]struct{}{
+			"AWSAccessKeyId":   {},
+			"Signature":        {},
+			"sig":              {},
+			"X-Goog-Signature": {},
+		}
+
+		for key := range query {
+			if _, isSensitive := sensitiveKeys[key]; isSensitive {
+				query.Set(key, "REDACTED")
+			}
+		}
+
+		attrs = append(attrs, semconv.URLQuery(query.Encode()))
+	}
 
 	if protoName != "" && protoName != "http" {
 		attrs = append(attrs, semconv.NetworkProtocolName(protoName))


### PR DESCRIPTION
Fixes #8867 

This pull request enhances HTTP server instrumentation across multiple packages by adding support for capturing the `url.query` attribute in trace data, while also redacting sensitive query parameters. The changes ensure consistency in both production code and tests, and improve security by preventing sensitive data from being logged.

Key changes include:

**Security and Trace Attribute Improvements:**

* Updated the `RequestTraceAttrs` function in several HTTP server instrumentation packages (including `go-restful`, `gin-gonic`, `gorilla/mux`, `labstack/echo`, and standard library HTTP) to add the `url.query` attribute to trace spans. Sensitive query parameters such as `AWSAccessKeyId`, `Signature`, `sig`, and `X-Goog-Signature` are now redacted before being recorded. 

**Testing Consistency:**

* Modified test files in all affected packages to expect the new `url.query` attribute, ensuring test coverage for the updated trace data. 

These changes provide better visibility into HTTP requests while protecting sensitive information in query parameters.