### PR TITLE
fix(otelzap): avoid panic on malformed error fields

### DIFF
--- a/bridges/otelzap/core.go
+++ b/bridges/otelzap/core.go
@@ -275,7 +275,9 @@ func convertField(fields []zapcore.Field) (context.Context, []log.KeyValue, erro
 			continue
 		}
 		if field.Type == zapcore.ErrorType && field.Key == "error" {
-			errField = field.Interface.(error)
+			if err, ok := field.Interface.(error); ok && err != nil {
+				errField = err
+			}
 			continue
 		}
 		field.AddTo(enc)

--- a/bridges/otelzap/core_test.go
+++ b/bridges/otelzap/core_test.go
@@ -642,3 +642,41 @@ func TestConvertLevel(t *testing.T) {
 		}
 	}
 }
+
+func TestCoreMalformedErrorFieldDoesNotPanic(t *testing.T) {
+	tests := []struct {
+		name       string
+		fieldValue any
+	}{
+		{
+			name:       "NilError",
+			fieldValue: nil,
+		},
+		{
+			name:       "InvalidErrorType",
+			fieldValue: "not-an-error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newCaptureProvider()
+			logger := zap.New(NewCore(loggerName, WithLoggerProvider(p)))
+
+			ce := logger.Check(zap.ErrorLevel, testMessage)
+			require.NotNil(t, ce)
+
+			require.NotPanics(t, func() {
+				ce.Write(zapcore.Field{
+					Key:       "error",
+					Type:      zapcore.ErrorType,
+					Interface: tt.fieldValue,
+				})
+			})
+
+			r := p.logger.lastRecord(t)
+			require.NoError(t, r.err)
+			require.Empty(t, r.attrs)
+		})
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go-contrib/issues/9043

## Summary

Fixes a panic in `bridges/otelzap` when handling malformed zap error fields.

`convertField` previously performed an unguarded type assertion for fields with:

* `Type == zapcore.ErrorType`
* `Key == "error"`

This could panic if `field.Interface` was `nil` or not an `error`.

The conversion now safely checks the type assertion and ignores malformed error fields while preserving the existing behavior for valid `zap.Error(err)` fields.

## Changes

* Guarded the `field.Interface.(error)` type assertion in `convertField`
* Added tests covering:

  * `nil` error field values
  * invalid non-`error` field values

## Testing

Verified that:

* the new tests fail on the previous implementation
* all tests pass with this change
* valid `zap.Error(err)` behavior remains unchanged