### PR TITLE
detector/gcp: improve formatting for aggregated errors

### DIFF
--- a/detectors/gcp/detector.go
+++ b/detectors/gcp/detector.go
@@ -150,7 +150,7 @@ func (r *resourceBuilder) addZoneOrRegion(detect func() (string, gcp.LocationTyp
 func (r *resourceBuilder) build() (*resource.Resource, error) {
 	var err error
 	if len(r.errs) > 0 {
-		err = fmt.Errorf("%w: %v", resource.ErrPartialResource, errors.Join(r.errs...))
+		err = fmt.Errorf("%w: %w", resource.ErrPartialResource, errors.Join(r.errs...))
 	}
 	return resource.NewWithAttributes(semconv.SchemaURL, r.attrs...), err
 }

--- a/detectors/gcp/detector.go
+++ b/detectors/gcp/detector.go
@@ -5,6 +5,7 @@ package gcp // import "go.opentelemetry.io/contrib/detectors/gcp"
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -149,7 +150,7 @@ func (r *resourceBuilder) addZoneOrRegion(detect func() (string, gcp.LocationTyp
 func (r *resourceBuilder) build() (*resource.Resource, error) {
 	var err error
 	if len(r.errs) > 0 {
-		err = fmt.Errorf("%w: %s", resource.ErrPartialResource, r.errs)
+		err = fmt.Errorf("%w: %v", resource.ErrPartialResource, errors.Join(r.errs...))
 	}
 	return resource.NewWithAttributes(semconv.SchemaURL, r.attrs...), err
 }


### PR DESCRIPTION
GCP detector currently accumulates errors into a slice but formats them using %s, 
https://github.com/open-telemetry/opentelemetry-go-contrib/blob/b2c2fd45aabd4f8b08bf6df0e4bca6712215dcf3/detectors/gcp/detector.go#L152
which results in
`[err_mesg1 err_mesg1 err_mesg1 err_mesg1 err_mesg1]`

This approach uses delimiter-based formatting provided by `errors.Join`.

- No new tests due to lack of logic change.
- This change is not applied in deprecated detectors (gke, gce, cloud-run).

**Current State output**
```bash
=== error output ===
partial resource: [zone/region lookup failed: metadata endpoint unreachable cluster name lookup failed: permission denied host ID lookup failed: instance ID not found]

=== resource attributes (partial) ===
  cloud.account.id = my-project
  cloud.platform = gcp_kubernetes_engine
  cloud.provider = gcp
--- PASS: TestErrorFormatDemo (0.00s)
=== RUN   TestVersionSemver
--- PASS: TestVersionSemver (0.00s)
```

**Post Change**
```bash
=== error output ===
partial resource: zone/region lookup failed: metadata endpoint unreachable
cluster name lookup failed: permission denied
host ID lookup failed: instance ID not found

=== resource attributes (partial) ===
  cloud.account.id = my-project
  cloud.platform = gcp_kubernetes_engine
  cloud.provider = gcp
--- PASS: TestErrorFormatDemo (0.00s)
=== RUN   TestVersionSemver
--- PASS: TestVersionSemver (0.00s)
```


Fixes: #9059 