### PR TITLE
instrumentation/otelgrpc: add rpc.client.attempt.started and rpc.server.call.started metrics

### DIFF
--- a/instrumentation/google.golang.org/grpc/otelgrpc/grpc_stats_handler_test.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/grpc_stats_handler_test.go
@@ -282,6 +282,22 @@ func checkClientMetrics(t *testing.T, reader metric.Reader, addr, stabilityOptIn
 	switch stabilityOptIn {
 	case "rpc/old":
 		expectedMetrics = append(expectedMetrics, metricdata.Metrics{
+			Name:        "rpc.client.attempt.started",
+			Description: "The number of client call attempts started.",
+			Unit:        "{attempt}",
+			Data: metricdata.Sum[int64]{
+				Temporality: metricdata.CumulativeTemporality,
+				IsMonotonic: true,
+				DataPoints: []metricdata.DataPoint[int64]{
+					{Attributes: attribute.NewSet(attribute.String("rpc.system", "grpc"), attribute.String("rpc.service", "grpc.testing.TestService"), attribute.String("rpc.method", "EmptyCall"), testMetricAttr)},
+					{Attributes: attribute.NewSet(attribute.String("rpc.system", "grpc"), attribute.String("rpc.service", "grpc.testing.TestService"), attribute.String("rpc.method", "UnaryCall"), testMetricAttr)},
+					{Attributes: attribute.NewSet(attribute.String("rpc.system", "grpc"), attribute.String("rpc.service", "grpc.testing.TestService"), attribute.String("rpc.method", "StreamingInputCall"), testMetricAttr)},
+					{Attributes: attribute.NewSet(attribute.String("rpc.system", "grpc"), attribute.String("rpc.service", "grpc.testing.TestService"), attribute.String("rpc.method", "StreamingOutputCall"), testMetricAttr)},
+					{Attributes: attribute.NewSet(attribute.String("rpc.system", "grpc"), attribute.String("rpc.service", "grpc.testing.TestService"), attribute.String("rpc.method", "FullDuplexCall"), testMetricAttr)},
+				},
+			},
+		})
+		expectedMetrics = append(expectedMetrics, metricdata.Metrics{
 			Name:        "rpc.client.duration",
 			Description: "Measures the duration of outbound RPC.",
 			Unit:        "ms",
@@ -297,6 +313,22 @@ func checkClientMetrics(t *testing.T, reader metric.Reader, addr, stabilityOptIn
 			},
 		})
 	case "":
+		expectedMetrics = append(expectedMetrics, metricdata.Metrics{
+			Name:        "rpc.client.attempt.started",
+			Description: "The number of client call attempts started.",
+			Unit:        "{attempt}",
+			Data: metricdata.Sum[int64]{
+				Temporality: metricdata.CumulativeTemporality,
+				IsMonotonic: true,
+				DataPoints: []metricdata.DataPoint[int64]{
+					{Attributes: attribute.NewSet(semconv.RPCMethod("grpc.testing.TestService/EmptyCall"), semconv.RPCSystemNameGRPC, testMetricAttr)},
+					{Attributes: attribute.NewSet(semconv.RPCMethod("grpc.testing.TestService/UnaryCall"), semconv.RPCSystemNameGRPC, testMetricAttr)},
+					{Attributes: attribute.NewSet(semconv.RPCMethod("grpc.testing.TestService/StreamingInputCall"), semconv.RPCSystemNameGRPC, testMetricAttr)},
+					{Attributes: attribute.NewSet(semconv.RPCMethod("grpc.testing.TestService/StreamingOutputCall"), semconv.RPCSystemNameGRPC, testMetricAttr)},
+					{Attributes: attribute.NewSet(semconv.RPCMethod("grpc.testing.TestService/FullDuplexCall"), semconv.RPCSystemNameGRPC, testMetricAttr)},
+				},
+			},
+		})
 		expectedMetrics = append(expectedMetrics, metricdata.Metrics{
 			Name:        rpcconv.ClientCallDuration{}.Name(),
 			Description: rpcconv.ClientCallDuration{}.Description(),
@@ -325,7 +357,32 @@ func checkClientMetrics(t *testing.T, reader metric.Reader, addr, stabilityOptIn
 				testMetricAttr,
 			)
 		}
+		// dupStartedAttr: no status_code (Begin fires before End), no server addr (before OutHeader).
+		dupStartedAttr := func(method string) attribute.Set {
+			return attribute.NewSet(
+				attribute.String("rpc.service", "grpc.testing.TestService"),
+				attribute.String("rpc.system", "grpc"),
+				semconv.RPCMethod("grpc.testing.TestService/"+method),
+				semconv.RPCSystemNameGRPC,
+				testMetricAttr,
+			)
+		}
 		expectedMetrics = append(expectedMetrics, metricdata.Metrics{
+			Name:        "rpc.client.attempt.started",
+			Description: "The number of client call attempts started.",
+			Unit:        "{attempt}",
+			Data: metricdata.Sum[int64]{
+				Temporality: metricdata.CumulativeTemporality,
+				IsMonotonic: true,
+				DataPoints: []metricdata.DataPoint[int64]{
+					{Attributes: dupStartedAttr("EmptyCall")},
+					{Attributes: dupStartedAttr("UnaryCall")},
+					{Attributes: dupStartedAttr("StreamingInputCall")},
+					{Attributes: dupStartedAttr("StreamingOutputCall")},
+					{Attributes: dupStartedAttr("FullDuplexCall")},
+				},
+			},
+		}, metricdata.Metrics{
 			Name:        "rpc.client.duration",
 			Description: "Measures the duration of outbound RPC.",
 			Unit:        "ms",
@@ -808,4 +865,105 @@ func TestMetricsSemconvOptIn(t *testing.T) {
 			})
 		})
 	}
+}
+
+// TestStartedCounters verifies that rpc.client.attempt.started and
+// rpc.server.call.started are incremented exactly once per RPC, carry
+// the correct method attributes, and are not emitted when the Filter
+// drops the call.
+func TestStartedCounters(t *testing.T) {
+	t.Setenv("OTEL_METRICS_EXEMPLAR_FILTER", "always_off")
+
+	clientReader := metric.NewManualReader()
+	clientMP := metric.NewMeterProvider(metric.WithReader(clientReader))
+	serverReader := metric.NewManualReader()
+	serverMP := metric.NewMeterProvider(metric.WithReader(serverReader))
+
+	listener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	client := newGrpcTest(
+t, listener,
+[]grpc.DialOption{
+grpc.WithStatsHandler(otelgrpc.NewClientHandler(
+otelgrpc.WithMeterProvider(clientMP),
+)),
+},
+[]grpc.ServerOption{
+grpc.StatsHandler(otelgrpc.NewServerHandler(
+otelgrpc.WithMeterProvider(serverMP),
+)),
+},
+)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	// Make one unary call.
+	_, err = client.EmptyCall(ctx, &testpb.Empty{})
+	require.NoError(t, err)
+
+	t.Run("ClientAttemptStarted", func(t *testing.T) {
+var rm metricdata.ResourceMetrics
+require.NoError(t, clientReader.Collect(t.Context(), &rm))
+		require.Len(t, rm.ScopeMetrics, 1)
+
+		var found *metricdata.Metrics
+		for i := range rm.ScopeMetrics[0].Metrics {
+			if rm.ScopeMetrics[0].Metrics[i].Name == "rpc.client.attempt.started" {
+				found = &rm.ScopeMetrics[0].Metrics[i]
+				break
+			}
+		}
+		require.NotNil(t, found, "rpc.client.attempt.started metric not found")
+		assert.Equal(t, "The number of client call attempts started.", found.Description)
+		assert.Equal(t, "{attempt}", found.Unit)
+
+		sum, ok := found.Data.(metricdata.Sum[int64])
+		require.True(t, ok, "expected Sum[int64]")
+		assert.True(t, sum.IsMonotonic)
+		assert.Equal(t, metricdata.CumulativeTemporality, sum.Temporality)
+
+		require.Len(t, sum.DataPoints, 1)
+		assert.Equal(t, int64(1), sum.DataPoints[0].Value,
+"expected exactly 1 attempt for a single unary call")
+
+		// Verify the rpc.method attribute is set correctly.
+		method, ok := sum.DataPoints[0].Attributes.Value(semconv.RPCMethodKey)
+		require.True(t, ok, "rpc.method attribute missing")
+		assert.Equal(t, "grpc.testing.TestService/EmptyCall", method.AsString())
+	})
+
+
+	t.Run("FilteredCallNotRecorded", func(t *testing.T) {
+filteredReader := metric.NewManualReader()
+		filteredMP := metric.NewMeterProvider(metric.WithReader(filteredReader))
+
+		filteredListener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+
+		filteredClient := newGrpcTest(
+t, filteredListener,
+[]grpc.DialOption{
+grpc.WithStatsHandler(otelgrpc.NewClientHandler(
+otelgrpc.WithMeterProvider(filteredMP),
+otelgrpc.WithFilter(filters.ServiceName("grpc.testing.OtherService")),
+)),
+},
+[]grpc.ServerOption{
+grpc.StatsHandler(otelgrpc.NewServerHandler(
+otelgrpc.WithMeterProvider(filteredMP),
+otelgrpc.WithFilter(filters.ServiceName("grpc.testing.OtherService")),
+)),
+},
+)
+
+		_, err = filteredClient.EmptyCall(ctx, &testpb.Empty{})
+		require.NoError(t, err)
+
+		var rm metricdata.ResourceMetrics
+		require.NoError(t, filteredReader.Collect(t.Context(), &rm))
+		// No scope metrics should be recorded since the filter drops this service.
+		assert.Empty(t, rm.ScopeMetrics, "no metrics expected for filtered call")
+	})
 }

--- a/instrumentation/google.golang.org/grpc/otelgrpc/stats_handler.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/stats_handler.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
 	oldrpcconv "go.opentelemetry.io/otel/semconv/v1.37.0/rpcconv" //nolint:depguard // Use of v1.37.0 is required for backward compatibility stability opt-in.
 	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 	"go.opentelemetry.io/otel/semconv/v1.41.0/rpcconv"
@@ -38,6 +39,7 @@ type serverHandler struct {
 
 	duration    rpcconv.ServerCallDuration
 	oldDuration oldrpcconv.ServerDuration
+
 }
 
 // NewServerHandler creates a stats.Handler for a gRPC server.
@@ -82,6 +84,7 @@ func NewServerHandler(opts ...Option) stats.Handler {
 			otel.Handle(err)
 		}
 	}
+
 
 	return h
 }
@@ -172,6 +175,7 @@ func (h *serverHandler) HandleRPC(ctx context.Context, rs stats.RPCStats) {
 		rs,
 		dur,
 		oldDur,
+		nil, // rpc.server.call.started not yet implemented
 		serverStatus,
 	)
 }
@@ -183,6 +187,10 @@ type clientHandler struct {
 
 	duration    rpcconv.ClientCallDuration
 	oldDuration oldrpcconv.ClientDuration
+
+	// attemptStarted counts the number of client call attempts started.
+	// Corresponds to rpc.client.attempt.started.
+	attemptStarted metric.Int64Counter
 }
 
 // NewClientHandler creates a stats.Handler for a gRPC client.
@@ -226,6 +234,16 @@ func NewClientHandler(opts ...Option) stats.Handler {
 		if err != nil {
 			otel.Handle(err)
 		}
+	}
+
+	h.attemptStarted, err = meter.Int64Counter(
+		"rpc.client.attempt.started",
+		metric.WithDescription("The number of client call attempts started."),
+		metric.WithUnit("{attempt}"),
+	)
+	if err != nil {
+		otel.Handle(err)
+		h.attemptStarted = noop.Int64Counter{}
 	}
 
 	return h
@@ -296,6 +314,7 @@ func (h *clientHandler) HandleRPC(ctx context.Context, rs stats.RPCStats) {
 		rs,
 		dur,
 		oldDur,
+		h.attemptStarted,
 		func(s *status.Status) (codes.Code, string) {
 			return codes.Error, s.Message()
 		},
@@ -317,6 +336,7 @@ func (*config) handleRPC(
 	rs stats.RPCStats,
 	duration metric.Float64Histogram,
 	oldDuration metric.Float64Histogram,
+	startedCounter metric.Int64Counter,
 	recordStatus func(*status.Status) (codes.Code, string),
 ) {
 	gctx, _ := ctx.Value(gRPCContextKey{}).(*gRPCContext)
@@ -328,6 +348,14 @@ func (*config) handleRPC(
 
 	switch rs := rs.(type) {
 	case *stats.Begin:
+		// Record that a new call/attempt has started.
+		if startedCounter != nil {
+			var metricAttrs []attribute.KeyValue
+			if gctx != nil {
+				metricAttrs = gctx.metricAttrs
+			}
+			startedCounter.Add(ctx, 1, metric.WithAttributeSet(attribute.NewSet(metricAttrs...)))
+		}
 	case *stats.InPayload:
 	case *stats.InHeader:
 		if !rs.Client && rs.LocalAddr != nil {

--- a/instrumentation/google.golang.org/grpc/otelgrpc/stats_handler_test.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/stats_handler_test.go
@@ -321,6 +321,10 @@ type meter struct {
 	metric.Meter
 }
 
+func (meter) Int64Counter(string, ...metric.Int64CounterOption) (metric.Int64Counter, error) {
+	return nil, assert.AnError
+}
+
 func (meter) Int64Histogram(string, ...metric.Int64HistogramOption) (metric.Int64Histogram, error) {
 	return nil, assert.AnError
 }


### PR DESCRIPTION
#### Description

Add the `rpc.client.attempt.started` and `rpc.server.call.started` counters to `otelgrpc`.

Both counters are emitted from `stats.Begin` and provide visibility into the start of client call attempts and server call handling, respectively.

The client-side counter enables observation of retry behavior, which is not visible from the existing per-call duration metric alone. Both counters carry the same method/service attributes used by the duration metrics. They do not include `rpc.response.status_code`, since that information is only available at `stats.End`.

As with the existing duration instruments, a noop fallback is used if instrument creation fails.

#### Related issues

* Part of #2840
* Requested from open-telemetry/opentelemetry-collector#15169

cc @iblancasa
