### PR TITLE
[Prototype] bridges/otelslog: set log_bridge.name and log_bridge.version Instrumentation Scope attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `error.type` attribute to `http.client.request.duration` for transport failures in `otelhttp`. (#8801)
 - Add examples for prometheus compatibility document. (#8716)
 - Add `Resource` method to `SDK` in `go.opentelemetry.io/contrib/otelconf/x` to expose the resolved SDK resource from declarative configuration. (#8912)
-- Set `log_bridge.name` and `log_bridge.version` Instrumentation Scope attributes on Loggers created by `go.opentelemetry.io/contrib/bridges/otelslog` to identify the bridge per the in-progress [semantic convention proposal](https://github.com/open-telemetry/semantic-conventions/pull/3716).
+- Set `log.bridge.name` and `log.bridge.version` Instrumentation Scope attributes on Loggers created by `go.opentelemetry.io/contrib/bridges/otelslog` to identify the bridge per the in-progress [semantic convention proposal](https://github.com/open-telemetry/semantic-conventions/pull/3716).
 - Add `go.opentelemetry.io/contrib/detectors/hetzner` — a new resource detector for Hetzner Cloud servers, ported from `processor/resourcedetectionprocessor/internal/hetzner` in `opentelemetry-collector-contrib`. Detects `cloud.provider`, `cloud.platform`, `cloud.region`, `cloud.availability_zone`, `host.id`, and `host.name`. (#8962)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `error.type` attribute to `http.client.request.duration` for transport failures in `otelhttp`. (#8801)
 - Add examples for prometheus compatibility document. (#8716)
 - Add `Resource` method to `SDK` in `go.opentelemetry.io/contrib/otelconf/x` to expose the resolved SDK resource from declarative configuration. (#8912)
+- Set `log_bridge.name` and `log_bridge.version` Instrumentation Scope attributes on Loggers created by `go.opentelemetry.io/contrib/bridges/otelslog` to identify the bridge per the in-progress [semantic convention proposal](https://github.com/open-telemetry/semantic-conventions/pull/3716).
 - Add `go.opentelemetry.io/contrib/detectors/hetzner` — a new resource detector for Hetzner Cloud servers, ported from `processor/resourcedetectionprocessor/internal/hetzner` in `opentelemetry-collector-contrib`. Detects `cloud.provider`, `cloud.platform`, `cloud.region`, `cloud.availability_zone`, `host.id`, and `host.name`. (#8962)
 
 ### Changed

--- a/bridges/otelslog/handler.go
+++ b/bridges/otelslog/handler.go
@@ -57,7 +57,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 )
 
-// bridgeName is the value reported as the log_bridge.name Instrumentation
+// bridgeName is the value reported as the log.bridge.name Instrumentation
 // Scope attribute on Loggers created by this bridge. It identifies the bridge
 // package itself, distinct from the producer (typically the slog logger name)
 // reported as the Instrumentation Scope name.
@@ -99,8 +99,8 @@ func (c config) logger(name string) log.Logger {
 	// on the unlikely event of a key collision.
 	opts := []log.LoggerOption{
 		log.WithInstrumentationAttributes(
-			attribute.String("log_bridge.name", bridgeName),
-			attribute.String("log_bridge.version", Version),
+			attribute.String("log.bridge.name", bridgeName),
+			attribute.String("log.bridge.version", Version),
 		),
 	}
 	if c.version != "" {

--- a/bridges/otelslog/handler.go
+++ b/bridges/otelslog/handler.go
@@ -57,6 +57,14 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 )
 
+// bridgeName is the value reported as the log_bridge.name Instrumentation
+// Scope attribute on Loggers created by this bridge. It identifies the bridge
+// package itself, distinct from the producer (typically the slog logger name)
+// reported as the Instrumentation Scope name.
+//
+// See open-telemetry/semantic-conventions#3716.
+const bridgeName = "go.opentelemetry.io/contrib/bridges/otelslog"
+
 // NewLogger returns a new [slog.Logger] backed by a new [Handler]. See
 // [NewHandler] for details on how the backing Handler is created.
 func NewLogger(name string, options ...Option) *slog.Logger {
@@ -85,7 +93,16 @@ func newConfig(options []Option) config {
 }
 
 func (c config) logger(name string) log.Logger {
-	var opts []log.LoggerOption
+	// Identify this bridge per the in-progress OpenTelemetry semantic
+	// convention proposed in open-telemetry/semantic-conventions#3716.
+	// These are placed first so user-supplied WithAttributes can override
+	// on the unlikely event of a key collision.
+	opts := []log.LoggerOption{
+		log.WithInstrumentationAttributes(
+			attribute.String("log_bridge.name", bridgeName),
+			attribute.String("log_bridge.version", Version),
+		),
+	}
 	if c.version != "" {
 		opts = append(opts, log.WithInstrumentationVersion(c.version))
 	}

--- a/bridges/otelslog/handler_test.go
+++ b/bridges/otelslog/handler_test.go
@@ -479,7 +479,13 @@ func TestNewHandlerConfiguration(t *testing.T) {
 		require.IsType(t, &recorder{}, h.logger)
 
 		l := h.logger.(*recorder)
-		want := scope{Name: name}
+		want := scope{
+			Name: name,
+			Attributes: attribute.NewSet(
+				attribute.String("log_bridge.name", "go.opentelemetry.io/contrib/bridges/otelslog"),
+				attribute.String("log_bridge.version", Version),
+			),
+		}
 		assert.Equal(t, want, l.Scope)
 	})
 
@@ -501,10 +507,14 @@ func TestNewHandlerConfiguration(t *testing.T) {
 
 		l := h.logger.(*recorder)
 		scope := scope{
-			Name:       "name",
-			Version:    "ver",
-			SchemaURL:  "url",
-			Attributes: attribute.NewSet(attribute.String("testattr", "testval")),
+			Name:      "name",
+			Version:   "ver",
+			SchemaURL: "url",
+			Attributes: attribute.NewSet(
+				attribute.String("log_bridge.name", "go.opentelemetry.io/contrib/bridges/otelslog"),
+				attribute.String("log_bridge.version", Version),
+				attribute.String("testattr", "testval"),
+			),
 		}
 		assert.Equal(t, scope, l.Scope)
 	})

--- a/bridges/otelslog/handler_test.go
+++ b/bridges/otelslog/handler_test.go
@@ -482,8 +482,8 @@ func TestNewHandlerConfiguration(t *testing.T) {
 		want := scope{
 			Name: name,
 			Attributes: attribute.NewSet(
-				attribute.String("log_bridge.name", "go.opentelemetry.io/contrib/bridges/otelslog"),
-				attribute.String("log_bridge.version", Version),
+				attribute.String("log.bridge.name", "go.opentelemetry.io/contrib/bridges/otelslog"),
+				attribute.String("log.bridge.version", Version),
 			),
 		}
 		assert.Equal(t, want, l.Scope)
@@ -511,8 +511,8 @@ func TestNewHandlerConfiguration(t *testing.T) {
 			Version:   "ver",
 			SchemaURL: "url",
 			Attributes: attribute.NewSet(
-				attribute.String("log_bridge.name", "go.opentelemetry.io/contrib/bridges/otelslog"),
-				attribute.String("log_bridge.version", Version),
+				attribute.String("log.bridge.name", "go.opentelemetry.io/contrib/bridges/otelslog"),
+				attribute.String("log.bridge.version", Version),
 				attribute.String("testattr", "testval"),
 			),
 		}


### PR DESCRIPTION
Draft prototype for the in-progress semantic convention proposed in open-telemetry/semantic-conventions#3716 (issue: open-telemetry/semantic-conventions#1550).

Sets `log_bridge.name` and `log_bridge.version` Instrumentation Scope attributes on every Logger created by `otelslog`, identifying the bridge package distinct from the producer (slog logger name) reported as the scope name.

Same trivial change applies to `otelzap`/`otellogrus`/`otellogr` — kept minimal here to drive the semconv discussion.

Related: open-telemetry/opentelemetry-specification#5089, open-telemetry/opentelemetry-rust#3515