### PR TITLE
xrayconfig: improve mock collector synchronization and test assertions

### DIFF
--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/xrayconfig/mock_collector_test.go
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/xrayconfig/mock_collector_test.go
@@ -80,6 +80,7 @@ type mockCollector struct {
 	ln       *listener
 	stopFunc func()
 	stopOnce sync.Once
+	wg       sync.WaitGroup
 }
 
 type mockConfig struct {
@@ -98,9 +99,8 @@ func (mc *mockCollector) stop() error {
 		if mc.stopFunc != nil {
 			mc.stopFunc()
 		}
+		mc.wg.Wait()
 	})
-	// Give it sometime to shutdown.
-	<-time.After(160 * time.Millisecond)
 
 	// Getting the lock ensures the traceSvc is done flushing.
 	mc.traceSvc.mu.Lock()
@@ -135,9 +135,9 @@ func runMockCollectorWithConfig(t *testing.T, mockConfig *mockConfig) *mockColle
 	mc := makeMockCollector(t, mockConfig)
 	collectortracepb.RegisterTraceServiceServer(srv, mc.traceSvc)
 	mc.ln = newListener(ln)
-	go func() {
+	mc.wg.Go(func() {
 		_ = srv.Serve(net.Listener(mc.ln))
-	}()
+	})
 
 	mc.endpoint = ln.Addr().String()
 	// srv.Stop calls Close on mc.ln.

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/xrayconfig/xrayconfig_test.go
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/xrayconfig/xrayconfig_test.go
@@ -169,7 +169,6 @@ func TestWrapEndToEnd(t *testing.T) {
 	defer func() {
 		_ = mockCollector.Stop()
 	}()
-	<-time.After(5 * time.Millisecond)
 
 	wrapped := otellambda.InstrumentHandler(customerHandler, WithRecommendedOptions(tp)...)
 	wrappedCallable := reflect.ValueOf(wrapped)
@@ -178,7 +177,10 @@ func TestWrapEndToEnd(t *testing.T) {
 	assert.Equal(t, "hello world", resp[0].Interface())
 	assert.Nil(t, resp[1].Interface())
 
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+		assert.Len(collect, mockCollector.getResourceSpans(), 1)
+	}, time.Second, 5*time.Millisecond)
+
 	resSpans := mockCollector.getResourceSpans()
-	assert.Len(t, resSpans, 1)
 	assertSpanEqualsIgnoreTimeAndSpanID(t, &expectedResourceSpans, resSpans[0])
 }


### PR DESCRIPTION
Improve the stability of AWS Lambda X-Ray configuration tests by replacing arbitrary delays with proper synchronization and polling assertions.