### PR TITLE
otelconf: add default attributes to configuration-provided resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- The resource created by `go.opentelemetry.io/contrib/otelconf` now includes [default SDK attributes](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/resource#Default). (#8990)
+- The resource created by `go.opentelemetry.io/contrib/otelconf` now includes [default SDK attributes](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/resource#Default) and, when no schema URL is provided, falls back to the SDK's default schema URL. (#8990)
 - Add `azurecontainerapps` resource detector for Azure Container Apps. (#8939)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- The resource created by `go.opentelemetry.io/contrib/otelconf` now includes [default SDK attributes](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/resource#Default). (#8990)
 - Add `azurecontainerapps` resource detector for Azure Container Apps. (#8939)
-### Changed
-
-- The configuration-provided resource now includes default SDK attributes. (#8990)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+<<<<<<< HEAD
 - The `Version()` function in `go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux` has been replaced by `const Version`. (#9076)
+=======
+- The configuration-provided resource now includes default SDK attributes. (#8990)
+>>>>>>> 052b058b8 (fix changelog)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Set the "error" field (e.g. created via `zap.Error`) as `record.SetErr` instead of a plain attribute in `go.opentelemetry.io/contrib/bridges/otelzap`. (#8719)
 - Set fields implementing `error` interface from `slog` records as `record.SetErr` instead of plain attributes in `go.opentelemetry.io/contrib/bridges/otelslog`. (#8774)
 - Set emitted errors in `go.opentelemetry.io/contrib/bridges/otellogr` as record errors (`Record.SetErr`) instead of `exception.message` attributes. (#8775)
-- The configuration-provided resource now includes default SDK attributes. ()
+- The configuration-provided resource now includes default SDK attributes. (#8990)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
-<<<<<<< HEAD
 - The `Version()` function in `go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux` has been replaced by `const Version`. (#9076)
-=======
-- The configuration-provided resource now includes default SDK attributes. (#8990)
->>>>>>> 052b058b8 (fix changelog)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Set the "error" field (e.g. created via `zap.Error`) as `record.SetErr` instead of a plain attribute in `go.opentelemetry.io/contrib/bridges/otelzap`. (#8719)
 - Set fields implementing `error` interface from `slog` records as `record.SetErr` instead of plain attributes in `go.opentelemetry.io/contrib/bridges/otelslog`. (#8774)
 - Set emitted errors in `go.opentelemetry.io/contrib/bridges/otellogr` as record errors (`Record.SetErr`) instead of `exception.message` attributes. (#8775)
+- The configuration-provided resource now includes default SDK attributes. ()
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Add `azurecontainerapps` resource detector for Azure Container Apps. (#8939)
+### Changed
+
+- The configuration-provided resource now includes default SDK attributes. (#8990)
 
 ### Changed
 
@@ -35,7 +38,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Set the "error" field (e.g. created via `zap.Error`) as `record.SetErr` instead of a plain attribute in `go.opentelemetry.io/contrib/bridges/otelzap`. (#8719)
 - Set fields implementing `error` interface from `slog` records as `record.SetErr` instead of plain attributes in `go.opentelemetry.io/contrib/bridges/otelslog`. (#8774)
 - Set emitted errors in `go.opentelemetry.io/contrib/bridges/otellogr` as record errors (`Record.SetErr`) instead of `exception.message` attributes. (#8775)
-- The configuration-provided resource now includes default SDK attributes. (#8990)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- The resource created by `go.opentelemetry.io/contrib/otelconf` now includes [default SDK attributes](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/resource#Default) and, when no schema URL is provided, falls back to the SDK's default schema URL. (#8990)
+- The resource created by `go.opentelemetry.io/contrib/otelconf` now includes [default SDK attributes](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/resource#Default). (#8990)
 - Add `azurecontainerapps` resource detector for Azure Container Apps. (#8939)
 
 ### Changed

--- a/otelconf/resource.go
+++ b/otelconf/resource.go
@@ -22,7 +22,7 @@ func newResource(r *Resource) (*resource.Resource, error) {
 		attrs = append(attrs, kv.FromNameValue(v.Name, v.Value))
 	}
 
-	var schema string
+	schema := resource.Default().SchemaURL()
 	if r.SchemaUrl != nil {
 		schema = *r.SchemaUrl
 	}

--- a/otelconf/resource.go
+++ b/otelconf/resource.go
@@ -22,7 +22,7 @@ func newResource(r *Resource) (*resource.Resource, error) {
 		attrs = append(attrs, kv.FromNameValue(v.Name, v.Value))
 	}
 
-	schema := resource.Default().SchemaURL()
+	var schema string
 	if r.SchemaUrl != nil {
 		schema = *r.SchemaUrl
 	}

--- a/otelconf/resource.go
+++ b/otelconf/resource.go
@@ -27,6 +27,7 @@ func newResource(r *Resource) (*resource.Resource, error) {
 		schema = *r.SchemaUrl
 	}
 	opts := []resource.Option{
+		resource.WithAttributes(resource.Default().Attributes()...),
 		resource.WithAttributes(attrs...),
 		resource.WithSchemaURL(schema),
 	}

--- a/otelconf/resource_test.go
+++ b/otelconf/resource_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestNewResource(t *testing.T) {
 	withDefaultAttributes := func(attrs ...attribute.KeyValue) []attribute.KeyValue {
-		// Order matters as we expect default attributes to be overriden by config resource attributes
+		// Default attributes come first so they're overridden by config-provided attributes
 		return append(
 			resource.Default().Attributes(),
 			attrs...,
@@ -77,7 +77,8 @@ func TestNewResource(t *testing.T) {
 				},
 				SchemaUrl: ptr(semconv.SchemaURL),
 			},
-			wantResource: resource.NewWithAttributes(semconv.SchemaURL,
+			wantResource: resource.NewWithAttributes(
+				semconv.SchemaURL,
 				withDefaultAttributes(semconv.ServiceName("service-a"),
 					attribute.Bool("attr-bool", true))...,
 			),

--- a/otelconf/resource_test.go
+++ b/otelconf/resource_test.go
@@ -79,13 +79,14 @@ func TestNewResource(t *testing.T) {
 			require.ErrorIs(t, err, tt.wantErrT)
 
 			assert.Equal(t, tt.wantSchemaURL, got.SchemaURL())
-			assert.True(t, got.Set().HasValue(semconv.TelemetrySDKNameKey))
-			assert.True(t, got.Set().HasValue(semconv.TelemetrySDKLanguageKey))
-			assert.True(t, got.Set().HasValue(semconv.TelemetrySDKVersionKey))
+			assert.Truef(t, got.Set().HasValue(semconv.ServiceNameKey), "should have %q attribute", semconv.ServiceNameKey)
+			assert.Truef(t, got.Set().HasValue(semconv.TelemetrySDKNameKey), "should have %q attribute", semconv.TelemetrySDKNameKey)
+			assert.Truef(t, got.Set().HasValue(semconv.TelemetrySDKLanguageKey), "should have %q attribute", semconv.TelemetrySDKLanguageKey)
+			assert.Truef(t, got.Set().HasValue(semconv.TelemetrySDKVersionKey), "should have %q attribute", semconv.TelemetrySDKVersionKey)
 			for _, want := range tt.wantAttrs {
 				got, ok := got.Set().Value(want.Key)
-				if assert.True(t, ok) {
-					assert.Equal(t, want.Value, got)
+				if assert.Truef(t, ok, "should have %q attribute", want.Key) {
+					assert.Equalf(t, want.Value, got, "%q attribute value mismatch", want.Key)
 				}
 			}
 		})

--- a/otelconf/resource_test.go
+++ b/otelconf/resource_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 )
@@ -17,7 +18,12 @@ func TestNewResource(t *testing.T) {
 	withDefaultAttributes := func(attrs ...attribute.KeyValue) []attribute.KeyValue {
 		// Default attributes come first so they're overridden by config-provided attributes
 		return append(
-			resource.Default().Attributes(),
+			[]attribute.KeyValue{
+				semconv.ServiceName("unknown_service:otelconf.test"),
+				semconv.TelemetrySDKName("opentelemetry"),
+				semconv.TelemetrySDKLanguageGo,
+				semconv.TelemetrySDKVersion(sdk.Version()),
+			},
 			attrs...,
 		)
 	}

--- a/otelconf/resource_test.go
+++ b/otelconf/resource_test.go
@@ -9,45 +9,32 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/sdk"
-	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 )
 
 func TestNewResource(t *testing.T) {
-	withDefaultAttributes := func(attrs ...attribute.KeyValue) []attribute.KeyValue {
-		// Default attributes come first so they're overridden by config-provided attributes
-		return append(
-			[]attribute.KeyValue{
-				semconv.ServiceName("unknown_service:otelconf.test"),
-				semconv.TelemetrySDKName("opentelemetry"),
-				semconv.TelemetrySDKLanguageGo,
-				semconv.TelemetrySDKVersion(sdk.Version()),
-			},
-			attrs...,
-		)
-	}
 	tests := []struct {
-		name         string
-		config       *Resource
-		wantResource *resource.Resource
-		wantErrT     error
+		name          string
+		config        *Resource
+		wantSchemaURL string
+		wantAttrs     []attribute.KeyValue
+		wantErrT      error
 	}{
 		{
-			name:         "no-resource-configuration",
-			wantResource: resource.Default(),
+			name:          "no-resource-configuration",
+			wantSchemaURL: semconv.SchemaURL,
 		},
 		{
-			name:         "resource-no-attributes",
-			config:       &Resource{},
-			wantResource: resource.NewSchemaless(withDefaultAttributes()...),
+			name:          "resource-no-attributes",
+			config:        &Resource{},
+			wantSchemaURL: "",
 		},
 		{
 			name: "resource-with-schema",
 			config: &Resource{
 				SchemaUrl: ptr(semconv.SchemaURL),
 			},
-			wantResource: resource.NewWithAttributes(semconv.SchemaURL, withDefaultAttributes()...),
+			wantSchemaURL: semconv.SchemaURL,
 		},
 		{
 			name: "resource-with-attributes",
@@ -56,10 +43,8 @@ func TestNewResource(t *testing.T) {
 					{Name: string(semconv.ServiceNameKey), Value: "service-a"},
 				},
 			},
-			wantResource: resource.NewWithAttributes(
-				"",
-				withDefaultAttributes(semconv.ServiceName("service-a"))...,
-			),
+			wantSchemaURL: "",
+			wantAttrs:     []attribute.KeyValue{semconv.ServiceName("service-a")},
 		},
 		{
 			name: "resource-with-attributes-and-schema",
@@ -69,10 +54,8 @@ func TestNewResource(t *testing.T) {
 				},
 				SchemaUrl: ptr(semconv.SchemaURL),
 			},
-			wantResource: resource.NewWithAttributes(
-				semconv.SchemaURL,
-				withDefaultAttributes(semconv.ServiceName("service-a"))...,
-			),
+			wantSchemaURL: semconv.SchemaURL,
+			wantAttrs:     []attribute.KeyValue{semconv.ServiceName("service-a")},
 		},
 		{
 			name: "resource-with-additional-attributes-and-schema",
@@ -83,18 +66,28 @@ func TestNewResource(t *testing.T) {
 				},
 				SchemaUrl: ptr(semconv.SchemaURL),
 			},
-			wantResource: resource.NewWithAttributes(
-				semconv.SchemaURL,
-				withDefaultAttributes(semconv.ServiceName("service-a"),
-					attribute.Bool("attr-bool", true))...,
-			),
+			wantSchemaURL: semconv.SchemaURL,
+			wantAttrs: []attribute.KeyValue{
+				semconv.ServiceName("service-a"),
+				attribute.Bool("attr-bool", true),
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := newResource(tt.config)
 			require.ErrorIs(t, err, tt.wantErrT)
-			assert.Equal(t, tt.wantResource, got)
+
+			assert.Equal(t, tt.wantSchemaURL, got.SchemaURL())
+			assert.True(t, got.Set().HasValue(semconv.TelemetrySDKNameKey))
+			assert.True(t, got.Set().HasValue(semconv.TelemetrySDKLanguageKey))
+			assert.True(t, got.Set().HasValue(semconv.TelemetrySDKVersionKey))
+			for _, want := range tt.wantAttrs {
+				got, ok := got.Set().Value(want.Key)
+				if assert.True(t, ok) {
+					assert.Equal(t, want.Value, got)
+				}
+			}
 		})
 	}
 }

--- a/otelconf/resource_test.go
+++ b/otelconf/resource_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 func TestNewResource(t *testing.T) {
-	defaultSchema := resource.Default().SchemaURL()
-	customSchema := "https://opentelemetry.io/schemas/example"
+	defaultSchemaURL := resource.Default().SchemaURL()
+	customSchemaURL := "https://example.com/otel/schema"
 
 	tests := []struct {
 		name          string
@@ -26,19 +26,19 @@ func TestNewResource(t *testing.T) {
 	}{
 		{
 			name:          "no-resource-configuration",
-			wantSchemaURL: defaultSchema,
+			wantSchemaURL: defaultSchemaURL,
 		},
 		{
 			name:          "resource-no-attributes",
 			config:        &Resource{},
-			wantSchemaURL: defaultSchema,
+			wantSchemaURL: defaultSchemaURL,
 		},
 		{
 			name: "resource-with-schema",
 			config: &Resource{
-				SchemaUrl: ptr(customSchema),
+				SchemaUrl: ptr(customSchemaURL),
 			},
-			wantSchemaURL: customSchema,
+			wantSchemaURL: customSchemaURL,
 		},
 		{
 			name: "resource-with-attributes",
@@ -47,7 +47,7 @@ func TestNewResource(t *testing.T) {
 					{Name: string(semconv.ServiceNameKey), Value: "service-a"},
 				},
 			},
-			wantSchemaURL: defaultSchema,
+			wantSchemaURL: defaultSchemaURL,
 			wantAttrs:     []attribute.KeyValue{semconv.ServiceName("service-a")},
 		},
 		{
@@ -56,9 +56,9 @@ func TestNewResource(t *testing.T) {
 				Attributes: []AttributeNameValue{
 					{Name: string(semconv.ServiceNameKey), Value: "service-a"},
 				},
-				SchemaUrl: ptr(customSchema),
+				SchemaUrl: ptr(customSchemaURL),
 			},
-			wantSchemaURL: customSchema,
+			wantSchemaURL: customSchemaURL,
 			wantAttrs:     []attribute.KeyValue{semconv.ServiceName("service-a")},
 		},
 		{
@@ -68,9 +68,9 @@ func TestNewResource(t *testing.T) {
 					{Name: string(semconv.ServiceNameKey), Value: "service-a"},
 					{Name: "attr-bool", Value: true},
 				},
-				SchemaUrl: ptr(customSchema),
+				SchemaUrl: ptr(customSchemaURL),
 			},
-			wantSchemaURL: customSchema,
+			wantSchemaURL: customSchemaURL,
 			wantAttrs: []attribute.KeyValue{
 				semconv.ServiceName("service-a"),
 				attribute.Bool("attr-bool", true),

--- a/otelconf/resource_test.go
+++ b/otelconf/resource_test.go
@@ -84,9 +84,9 @@ func TestNewResource(t *testing.T) {
 			assert.Truef(t, got.Set().HasValue(semconv.TelemetrySDKLanguageKey), "should have %q attribute", semconv.TelemetrySDKLanguageKey)
 			assert.Truef(t, got.Set().HasValue(semconv.TelemetrySDKVersionKey), "should have %q attribute", semconv.TelemetrySDKVersionKey)
 			for _, want := range tt.wantAttrs {
-				got, ok := got.Set().Value(want.Key)
+				gotValue, ok := got.Set().Value(want.Key)
 				if assert.Truef(t, ok, "should have %q attribute", want.Key) {
-					assert.Equalf(t, want.Value, got, "%q attribute value mismatch", want.Key)
+					assert.Equalf(t, want.Value, gotValue, "%q attribute value mismatch", want.Key)
 				}
 			}
 		})

--- a/otelconf/resource_test.go
+++ b/otelconf/resource_test.go
@@ -14,6 +14,13 @@ import (
 )
 
 func TestNewResource(t *testing.T) {
+	withDefaultAttributes := func(attrs ...attribute.KeyValue) []attribute.KeyValue {
+		// Order matters as we expect default attributes to be overriden by config resource attributes
+		return append(
+			resource.Default().Attributes(),
+			attrs...,
+		)
+	}
 	tests := []struct {
 		name         string
 		config       *Resource
@@ -27,14 +34,14 @@ func TestNewResource(t *testing.T) {
 		{
 			name:         "resource-no-attributes",
 			config:       &Resource{},
-			wantResource: resource.NewSchemaless(),
+			wantResource: resource.NewSchemaless(withDefaultAttributes()...),
 		},
 		{
 			name: "resource-with-schema",
 			config: &Resource{
 				SchemaUrl: ptr(semconv.SchemaURL),
 			},
-			wantResource: resource.NewWithAttributes(semconv.SchemaURL),
+			wantResource: resource.NewWithAttributes(semconv.SchemaURL, withDefaultAttributes()...),
 		},
 		{
 			name: "resource-with-attributes",
@@ -45,7 +52,7 @@ func TestNewResource(t *testing.T) {
 			},
 			wantResource: resource.NewWithAttributes(
 				"",
-				semconv.ServiceName("service-a"),
+				withDefaultAttributes(semconv.ServiceName("service-a"))...,
 			),
 		},
 		{
@@ -58,7 +65,7 @@ func TestNewResource(t *testing.T) {
 			},
 			wantResource: resource.NewWithAttributes(
 				semconv.SchemaURL,
-				semconv.ServiceName("service-a"),
+				withDefaultAttributes(semconv.ServiceName("service-a"))...,
 			),
 		},
 		{
@@ -71,14 +78,15 @@ func TestNewResource(t *testing.T) {
 				SchemaUrl: ptr(semconv.SchemaURL),
 			},
 			wantResource: resource.NewWithAttributes(semconv.SchemaURL,
-				semconv.ServiceName("service-a"),
-				attribute.Bool("attr-bool", true)),
+				withDefaultAttributes(semconv.ServiceName("service-a"),
+					attribute.Bool("attr-bool", true))...,
+			),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := newResource(tt.config)
-			require.ErrorIs(t, tt.wantErrT, err)
+			require.ErrorIs(t, err, tt.wantErrT)
 			assert.Equal(t, tt.wantResource, got)
 		})
 	}

--- a/otelconf/resource_test.go
+++ b/otelconf/resource_test.go
@@ -14,9 +14,6 @@ import (
 )
 
 func TestNewResource(t *testing.T) {
-	defaultSchemaURL := resource.Default().SchemaURL()
-	customSchemaURL := "https://example.com/otel/schema"
-
 	tests := []struct {
 		name          string
 		config        *Resource
@@ -26,19 +23,19 @@ func TestNewResource(t *testing.T) {
 	}{
 		{
 			name:          "no-resource-configuration",
-			wantSchemaURL: defaultSchemaURL,
+			wantSchemaURL: resource.Default().SchemaURL(),
 		},
 		{
 			name:          "resource-no-attributes",
 			config:        &Resource{},
-			wantSchemaURL: defaultSchemaURL,
+			wantSchemaURL: "",
 		},
 		{
 			name: "resource-with-schema",
 			config: &Resource{
-				SchemaUrl: ptr(customSchemaURL),
+				SchemaUrl: ptr(semconv.SchemaURL),
 			},
-			wantSchemaURL: customSchemaURL,
+			wantSchemaURL: semconv.SchemaURL,
 		},
 		{
 			name: "resource-with-attributes",
@@ -47,7 +44,7 @@ func TestNewResource(t *testing.T) {
 					{Name: string(semconv.ServiceNameKey), Value: "service-a"},
 				},
 			},
-			wantSchemaURL: defaultSchemaURL,
+			wantSchemaURL: "",
 			wantAttrs:     []attribute.KeyValue{semconv.ServiceName("service-a")},
 		},
 		{
@@ -56,9 +53,9 @@ func TestNewResource(t *testing.T) {
 				Attributes: []AttributeNameValue{
 					{Name: string(semconv.ServiceNameKey), Value: "service-a"},
 				},
-				SchemaUrl: ptr(customSchemaURL),
+				SchemaUrl: ptr(semconv.SchemaURL),
 			},
-			wantSchemaURL: customSchemaURL,
+			wantSchemaURL: semconv.SchemaURL,
 			wantAttrs:     []attribute.KeyValue{semconv.ServiceName("service-a")},
 		},
 		{
@@ -68,9 +65,9 @@ func TestNewResource(t *testing.T) {
 					{Name: string(semconv.ServiceNameKey), Value: "service-a"},
 					{Name: "attr-bool", Value: true},
 				},
-				SchemaUrl: ptr(customSchemaURL),
+				SchemaUrl: ptr(semconv.SchemaURL),
 			},
-			wantSchemaURL: customSchemaURL,
+			wantSchemaURL: semconv.SchemaURL,
 			wantAttrs: []attribute.KeyValue{
 				semconv.ServiceName("service-a"),
 				attribute.Bool("attr-bool", true),

--- a/otelconf/resource_test.go
+++ b/otelconf/resource_test.go
@@ -9,10 +9,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 )
 
 func TestNewResource(t *testing.T) {
+	defaultSchema := resource.Default().SchemaURL()
+	customSchema := "https://opentelemetry.io/schemas/example"
+
 	tests := []struct {
 		name          string
 		config        *Resource
@@ -22,19 +26,19 @@ func TestNewResource(t *testing.T) {
 	}{
 		{
 			name:          "no-resource-configuration",
-			wantSchemaURL: semconv.SchemaURL,
+			wantSchemaURL: defaultSchema,
 		},
 		{
 			name:          "resource-no-attributes",
 			config:        &Resource{},
-			wantSchemaURL: "",
+			wantSchemaURL: defaultSchema,
 		},
 		{
 			name: "resource-with-schema",
 			config: &Resource{
-				SchemaUrl: ptr(semconv.SchemaURL),
+				SchemaUrl: ptr(customSchema),
 			},
-			wantSchemaURL: semconv.SchemaURL,
+			wantSchemaURL: customSchema,
 		},
 		{
 			name: "resource-with-attributes",
@@ -43,7 +47,7 @@ func TestNewResource(t *testing.T) {
 					{Name: string(semconv.ServiceNameKey), Value: "service-a"},
 				},
 			},
-			wantSchemaURL: "",
+			wantSchemaURL: defaultSchema,
 			wantAttrs:     []attribute.KeyValue{semconv.ServiceName("service-a")},
 		},
 		{
@@ -52,9 +56,9 @@ func TestNewResource(t *testing.T) {
 				Attributes: []AttributeNameValue{
 					{Name: string(semconv.ServiceNameKey), Value: "service-a"},
 				},
-				SchemaUrl: ptr(semconv.SchemaURL),
+				SchemaUrl: ptr(customSchema),
 			},
-			wantSchemaURL: semconv.SchemaURL,
+			wantSchemaURL: customSchema,
 			wantAttrs:     []attribute.KeyValue{semconv.ServiceName("service-a")},
 		},
 		{
@@ -64,9 +68,9 @@ func TestNewResource(t *testing.T) {
 					{Name: string(semconv.ServiceNameKey), Value: "service-a"},
 					{Name: "attr-bool", Value: true},
 				},
-				SchemaUrl: ptr(semconv.SchemaURL),
+				SchemaUrl: ptr(customSchema),
 			},
-			wantSchemaURL: semconv.SchemaURL,
+			wantSchemaURL: customSchema,
 			wantAttrs: []attribute.KeyValue{
 				semconv.ServiceName("service-a"),
 				attribute.Bool("attr-bool", true),

--- a/otelconf/x/resource.go
+++ b/otelconf/x/resource.go
@@ -46,6 +46,7 @@ func newResource(r *Resource) (*resource.Resource, error) {
 		schema = *r.SchemaUrl
 	}
 	opts := []resource.Option{
+		resource.WithAttributes(resource.Default().Attributes()...),
 		resource.WithAttributes(attrs...),
 		resource.WithSchemaURL(schema),
 	}

--- a/otelconf/x/resource.go
+++ b/otelconf/x/resource.go
@@ -41,7 +41,7 @@ func newResource(r *Resource) (*resource.Resource, error) {
 		attrs = append(attrs, kv.FromNameValue(v.Name, v.Value))
 	}
 
-	var schema string
+	schema := resource.Default().SchemaURL()
 	if r.SchemaUrl != nil {
 		schema = *r.SchemaUrl
 	}

--- a/otelconf/x/resource.go
+++ b/otelconf/x/resource.go
@@ -41,7 +41,7 @@ func newResource(r *Resource) (*resource.Resource, error) {
 		attrs = append(attrs, kv.FromNameValue(v.Name, v.Value))
 	}
 
-	schema := resource.Default().SchemaURL()
+	var schema string
 	if r.SchemaUrl != nil {
 		schema = *r.SchemaUrl
 	}

--- a/otelconf/x/resource_test.go
+++ b/otelconf/x/resource_test.go
@@ -79,13 +79,14 @@ func TestNewResource(t *testing.T) {
 			require.ErrorIs(t, err, tt.wantErrT)
 
 			assert.Equal(t, tt.wantSchemaURL, got.SchemaURL())
-			assert.True(t, got.Set().HasValue(semconv.TelemetrySDKNameKey))
-			assert.True(t, got.Set().HasValue(semconv.TelemetrySDKLanguageKey))
-			assert.True(t, got.Set().HasValue(semconv.TelemetrySDKVersionKey))
+			assert.Truef(t, got.Set().HasValue(semconv.ServiceNameKey), "should have %q attribute", semconv.ServiceNameKey)
+			assert.Truef(t, got.Set().HasValue(semconv.TelemetrySDKNameKey), "should have %q attribute", semconv.TelemetrySDKNameKey)
+			assert.Truef(t, got.Set().HasValue(semconv.TelemetrySDKLanguageKey), "should have %q attribute", semconv.TelemetrySDKLanguageKey)
+			assert.Truef(t, got.Set().HasValue(semconv.TelemetrySDKVersionKey), "should have %q attribute", semconv.TelemetrySDKVersionKey)
 			for _, want := range tt.wantAttrs {
 				got, ok := got.Set().Value(want.Key)
-				if assert.True(t, ok) {
-					assert.Equal(t, want.Value, got)
+				if assert.Truef(t, ok, "should have %q attribute", want.Key) {
+					assert.Equalf(t, want.Value, got, "%q attribute value mismatch", want.Key)
 				}
 			}
 		})

--- a/otelconf/x/resource_test.go
+++ b/otelconf/x/resource_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 func TestNewResource(t *testing.T) {
-	defaultSchema := resource.Default().SchemaURL()
-	customSchema := "https://opentelemetry.io/schemas/example"
+	defaultSchemaURL := resource.Default().SchemaURL()
+	customSchemaURL := "https://example.com/otel/schema"
 
 	tests := []struct {
 		name          string
@@ -26,19 +26,19 @@ func TestNewResource(t *testing.T) {
 	}{
 		{
 			name:          "no-resource-configuration",
-			wantSchemaURL: defaultSchema,
+			wantSchemaURL: defaultSchemaURL,
 		},
 		{
 			name:          "resource-no-attributes",
 			config:        &Resource{},
-			wantSchemaURL: defaultSchema,
+			wantSchemaURL: defaultSchemaURL,
 		},
 		{
 			name: "resource-with-schema",
 			config: &Resource{
-				SchemaUrl: ptr(customSchema),
+				SchemaUrl: ptr(customSchemaURL),
 			},
-			wantSchemaURL: customSchema,
+			wantSchemaURL: customSchemaURL,
 		},
 		{
 			name: "resource-with-attributes",
@@ -47,7 +47,7 @@ func TestNewResource(t *testing.T) {
 					{Name: string(semconv.ServiceNameKey), Value: "service-a"},
 				},
 			},
-			wantSchemaURL: defaultSchema,
+			wantSchemaURL: defaultSchemaURL,
 			wantAttrs:     []attribute.KeyValue{semconv.ServiceName("service-a")},
 		},
 		{
@@ -56,9 +56,9 @@ func TestNewResource(t *testing.T) {
 				Attributes: []AttributeNameValue{
 					{Name: string(semconv.ServiceNameKey), Value: "service-a"},
 				},
-				SchemaUrl: ptr(customSchema),
+				SchemaUrl: ptr(customSchemaURL),
 			},
-			wantSchemaURL: customSchema,
+			wantSchemaURL: customSchemaURL,
 			wantAttrs:     []attribute.KeyValue{semconv.ServiceName("service-a")},
 		},
 		{
@@ -68,9 +68,9 @@ func TestNewResource(t *testing.T) {
 					{Name: string(semconv.ServiceNameKey), Value: "service-a"},
 					{Name: "attr-bool", Value: true},
 				},
-				SchemaUrl: ptr(customSchema),
+				SchemaUrl: ptr(customSchemaURL),
 			},
-			wantSchemaURL: customSchema,
+			wantSchemaURL: customSchemaURL,
 			wantAttrs: []attribute.KeyValue{
 				semconv.ServiceName("service-a"),
 				attribute.Bool("attr-bool", true),

--- a/otelconf/x/resource_test.go
+++ b/otelconf/x/resource_test.go
@@ -84,9 +84,9 @@ func TestNewResource(t *testing.T) {
 			assert.Truef(t, got.Set().HasValue(semconv.TelemetrySDKLanguageKey), "should have %q attribute", semconv.TelemetrySDKLanguageKey)
 			assert.Truef(t, got.Set().HasValue(semconv.TelemetrySDKVersionKey), "should have %q attribute", semconv.TelemetrySDKVersionKey)
 			for _, want := range tt.wantAttrs {
-				got, ok := got.Set().Value(want.Key)
+				gotValue, ok := got.Set().Value(want.Key)
 				if assert.Truef(t, ok, "should have %q attribute", want.Key) {
-					assert.Equalf(t, want.Value, got, "%q attribute value mismatch", want.Key)
+					assert.Equalf(t, want.Value, gotValue, "%q attribute value mismatch", want.Key)
 				}
 			}
 		})

--- a/otelconf/x/resource_test.go
+++ b/otelconf/x/resource_test.go
@@ -14,9 +14,6 @@ import (
 )
 
 func TestNewResource(t *testing.T) {
-	defaultSchemaURL := resource.Default().SchemaURL()
-	customSchemaURL := "https://example.com/otel/schema"
-
 	tests := []struct {
 		name          string
 		config        *Resource
@@ -26,19 +23,19 @@ func TestNewResource(t *testing.T) {
 	}{
 		{
 			name:          "no-resource-configuration",
-			wantSchemaURL: defaultSchemaURL,
+			wantSchemaURL: resource.Default().SchemaURL(),
 		},
 		{
 			name:          "resource-no-attributes",
 			config:        &Resource{},
-			wantSchemaURL: defaultSchemaURL,
+			wantSchemaURL: "",
 		},
 		{
 			name: "resource-with-schema",
 			config: &Resource{
-				SchemaUrl: ptr(customSchemaURL),
+				SchemaUrl: ptr(semconv.SchemaURL),
 			},
-			wantSchemaURL: customSchemaURL,
+			wantSchemaURL: semconv.SchemaURL,
 		},
 		{
 			name: "resource-with-attributes",
@@ -47,7 +44,7 @@ func TestNewResource(t *testing.T) {
 					{Name: string(semconv.ServiceNameKey), Value: "service-a"},
 				},
 			},
-			wantSchemaURL: defaultSchemaURL,
+			wantSchemaURL: "",
 			wantAttrs:     []attribute.KeyValue{semconv.ServiceName("service-a")},
 		},
 		{
@@ -56,9 +53,9 @@ func TestNewResource(t *testing.T) {
 				Attributes: []AttributeNameValue{
 					{Name: string(semconv.ServiceNameKey), Value: "service-a"},
 				},
-				SchemaUrl: ptr(customSchemaURL),
+				SchemaUrl: ptr(semconv.SchemaURL),
 			},
-			wantSchemaURL: customSchemaURL,
+			wantSchemaURL: semconv.SchemaURL,
 			wantAttrs:     []attribute.KeyValue{semconv.ServiceName("service-a")},
 		},
 		{
@@ -68,9 +65,9 @@ func TestNewResource(t *testing.T) {
 					{Name: string(semconv.ServiceNameKey), Value: "service-a"},
 					{Name: "attr-bool", Value: true},
 				},
-				SchemaUrl: ptr(customSchemaURL),
+				SchemaUrl: ptr(semconv.SchemaURL),
 			},
-			wantSchemaURL: customSchemaURL,
+			wantSchemaURL: semconv.SchemaURL,
 			wantAttrs: []attribute.KeyValue{
 				semconv.ServiceName("service-a"),
 				attribute.Bool("attr-bool", true),

--- a/otelconf/x/resource_test.go
+++ b/otelconf/x/resource_test.go
@@ -9,32 +9,32 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 )
 
 func TestNewResource(t *testing.T) {
 	tests := []struct {
-		name         string
-		config       *Resource
-		wantResource *resource.Resource
-		wantErrT     error
+		name          string
+		config        *Resource
+		wantSchemaURL string
+		wantAttrs     []attribute.KeyValue
+		wantErrT      error
 	}{
 		{
-			name:         "no-resource-configuration",
-			wantResource: resource.Default(),
+			name:          "no-resource-configuration",
+			wantSchemaURL: semconv.SchemaURL,
 		},
 		{
-			name:         "resource-no-attributes",
-			config:       &Resource{},
-			wantResource: resource.NewSchemaless(),
+			name:          "resource-no-attributes",
+			config:        &Resource{},
+			wantSchemaURL: "",
 		},
 		{
 			name: "resource-with-schema",
 			config: &Resource{
 				SchemaUrl: ptr(semconv.SchemaURL),
 			},
-			wantResource: resource.NewWithAttributes(semconv.SchemaURL),
+			wantSchemaURL: semconv.SchemaURL,
 		},
 		{
 			name: "resource-with-attributes",
@@ -43,10 +43,8 @@ func TestNewResource(t *testing.T) {
 					{Name: string(semconv.ServiceNameKey), Value: "service-a"},
 				},
 			},
-			wantResource: resource.NewWithAttributes(
-				"",
-				semconv.ServiceName("service-a"),
-			),
+			wantSchemaURL: "",
+			wantAttrs:     []attribute.KeyValue{semconv.ServiceName("service-a")},
 		},
 		{
 			name: "resource-with-attributes-and-schema",
@@ -56,10 +54,8 @@ func TestNewResource(t *testing.T) {
 				},
 				SchemaUrl: ptr(semconv.SchemaURL),
 			},
-			wantResource: resource.NewWithAttributes(
-				semconv.SchemaURL,
-				semconv.ServiceName("service-a"),
-			),
+			wantSchemaURL: semconv.SchemaURL,
+			wantAttrs:     []attribute.KeyValue{semconv.ServiceName("service-a")},
 		},
 		{
 			name: "resource-with-additional-attributes-and-schema",
@@ -70,16 +66,28 @@ func TestNewResource(t *testing.T) {
 				},
 				SchemaUrl: ptr(semconv.SchemaURL),
 			},
-			wantResource: resource.NewWithAttributes(semconv.SchemaURL,
+			wantSchemaURL: semconv.SchemaURL,
+			wantAttrs: []attribute.KeyValue{
 				semconv.ServiceName("service-a"),
-				attribute.Bool("attr-bool", true)),
+				attribute.Bool("attr-bool", true),
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := newResource(tt.config)
-			require.ErrorIs(t, tt.wantErrT, err)
-			assert.Equal(t, tt.wantResource, got)
+			require.ErrorIs(t, err, tt.wantErrT)
+
+			assert.Equal(t, tt.wantSchemaURL, got.SchemaURL())
+			assert.True(t, got.Set().HasValue(semconv.TelemetrySDKNameKey))
+			assert.True(t, got.Set().HasValue(semconv.TelemetrySDKLanguageKey))
+			assert.True(t, got.Set().HasValue(semconv.TelemetrySDKVersionKey))
+			for _, want := range tt.wantAttrs {
+				got, ok := got.Set().Value(want.Key)
+				if assert.True(t, ok) {
+					assert.Equal(t, want.Value, got)
+				}
+			}
 		})
 	}
 }

--- a/otelconf/x/resource_test.go
+++ b/otelconf/x/resource_test.go
@@ -9,10 +9,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 )
 
 func TestNewResource(t *testing.T) {
+	defaultSchema := resource.Default().SchemaURL()
+	customSchema := "https://opentelemetry.io/schemas/example"
+
 	tests := []struct {
 		name          string
 		config        *Resource
@@ -22,19 +26,19 @@ func TestNewResource(t *testing.T) {
 	}{
 		{
 			name:          "no-resource-configuration",
-			wantSchemaURL: semconv.SchemaURL,
+			wantSchemaURL: defaultSchema,
 		},
 		{
 			name:          "resource-no-attributes",
 			config:        &Resource{},
-			wantSchemaURL: "",
+			wantSchemaURL: defaultSchema,
 		},
 		{
 			name: "resource-with-schema",
 			config: &Resource{
-				SchemaUrl: ptr(semconv.SchemaURL),
+				SchemaUrl: ptr(customSchema),
 			},
-			wantSchemaURL: semconv.SchemaURL,
+			wantSchemaURL: customSchema,
 		},
 		{
 			name: "resource-with-attributes",
@@ -43,7 +47,7 @@ func TestNewResource(t *testing.T) {
 					{Name: string(semconv.ServiceNameKey), Value: "service-a"},
 				},
 			},
-			wantSchemaURL: "",
+			wantSchemaURL: defaultSchema,
 			wantAttrs:     []attribute.KeyValue{semconv.ServiceName("service-a")},
 		},
 		{
@@ -52,9 +56,9 @@ func TestNewResource(t *testing.T) {
 				Attributes: []AttributeNameValue{
 					{Name: string(semconv.ServiceNameKey), Value: "service-a"},
 				},
-				SchemaUrl: ptr(semconv.SchemaURL),
+				SchemaUrl: ptr(customSchema),
 			},
-			wantSchemaURL: semconv.SchemaURL,
+			wantSchemaURL: customSchema,
 			wantAttrs:     []attribute.KeyValue{semconv.ServiceName("service-a")},
 		},
 		{
@@ -64,9 +68,9 @@ func TestNewResource(t *testing.T) {
 					{Name: string(semconv.ServiceNameKey), Value: "service-a"},
 					{Name: "attr-bool", Value: true},
 				},
-				SchemaUrl: ptr(semconv.SchemaURL),
+				SchemaUrl: ptr(customSchema),
 			},
-			wantSchemaURL: semconv.SchemaURL,
+			wantSchemaURL: customSchema,
 			wantAttrs: []attribute.KeyValue{
 				semconv.ServiceName("service-a"),
 				attribute.Bool("attr-bool", true),


### PR DESCRIPTION
Problem discussion at Slack: https://cloud-native.slack.com/archives/C0476L7UJT1/p1777290327086879

This PR fixes the issue of telemetry SDK and service name attributes not being added when a config resource is provided, while being present in the default resource. The behavior of the Go SDK is now aligned with other SDKs.