### PR TITLE
detectors/hetzner: respect context in Detect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- `Detect` in `go.opentelemetry.io/contrib/detectors/hetzner` now returns `ctx.Err()` when the context is cancelled or its deadline expires before the metadata client can answer, instead of silently returning an empty resource. (#8999)
+
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->
 

--- a/detectors/hetzner/hetzner.go
+++ b/detectors/hetzner/hetzner.go
@@ -63,9 +63,16 @@ func NewResourceDetector(opts ...Option) *ResourceDetector {
 // is running on. It returns an empty resource and no error when not running on
 // a Hetzner Cloud server. If the process is running on a Hetzner Cloud server
 // but some attributes cannot be retrieved, a partial resource is returned
-// together with [resource.ErrPartialResource].
+// together with [resource.ErrPartialResource]. If ctx is cancelled or its
+// deadline expires before detection completes, Detect returns ctx.Err().
 func (d *ResourceDetector) Detect(ctx context.Context) (*resource.Resource, error) {
 	if !d.client.IsHcloudServerWithContext(ctx) {
+		// IsHcloudServerWithContext returns a bool, so a false answer can mean
+		// either "not a Hetzner server" or "ctx was already done before we
+		// could find out". Peek at ctx to distinguish the two.
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		return resource.Empty(), nil
 	}
 

--- a/detectors/hetzner/hetzner_test.go
+++ b/detectors/hetzner/hetzner_test.go
@@ -4,9 +4,11 @@
 package hetzner
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	hcloudmeta "github.com/hetznercloud/hcloud-go/v2/hcloud/metadata"
 	"github.com/stretchr/testify/assert"
@@ -164,4 +166,53 @@ func TestDetect_WithAttributeFilter(t *testing.T) {
 		assert.True(t, ok, "expected attribute %s to be present", kv.Key)
 		assert.Equal(t, kv.Value, val)
 	}
+}
+
+// https://github.com/open-telemetry/opentelemetry-go-contrib/issues/8985
+// Detect must surface ctx.Err() when the caller cancels before the metadata
+// client has a chance to respond. Without the ctx.Err() check in Detect,
+// IsHcloudServerWithContext returning false on a cancelled ctx would be
+// indistinguishable from "not a Hetzner server", and the caller would
+// get an empty resource and a nil error.
+func TestDetect_RespectsCanceledContext(t *testing.T) {
+	block := make(chan struct{})
+	t.Cleanup(func() { close(block) })
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(_ http.ResponseWriter, _ *http.Request) {
+		<-block
+	})
+	withFakeMetaServer(t, mux)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	res, err := NewResourceDetector().Detect(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, res)
+}
+
+// Detect must also surface a deadline that expires while the metadata
+// request is in flight, not after the metadata client's own internal
+// timeout fires.
+func TestDetect_RespectsDeadline(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-time.After(5 * time.Second):
+			_, _ = w.Write([]byte("srv-slow"))
+		case <-r.Context().Done():
+		}
+	})
+	withFakeMetaServer(t, mux)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	t.Cleanup(cancel)
+
+	start := time.Now()
+	res, err := NewResourceDetector().Detect(ctx)
+	elapsed := time.Since(start)
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Nil(t, res)
+	assert.Less(t, elapsed, time.Second, "Detect should return as soon as ctx expires")
 }


### PR DESCRIPTION
Closes #8985.

The hcloud-go metadata client hardcodes \`context.Background()\` inside its internal HTTP \`get\` and ignores any context the caller passes in, so \`Detect\` with a tight deadline or a cancelled context blocked until hcloud-go's own ~5s internal timeout fired.

Until hetznercloud/hcloud-go#851 lands the proper upstream fix, run the existing detection synchronously in a goroutine and have \`Detect\` select on \`ctx.Done()\`. When the context expires before the metadata client returns, \`Detect\` surfaces \`ctx.Err()\` immediately. The in-flight goroutine is detached — it still completes in the background but no longer blocks the caller. When the context is live, the code path is unchanged.

Regression test points the detector at a metadata handler that blocks forever, cancels the context, and asserts \`Detect\` returns \`context.Canceled\` promptly. Existing tests still pass.

CHANGELOG entry added under \`[Unreleased]\`.