### PR TITLE
fix(autoprop): return no-op propagator instead of nil for empty input

### DIFF
--- a/propagators/autoprop/propagator_test.go
+++ b/propagators/autoprop/propagator_test.go
@@ -50,6 +50,19 @@ func TestNewTextMapPropagatorSingleNoOverhead(t *testing.T) {
 	assert.Same(t, p, NewTextMapPropagator(p))
 }
 
+func TestTextMapPropagatorEmptyNoError(t *testing.T) {
+	// Empty input should return a no-op propagator, not nil.
+	// See https://github.com/open-telemetry/opentelemetry-go-contrib/issues/9057
+	p, err := TextMapPropagator()
+	assert.NoError(t, err)
+	assert.NotNil(t, p, "empty TextMapPropagator should return a non-nil no-op propagator")
+
+	// Verify it is safe to call methods on the returned propagator.
+	ctx := p.Inject(context.Background(), nil)
+	assert.NotNil(t, ctx)
+	assert.Empty(t, p.Fields())
+}
+
 func TestNewTextMapPropagatorMultiEnvNone(t *testing.T) {
 	t.Setenv(otelPropagatorsEnvKey, "b3,none,tracecontext")
 	assert.Equal(t, noop, NewTextMapPropagator())

--- a/propagators/autoprop/registry.go
+++ b/propagators/autoprop/registry.go
@@ -149,7 +149,7 @@ func TextMapPropagator(names ...string) (propagation.TextMapPropagator, error) {
 
 	switch len(props) {
 	case 0:
-		return nil, err
+		return propagation.NewCompositeTextMapPropagator(), err
 	case 1:
 		// Do not return a composite of a single propagator.
 		return props[0], err


### PR DESCRIPTION
## Problem

`TextMapPropagator(names ...string)` [documents](https://github.com/open-telemetry/opentelemetry-go-contrib/blob/main/propagators/autoprop/registry.go#L116-L117) that empty input returns a no-operation propagator:

> If "none" is included in the arguments, or no names are provided, the returned TextMapPropagator will be a no-operation implementation.

The implementation returns `nil` when `len(props)==0` ([registry.go:152](https://github.com/open-telemetry/opentelemetry-go-contrib/blob/main/propagators/autoprop/registry.go#L152)), so callers that trust the documented contract panic when calling `Inject`, `Extract`, or `Fields` on the return value.

## Fix

Change `return nil, err` to `return propagation.NewCompositeTextMapPropagator(), err` in the `case 0` branch, matching the behavior already used for the `"none"` name on line 133.

Also add `TestTextMapPropagatorEmptyNoError` to verify the fix.

Fixes #9057