### PR TITLE
chore: re-enable revive.context-as-argument rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -109,11 +109,9 @@ linters:
         - name: blank-imports
         - name: bool-literal-in-expr
         - name: constant-logical-expr
-        # TODO (#2877) re-enable linter when it is compatible. https://github.com/golangci/golangci-lint/issues/3280
         - name: context-as-argument
-          disabled: true
           arguments:
-            - allow-types-before: "*testing.T"
+            - allow-types-before: "*testing.T,*testing.B"
         - name: context-keys-type
         - name: deep-exit
         - name: defer
@@ -172,8 +170,6 @@ linters:
             - ["Otel", "Aws", "Gcp"] # DenyList
             - - skip-initialism-name-checks: true
                 upper-case-const: true
-                skip-package-name-checks: true
-                skip-package-name-collision-with-go-std: true
         - name: waitgroup-by-value
     testifylint:
       enable-all: true


### PR DESCRIPTION
Enable `revive.context-as-argument` rule, since `allow-types-before` is no longer an issue.

Remove the deprecated `skip-package-name-checks` and `skip-package-name-collision-with-go-std` options from the `var-naming` rule.

Fixes #2877

P.S. I'm a Revive maintainer.