### PR TITLE
otelmux: add WithSpanOptions to support custom span start attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Add `error.type` attribute to `http.client.request.duration` for transport failures in `otelhttp`. (#8801)
 - Add examples for prometheus compatibility document. (#8716)
+- Add `WithSpanOptions` to support custom span start attributes in `otelmux`. (#8854)
 
 ### Changed
 

--- a/instrumentation/github.com/gorilla/mux/otelmux/config.go
+++ b/instrumentation/github.com/gorilla/mux/otelmux/config.go
@@ -9,7 +9,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/propagation"
-	"go.opentelemetry.io/otel/trace"
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
@@ -23,7 +22,7 @@ type config struct {
 	Filters            []Filter
 	MeterProvider      metric.MeterProvider
 	MetricAttributesFn func(*http.Request) []attribute.KeyValue
-	SpanStartOptions   []trace.SpanStartOption
+	SpanStartOptions   []oteltrace.SpanStartOption
 }
 
 // Option specifies instrumentation configuration options.
@@ -74,7 +73,7 @@ func WithPropagators(propagators propagation.TextMapPropagator) Option {
 
 // WithSpanOptions configures an additional set of
 // trace.SpanStartOption, which are applied to each new span.
-func WithSpanOptions(opts ...trace.SpanStartOption) Option {
+func WithSpanOptions(opts ...oteltrace.SpanStartOption) Option {
 	return optionFunc(func(cfg *config) {
 		cfg.SpanStartOptions = append(cfg.SpanStartOptions, opts...)
 	})

--- a/instrumentation/github.com/gorilla/mux/otelmux/config.go
+++ b/instrumentation/github.com/gorilla/mux/otelmux/config.go
@@ -9,6 +9,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
@@ -22,6 +23,7 @@ type config struct {
 	Filters            []Filter
 	MeterProvider      metric.MeterProvider
 	MetricAttributesFn func(*http.Request) []attribute.KeyValue
+	SpanStartOptions   []trace.SpanStartOption
 }
 
 // Option specifies instrumentation configuration options.
@@ -67,6 +69,14 @@ func WithPropagators(propagators propagation.TextMapPropagator) Option {
 		if propagators != nil {
 			cfg.Propagators = propagators
 		}
+	})
+}
+
+// WithSpanOptions configures an additional set of
+// trace.SpanStartOption, which are applied to each new span.
+func WithSpanOptions(opts ...trace.SpanStartOption) Option {
+	return optionFunc(func(cfg *config) {
+		cfg.SpanStartOptions = append(cfg.SpanStartOptions, opts...)
 	})
 }
 

--- a/instrumentation/github.com/gorilla/mux/otelmux/mux.go
+++ b/instrumentation/github.com/gorilla/mux/otelmux/mux.go
@@ -66,6 +66,7 @@ func Middleware(service string, opts ...Option) mux.MiddlewareFunc {
 			meter:              meter,
 			semconv:            semconv.NewHTTPServer(meter),
 			metricAttributesFn: cfg.MetricAttributesFn,
+			spanStartOptions:   cfg.SpanStartOptions,
 		}
 	}
 }
@@ -82,6 +83,7 @@ type traceware struct {
 	meter              metric.Meter
 	semconv            semconv.HTTPServer
 	metricAttributesFn func(*http.Request) []attribute.KeyValue
+	spanStartOptions   []trace.SpanStartOption
 }
 
 // validMethods are all the OTel recognized HTTP methods.
@@ -124,6 +126,7 @@ func (tw traceware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		trace.WithSpanKind(trace.SpanKindServer),
 	}
 
+	opts = append(opts, tw.spanStartOptions...)
 	if tw.publicEndpoint || (tw.publicEndpointFn != nil && tw.publicEndpointFn(r.WithContext(ctx))) {
 		opts = append(opts, trace.WithNewRoot())
 		// Linking incoming span context if any for public endpoint.

--- a/instrumentation/github.com/gorilla/mux/otelmux/muxtest_test.go
+++ b/instrumentation/github.com/gorilla/mux/otelmux/muxtest_test.go
@@ -105,6 +105,35 @@ func TestCustomSpanNameFormatter(t *testing.T) {
 	}
 }
 
+func TestWithSpanOptions(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+
+	wantAttr := attribute.String("foo", "bar")
+	router := mux.NewRouter()
+	router.Use(otelmux.Middleware(
+		"foobar",
+		otelmux.WithTracerProvider(tp),
+		otelmux.WithSpanOptions(
+			trace.WithAttributes(wantAttr),
+		),
+	))
+	router.HandleFunc("/user/{id}", func(w http.ResponseWriter, r *http.Request) {})
+
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/user/111", http.NoBody)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, r)
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 1)
+	got := make(map[attribute.Key]attribute.Value, len(spans[0].Attributes))
+	for _, attr := range spans[0].Attributes {
+		got[attr.Key] = attr.Value
+	}
+	assert.Equal(t, wantAttr.Value, got[wantAttr.Key])
+}
+
 func ok(http.ResponseWriter, *http.Request) {}
 func notfound(w http.ResponseWriter, _ *http.Request) {
 	http.Error(w, "not found", http.StatusNotFound)

--- a/instrumentation/github.com/gorilla/mux/otelmux/muxtest_test.go
+++ b/instrumentation/github.com/gorilla/mux/otelmux/muxtest_test.go
@@ -118,7 +118,7 @@ func TestWithSpanOptions(t *testing.T) {
 			trace.WithAttributes(wantAttr),
 		),
 	))
-	router.HandleFunc("/user/{id}", func(w http.ResponseWriter, r *http.Request) {})
+	router.HandleFunc("/user/{id}", func(http.ResponseWriter, *http.Request) {})
 
 	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/user/111", http.NoBody)
 	w := httptest.NewRecorder()


### PR DESCRIPTION
## Summary
Fixes #8854

`otelmux.Middleware` has no equivalent to `otelhttp`'s `WithSpanOptions`. 
So users must create a custom wrapper to add the `trace.SpanStartOption` at creation time. 

## Fix 
Added `SpanStartOptions`  as a new field of the `otelmux` config.

**New API:**
```
  otelmux.Middleware(
      "",
      otelmux.WithTracerProvider(tracerProvider),
      otelmux.WithPropagators(propagation.TraceContext{}),
      otelmux.WithSpanOptions(
          trace.WithAttributes(attribute.String("component", "net/http")),                                                                                                                                                                                                                                           
      ),
  )   
```
## Test plan

- [x] `make test`
- [x] `make precommit`
- [x] Added `TestWithSpanOptions` - verifies the attributes passed via `WithSpanOptions` are present on the resulting span.