### PR TITLE
otelconf: fix standalone without_* Prometheus options being ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix Prometheus reader ignoring standalone `without_units` and `without_type_suffix` options in `go.opentelemetry.io/contrib/otelconf/v0.3.0`. (#9107)
+
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->
 

--- a/otelconf/v0.3.0/metric.go
+++ b/otelconf/v0.3.0/metric.go
@@ -394,6 +394,13 @@ func prometheusReaderOpts(prometheusConfig *Prometheus) ([]otelprom.Option, erro
 		opts = append(opts, otelprom.WithTranslationStrategy(otlptranslator.NoTranslation))
 	} else {
 		opts = append(opts, otelprom.WithTranslationStrategy(otlptranslator.NoUTF8EscapingWithSuffixes))
+
+		if prometheusConfig.WithoutTypeSuffix != nil && *prometheusConfig.WithoutTypeSuffix {
+			opts = append(opts, otelprom.WithoutCounterSuffixes())
+		}
+		if prometheusConfig.WithoutUnits != nil && *prometheusConfig.WithoutUnits {
+			opts = append(opts, otelprom.WithoutUnits())
+		}
 	}
 
 	if prometheusConfig.WithResourceConstantLabels != nil {

--- a/otelconf/v0.3.0/metric.go
+++ b/otelconf/v0.3.0/metric.go
@@ -396,10 +396,10 @@ func prometheusReaderOpts(prometheusConfig *Prometheus) ([]otelprom.Option, erro
 		opts = append(opts, otelprom.WithTranslationStrategy(otlptranslator.NoUTF8EscapingWithSuffixes))
 
 		if prometheusConfig.WithoutTypeSuffix != nil && *prometheusConfig.WithoutTypeSuffix {
-			opts = append(opts, otelprom.WithoutCounterSuffixes())
+			opts = append(opts, otelprom.WithoutCounterSuffixes()) //nolint:staticcheck // no WithTranslationStrategy equivalent for per-suffix control
 		}
 		if prometheusConfig.WithoutUnits != nil && *prometheusConfig.WithoutUnits {
-			opts = append(opts, otelprom.WithoutUnits())
+			opts = append(opts, otelprom.WithoutUnits()) //nolint:staticcheck // no WithTranslationStrategy equivalent for per-suffix control
 		}
 	}
 

--- a/otelconf/v0.3.0/metric_test.go
+++ b/otelconf/v0.3.0/metric_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
@@ -1397,6 +1398,20 @@ func TestPrometheusReaderOpts(t *testing.T) {
 			},
 			wantOptions: 2,
 		},
+		{
+			name: "without_type_suffix only",
+			cfg: Prometheus{
+				WithoutTypeSuffix: ptr(true),
+			},
+			wantOptions: 2,
+		},
+		{
+			name: "without_units only",
+			cfg: Prometheus{
+				WithoutUnits: ptr(true),
+			},
+			wantOptions: 2,
+		},
 	}
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1405,6 +1420,54 @@ func TestPrometheusReaderOpts(t *testing.T) {
 			require.Len(t, opts, tt.wantOptions)
 		})
 	}
+}
+
+// TestPrometheusReaderOptsStandaloneFlags verifies that a single without_* flag is
+// honoured even when the other is absent. Previously both had to be true simultaneously
+// before either took effect.
+func TestPrometheusReaderOptsStandaloneFlags(t *testing.T) {
+	// collectName creates a Prometheus exporter from opts, records one counter
+	// observation with unit "s", gathers all metrics, and returns the first
+	// metric family name that starts with "request_duration".
+	collectName := func(t *testing.T, opts []otelprom.Option) string {
+		t.Helper()
+		reg := prometheus.NewRegistry()
+		opts = append(opts, otelprom.WithRegisterer(reg))
+		exp, err := otelprom.New(opts...)
+		require.NoError(t, err)
+		mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(exp))
+		t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+		c, err := mp.Meter("test").Int64Counter("request_duration", metric.WithUnit("s"))
+		require.NoError(t, err)
+		c.Add(context.Background(), 1)
+
+		mfs, err := reg.Gather()
+		require.NoError(t, err)
+		for _, mf := range mfs {
+			if strings.HasPrefix(mf.GetName(), "request_duration") {
+				return mf.GetName()
+			}
+		}
+		t.Fatal("request_duration metric not found")
+		return ""
+	}
+
+	t.Run("without_units only omits unit suffix", func(t *testing.T) {
+		cfg := Prometheus{WithoutUnits: ptr(true)}
+		opts, err := prometheusReaderOpts(&cfg)
+		require.NoError(t, err)
+		// Unit suffix (_seconds) must be absent; counter suffix (_total) stays.
+		assert.Equal(t, "request_duration_total", collectName(t, opts))
+	})
+
+	t.Run("without_type_suffix only omits counter suffix", func(t *testing.T) {
+		cfg := Prometheus{WithoutTypeSuffix: ptr(true)}
+		opts, err := prometheusReaderOpts(&cfg)
+		require.NoError(t, err)
+		// Counter suffix (_total) must be absent; unit suffix (_seconds) stays.
+		assert.Equal(t, "request_duration_seconds", collectName(t, opts))
+	})
 }
 
 func TestPrometheusIPv6(t *testing.T) {

--- a/otelconf/v0.3.0/metric_test.go
+++ b/otelconf/v0.3.0/metric_test.go
@@ -1423,7 +1423,7 @@ func TestPrometheusReaderOpts(t *testing.T) {
 }
 
 // TestPrometheusReaderOptsStandaloneFlags verifies that a single without_* flag is
-// honoured even when the other is absent. Previously both had to be true simultaneously
+// honored even when the other is absent. Previously both had to be true simultaneously
 // before either took effect.
 func TestPrometheusReaderOptsStandaloneFlags(t *testing.T) {
 	// collectName creates a Prometheus exporter from opts, records one counter
@@ -1436,11 +1436,15 @@ func TestPrometheusReaderOptsStandaloneFlags(t *testing.T) {
 		exp, err := otelprom.New(opts...)
 		require.NoError(t, err)
 		mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(exp))
-		t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+		t.Cleanup(func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_ = mp.Shutdown(ctx)
+		})
 
 		c, err := mp.Meter("test").Int64Counter("request_duration", metric.WithUnit("s"))
 		require.NoError(t, err)
-		c.Add(context.Background(), 1)
+		c.Add(t.Context(), 1)
 
 		mfs, err := reg.Gather()
 		require.NoError(t, err)


### PR DESCRIPTION
## Description

Standalone `without_units` / `without_type_suffix` Prometheus options were
ignored when set on their own - only the both-set case was handled. This
applies the matching option in the single-flag case (`without_type_suffix`
→ `WithoutCounterSuffixes()`, `without_units` → `WithoutUnits()`).

Fixes #9051

## Verification

Ran the reproduction PoC from the issue against the change: standalone
`without_units` now yields `request_duration_total` and standalone
`without_type_suffix` yields `request_duration_seconds`, matching the
direct-API behavior.

<img width="1187" height="441" alt="image" src="https://github.com/user-attachments/assets/750b8013-573f-40e2-a396-9f46d244764d" />
