### PR TITLE
otelconf: allow null OTLP endpoint to use defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - The `Version()` function in `go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux` has been replaced by `const Version`. (#9076)
 
+### Fixed
+
+- Allow `endpoint` to be omitted or set to `null` for OTLP exporters in `go.opentelemetry.io/contrib/otelconf` and `go.opentelemetry.io/contrib/otelconf/x`; the SDK exporter defaults are used in this case, matching the OpenTelemetry configuration schema. (#9052)
+
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->
 

--- a/otelconf/config_json.go
+++ b/otelconf/config_json.go
@@ -470,96 +470,56 @@ func (j *SpanLimits) UnmarshalJSON(value []byte) error {
 // UnmarshalJSON implements json.Unmarshaler.
 func (j *OTLPHttpMetricExporter) UnmarshalJSON(b []byte) error {
 	type Plain OTLPHttpMetricExporter
-	type shadow struct {
-		Plain
-		Endpoint json.RawMessage `json:"endpoint"`
-	}
-	var sh shadow
-	if err := json.Unmarshal(b, &sh); err != nil {
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
 		return errors.Join(newErrUnmarshal(j), err)
 	}
-	if sh.Endpoint == nil {
-		return newErrRequired(j, "endpoint")
-	}
-	if err := json.Unmarshal(sh.Endpoint, &sh.Plain.Endpoint); err != nil {
-		return err
-	}
-	if sh.Timeout != nil && 0 > *sh.Timeout {
+	if plain.Timeout != nil && 0 > *plain.Timeout {
 		return newErrGreaterOrEqualZero("timeout")
 	}
-	*j = OTLPHttpMetricExporter(sh.Plain)
+	*j = OTLPHttpMetricExporter(plain)
 	return nil
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (j *OTLPGrpcMetricExporter) UnmarshalJSON(b []byte) error {
 	type Plain OTLPGrpcMetricExporter
-	type shadow struct {
-		Plain
-		Endpoint json.RawMessage `json:"endpoint"`
-	}
-	var sh shadow
-	if err := json.Unmarshal(b, &sh); err != nil {
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
 		return errors.Join(newErrUnmarshal(j), err)
 	}
-	if sh.Endpoint == nil {
-		return newErrRequired(j, "endpoint")
-	}
-	if err := json.Unmarshal(sh.Endpoint, &sh.Plain.Endpoint); err != nil {
-		return err
-	}
-	if sh.Timeout != nil && 0 > *sh.Timeout {
+	if plain.Timeout != nil && 0 > *plain.Timeout {
 		return newErrGreaterOrEqualZero("timeout")
 	}
-	*j = OTLPGrpcMetricExporter(sh.Plain)
+	*j = OTLPGrpcMetricExporter(plain)
 	return nil
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (j *OTLPHttpExporter) UnmarshalJSON(b []byte) error {
 	type Plain OTLPHttpExporter
-	type shadow struct {
-		Plain
-		Endpoint json.RawMessage `json:"endpoint"`
-	}
-	var sh shadow
-	if err := json.Unmarshal(b, &sh); err != nil {
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
 		return errors.Join(newErrUnmarshal(j), err)
 	}
-	if sh.Endpoint == nil {
-		return newErrRequired(j, "endpoint")
-	}
-	if err := json.Unmarshal(sh.Endpoint, &sh.Plain.Endpoint); err != nil {
-		return err
-	}
-	if sh.Timeout != nil && 0 > *sh.Timeout {
+	if plain.Timeout != nil && 0 > *plain.Timeout {
 		return newErrGreaterOrEqualZero("timeout")
 	}
-	*j = OTLPHttpExporter(sh.Plain)
+	*j = OTLPHttpExporter(plain)
 	return nil
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (j *OTLPGrpcExporter) UnmarshalJSON(b []byte) error {
 	type Plain OTLPGrpcExporter
-	type shadow struct {
-		Plain
-		Endpoint json.RawMessage `json:"endpoint"`
-	}
-	var sh shadow
-	if err := json.Unmarshal(b, &sh); err != nil {
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
 		return errors.Join(newErrUnmarshal(j), err)
 	}
-	if sh.Endpoint == nil {
-		return newErrRequired(j, "endpoint")
-	}
-	if err := json.Unmarshal(sh.Endpoint, &sh.Plain.Endpoint); err != nil {
-		return err
-	}
-	if sh.Timeout != nil && 0 > *sh.Timeout {
+	if plain.Timeout != nil && 0 > *plain.Timeout {
 		return newErrGreaterOrEqualZero("timeout")
 	}
-	*j = OTLPGrpcExporter(sh.Plain)
+	*j = OTLPGrpcExporter(plain)
 	return nil
 }
 

--- a/otelconf/config_test.go
+++ b/otelconf/config_test.go
@@ -1534,10 +1534,14 @@ func TestUnmarshalOTLPHttpExporter(t *testing.T) {
 			wantExporter: OTLPHttpExporter{Endpoint: ptr("localhost:4318")},
 		},
 		{
-			name:       "missing required endpoint field",
+			name:       "missing endpoint uses default",
 			jsonConfig: []byte(`{}`),
 			yamlConfig: []byte("{}"),
-			wantErrT:   newErrRequired(&OTLPHttpExporter{}, "endpoint"),
+		},
+		{
+			name:       "null endpoint uses default",
+			jsonConfig: []byte(`{"endpoint":null}`),
+			yamlConfig: []byte("endpoint: null\n"),
 		},
 		{
 			name:         "valid with zero timeout",
@@ -1587,10 +1591,14 @@ func TestUnmarshalOTLPGrpcExporter(t *testing.T) {
 			wantExporter: OTLPGrpcExporter{Endpoint: ptr("localhost:4318")},
 		},
 		{
-			name:       "missing required endpoint field",
+			name:       "missing endpoint uses default",
 			jsonConfig: []byte(`{}`),
 			yamlConfig: []byte("{}"),
-			wantErrT:   newErrRequired(&OTLPGrpcExporter{}, "endpoint"),
+		},
+		{
+			name:       "null endpoint uses default",
+			jsonConfig: []byte(`{"endpoint":null}`),
+			yamlConfig: []byte("endpoint: null\n"),
 		},
 		{
 			name:         "valid with zero timeout",
@@ -1640,10 +1648,14 @@ func TestUnmarshalOTLPHttpMetricExporter(t *testing.T) {
 			wantExporter: OTLPHttpMetricExporter{Endpoint: ptr("localhost:4318")},
 		},
 		{
-			name:       "missing required endpoint field",
+			name:       "missing endpoint uses default",
 			jsonConfig: []byte(`{}`),
 			yamlConfig: []byte("{}"),
-			wantErrT:   newErrRequired(&OTLPHttpMetricExporter{}, "endpoint"),
+		},
+		{
+			name:       "null endpoint uses default",
+			jsonConfig: []byte(`{"endpoint":null}`),
+			yamlConfig: []byte("endpoint: null\n"),
 		},
 		{
 			name:         "valid with zero timeout",
@@ -1693,10 +1705,14 @@ func TestUnmarshalOTLPGrpcMetricExporter(t *testing.T) {
 			wantExporter: OTLPGrpcMetricExporter{Endpoint: ptr("localhost:4318")},
 		},
 		{
-			name:       "missing required endpoint field",
+			name:       "missing endpoint uses default",
 			jsonConfig: []byte(`{}`),
 			yamlConfig: []byte("{}"),
-			wantErrT:   newErrRequired(&OTLPGrpcMetricExporter{}, "endpoint"),
+		},
+		{
+			name:       "null endpoint uses default",
+			jsonConfig: []byte(`{"endpoint":null}`),
+			yamlConfig: []byte("endpoint: null\n"),
 		},
 		{
 			name:         "valid with zero timeout",

--- a/otelconf/config_yaml.go
+++ b/otelconf/config_yaml.go
@@ -285,9 +285,6 @@ func (j *SpanLimits) UnmarshalYAML(node *yaml.Node) error {
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (j *OTLPHttpMetricExporter) UnmarshalYAML(node *yaml.Node) error {
-	if !hasYAMLMapKey(node, "endpoint") {
-		return newErrRequired(j, "endpoint")
-	}
 	type Plain OTLPHttpMetricExporter
 	var plain Plain
 	if err := node.Decode(&plain); err != nil {
@@ -302,9 +299,6 @@ func (j *OTLPHttpMetricExporter) UnmarshalYAML(node *yaml.Node) error {
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (j *OTLPGrpcMetricExporter) UnmarshalYAML(node *yaml.Node) error {
-	if !hasYAMLMapKey(node, "endpoint") {
-		return newErrRequired(j, "endpoint")
-	}
 	type Plain OTLPGrpcMetricExporter
 	var plain Plain
 	if err := node.Decode(&plain); err != nil {
@@ -319,9 +313,6 @@ func (j *OTLPGrpcMetricExporter) UnmarshalYAML(node *yaml.Node) error {
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (j *OTLPHttpExporter) UnmarshalYAML(node *yaml.Node) error {
-	if !hasYAMLMapKey(node, "endpoint") {
-		return newErrRequired(j, "endpoint")
-	}
 	type Plain OTLPHttpExporter
 	var plain Plain
 	if err := node.Decode(&plain); err != nil {
@@ -336,9 +327,6 @@ func (j *OTLPHttpExporter) UnmarshalYAML(node *yaml.Node) error {
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (j *OTLPGrpcExporter) UnmarshalYAML(node *yaml.Node) error {
-	if !hasYAMLMapKey(node, "endpoint") {
-		return newErrRequired(j, "endpoint")
-	}
 	type Plain OTLPGrpcExporter
 	var plain Plain
 	if err := node.Decode(&plain); err != nil {

--- a/otelconf/x/config_json.go
+++ b/otelconf/x/config_json.go
@@ -594,96 +594,56 @@ func (j *SpanLimits) UnmarshalJSON(value []byte) error {
 // UnmarshalJSON implements json.Unmarshaler.
 func (j *OTLPHttpMetricExporter) UnmarshalJSON(b []byte) error {
 	type Plain OTLPHttpMetricExporter
-	type shadow struct {
-		Plain
-		Endpoint json.RawMessage `json:"endpoint"`
-	}
-	var sh shadow
-	if err := json.Unmarshal(b, &sh); err != nil {
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
 		return errors.Join(newErrUnmarshal(j), err)
 	}
-	if sh.Endpoint == nil {
-		return newErrRequired(j, "endpoint")
-	}
-	if err := json.Unmarshal(sh.Endpoint, &sh.Plain.Endpoint); err != nil {
-		return err
-	}
-	if sh.Timeout != nil && 0 > *sh.Timeout {
+	if plain.Timeout != nil && 0 > *plain.Timeout {
 		return newErrGreaterOrEqualZero("timeout")
 	}
-	*j = OTLPHttpMetricExporter(sh.Plain)
+	*j = OTLPHttpMetricExporter(plain)
 	return nil
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (j *OTLPGrpcMetricExporter) UnmarshalJSON(b []byte) error {
 	type Plain OTLPGrpcMetricExporter
-	type shadow struct {
-		Plain
-		Endpoint json.RawMessage `json:"endpoint"`
-	}
-	var sh shadow
-	if err := json.Unmarshal(b, &sh); err != nil {
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
 		return errors.Join(newErrUnmarshal(j), err)
 	}
-	if sh.Endpoint == nil {
-		return newErrRequired(j, "endpoint")
-	}
-	if err := json.Unmarshal(sh.Endpoint, &sh.Plain.Endpoint); err != nil {
-		return err
-	}
-	if sh.Timeout != nil && 0 > *sh.Timeout {
+	if plain.Timeout != nil && 0 > *plain.Timeout {
 		return newErrGreaterOrEqualZero("timeout")
 	}
-	*j = OTLPGrpcMetricExporter(sh.Plain)
+	*j = OTLPGrpcMetricExporter(plain)
 	return nil
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (j *OTLPHttpExporter) UnmarshalJSON(b []byte) error {
 	type Plain OTLPHttpExporter
-	type shadow struct {
-		Plain
-		Endpoint json.RawMessage `json:"endpoint"`
-	}
-	var sh shadow
-	if err := json.Unmarshal(b, &sh); err != nil {
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
 		return errors.Join(newErrUnmarshal(j), err)
 	}
-	if sh.Endpoint == nil {
-		return newErrRequired(j, "endpoint")
-	}
-	if err := json.Unmarshal(sh.Endpoint, &sh.Plain.Endpoint); err != nil {
-		return err
-	}
-	if sh.Timeout != nil && 0 > *sh.Timeout {
+	if plain.Timeout != nil && 0 > *plain.Timeout {
 		return newErrGreaterOrEqualZero("timeout")
 	}
-	*j = OTLPHttpExporter(sh.Plain)
+	*j = OTLPHttpExporter(plain)
 	return nil
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (j *OTLPGrpcExporter) UnmarshalJSON(b []byte) error {
 	type Plain OTLPGrpcExporter
-	type shadow struct {
-		Plain
-		Endpoint json.RawMessage `json:"endpoint"`
-	}
-	var sh shadow
-	if err := json.Unmarshal(b, &sh); err != nil {
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
 		return errors.Join(newErrUnmarshal(j), err)
 	}
-	if sh.Endpoint == nil {
-		return newErrRequired(j, "endpoint")
-	}
-	if err := json.Unmarshal(sh.Endpoint, &sh.Plain.Endpoint); err != nil {
-		return err
-	}
-	if sh.Timeout != nil && 0 > *sh.Timeout {
+	if plain.Timeout != nil && 0 > *plain.Timeout {
 		return newErrGreaterOrEqualZero("timeout")
 	}
-	*j = OTLPGrpcExporter(sh.Plain)
+	*j = OTLPGrpcExporter(plain)
 	return nil
 }
 

--- a/otelconf/x/config_test.go
+++ b/otelconf/x/config_test.go
@@ -1701,10 +1701,14 @@ func TestUnmarshalOTLPHttpExporter(t *testing.T) {
 			wantExporter: OTLPHttpExporter{Endpoint: ptr("localhost:4318")},
 		},
 		{
-			name:       "missing required endpoint field",
+			name:       "missing endpoint uses default",
 			jsonConfig: []byte(`{}`),
 			yamlConfig: []byte("{}"),
-			wantErrT:   newErrRequired(&OTLPHttpExporter{}, "endpoint"),
+		},
+		{
+			name:       "null endpoint uses default",
+			jsonConfig: []byte(`{"endpoint":null}`),
+			yamlConfig: []byte("endpoint: null\n"),
 		},
 		{
 			name:         "valid with zero timeout",
@@ -1754,10 +1758,14 @@ func TestUnmarshalOTLPGrpcExporter(t *testing.T) {
 			wantExporter: OTLPGrpcExporter{Endpoint: ptr("localhost:4318")},
 		},
 		{
-			name:       "missing required endpoint field",
+			name:       "missing endpoint uses default",
 			jsonConfig: []byte(`{}`),
 			yamlConfig: []byte("{}"),
-			wantErrT:   newErrRequired(&OTLPGrpcExporter{}, "endpoint"),
+		},
+		{
+			name:       "null endpoint uses default",
+			jsonConfig: []byte(`{"endpoint":null}`),
+			yamlConfig: []byte("endpoint: null\n"),
 		},
 		{
 			name:         "valid with zero timeout",
@@ -1807,10 +1815,14 @@ func TestUnmarshalOTLPHttpMetricExporter(t *testing.T) {
 			wantExporter: OTLPHttpMetricExporter{Endpoint: ptr("localhost:4318")},
 		},
 		{
-			name:       "missing required endpoint field",
+			name:       "missing endpoint uses default",
 			jsonConfig: []byte(`{}`),
 			yamlConfig: []byte("{}"),
-			wantErrT:   newErrRequired(&OTLPHttpMetricExporter{}, "endpoint"),
+		},
+		{
+			name:       "null endpoint uses default",
+			jsonConfig: []byte(`{"endpoint":null}`),
+			yamlConfig: []byte("endpoint: null\n"),
 		},
 		{
 			name:         "valid with zero timeout",
@@ -1860,10 +1872,14 @@ func TestUnmarshalOTLPGrpcMetricExporter(t *testing.T) {
 			wantExporter: OTLPGrpcMetricExporter{Endpoint: ptr("localhost:4318")},
 		},
 		{
-			name:       "missing required endpoint field",
+			name:       "missing endpoint uses default",
 			jsonConfig: []byte(`{}`),
 			yamlConfig: []byte("{}"),
-			wantErrT:   newErrRequired(&OTLPGrpcMetricExporter{}, "endpoint"),
+		},
+		{
+			name:       "null endpoint uses default",
+			jsonConfig: []byte(`{"endpoint":null}`),
+			yamlConfig: []byte("endpoint: null\n"),
 		},
 		{
 			name:         "valid with zero timeout",

--- a/otelconf/x/config_yaml.go
+++ b/otelconf/x/config_yaml.go
@@ -314,9 +314,6 @@ func (j *SpanLimits) UnmarshalYAML(node *yaml.Node) error {
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (j *OTLPHttpMetricExporter) UnmarshalYAML(node *yaml.Node) error {
-	if !hasYAMLMapKey(node, "endpoint") {
-		return newErrRequired(j, "endpoint")
-	}
 	type Plain OTLPHttpMetricExporter
 	var plain Plain
 	if err := node.Decode(&plain); err != nil {
@@ -331,9 +328,6 @@ func (j *OTLPHttpMetricExporter) UnmarshalYAML(node *yaml.Node) error {
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (j *OTLPGrpcMetricExporter) UnmarshalYAML(node *yaml.Node) error {
-	if !hasYAMLMapKey(node, "endpoint") {
-		return newErrRequired(j, "endpoint")
-	}
 	type Plain OTLPGrpcMetricExporter
 	var plain Plain
 	if err := node.Decode(&plain); err != nil {
@@ -348,9 +342,6 @@ func (j *OTLPGrpcMetricExporter) UnmarshalYAML(node *yaml.Node) error {
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (j *OTLPHttpExporter) UnmarshalYAML(node *yaml.Node) error {
-	if !hasYAMLMapKey(node, "endpoint") {
-		return newErrRequired(j, "endpoint")
-	}
 	type Plain OTLPHttpExporter
 	var plain Plain
 	if err := node.Decode(&plain); err != nil {
@@ -365,9 +356,6 @@ func (j *OTLPHttpExporter) UnmarshalYAML(node *yaml.Node) error {
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (j *OTLPGrpcExporter) UnmarshalYAML(node *yaml.Node) error {
-	if !hasYAMLMapKey(node, "endpoint") {
-		return newErrRequired(j, "endpoint")
-	}
 	type Plain OTLPGrpcExporter
 	var plain Plain
 	if err := node.Decode(&plain); err != nil {


### PR DESCRIPTION
Closes #9052.

The required `endpoint` field for OTLP exporter configs only checked that the JSON/YAML key was present, so `{"endpoint":null}` and `endpoint: null` decoded to a nil `*string` and bypassed `newErrRequired`. Add a post-unmarshal nil check in the manual JSON and YAML unmarshalers for `OTLPHttpExporter`, `OTLPGrpcExporter`, `OTLPHttpMetricExporter`, and `OTLPGrpcMetricExporter` in `otelconf` and `otelconf/x`, returning the same `newErrRequired(j, "endpoint")` used for the missing-key case.

Add `null endpoint` cases to the existing `TestUnmarshalOTLP*` table tests covering both JSON and YAML inputs.