### PR TITLE
Honor WithContext for otelconf resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- Honor the context configured with `WithContext` when constructing resources in `go.opentelemetry.io/contrib/otelconf` and `go.opentelemetry.io/contrib/otelconf/x`. (#TBD)
+- Honor the context configured with `WithContext` when constructing resources in `go.opentelemetry.io/contrib/otelconf` and `go.opentelemetry.io/contrib/otelconf/x`. (#9160)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - The `Version()` function in `go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux` has been replaced by `const Version`. (#9076)
 
+### Fixed
+
+- Honor the context configured with `WithContext` when constructing resources in `go.opentelemetry.io/contrib/otelconf` and `go.opentelemetry.io/contrib/otelconf/x`. (#TBD)
+
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->
 

--- a/otelconf/config.go
+++ b/otelconf/config.go
@@ -118,7 +118,7 @@ func NewSDK(opts ...ConfigurationOption) (SDK, error) {
 		return noopSDK, nil
 	}
 
-	r, err := newResource(o.opentelemetryConfig.Resource)
+	r, err := newResource(o.ctx, o.opentelemetryConfig.Resource)
 	if err != nil {
 		return noopSDK, err
 	}

--- a/otelconf/resource.go
+++ b/otelconf/resource.go
@@ -33,7 +33,7 @@ func newResourceWithBuilder(ctx context.Context, r *Resource, build resourceBuil
 		schema = *r.SchemaUrl
 	}
 	opts := []resource.Option{
-		resource.WithAttributes(resource.Default().Attributes()...),
+		resource.WithAttributes(resource.DefaultWithContext(ctx).Attributes()...),
 		resource.WithAttributes(attrs...),
 		resource.WithSchemaURL(schema),
 	}

--- a/otelconf/resource.go
+++ b/otelconf/resource.go
@@ -12,9 +12,15 @@ import (
 	"go.opentelemetry.io/contrib/otelconf/internal/kv"
 )
 
-func newResource(r *Resource) (*resource.Resource, error) {
+type resourceBuilder func(context.Context, ...resource.Option) (*resource.Resource, error)
+
+func newResource(ctx context.Context, r *Resource) (*resource.Resource, error) {
+	return newResourceWithBuilder(ctx, r, resource.New)
+}
+
+func newResourceWithBuilder(ctx context.Context, r *Resource, build resourceBuilder) (*resource.Resource, error) {
 	if r == nil {
-		return resource.Default(), nil
+		return resource.DefaultWithContext(ctx), nil
 	}
 
 	attrs := make([]attribute.KeyValue, 0, len(r.Attributes))
@@ -32,5 +38,5 @@ func newResource(r *Resource) (*resource.Resource, error) {
 		resource.WithSchemaURL(schema),
 	}
 
-	return resource.New(context.Background(), opts...)
+	return build(ctx, opts...)
 }

--- a/otelconf/resource_test.go
+++ b/otelconf/resource_test.go
@@ -4,6 +4,7 @@
 package otelconf
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -76,7 +77,7 @@ func TestNewResource(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := newResource(tt.config)
+			got, err := newResource(t.Context(), tt.config)
 			require.ErrorIs(t, err, tt.wantErrT)
 
 			assert.Equal(t, tt.wantSchemaURL, got.SchemaURL())
@@ -93,3 +94,16 @@ func TestNewResource(t *testing.T) {
 		})
 	}
 }
+
+func TestNewResourceUsesContext(t *testing.T) {
+	wantCtx := context.WithValue(t.Context(), ctxKey{}, "resource")
+	want := resource.NewSchemaless(attribute.String("from", "builder"))
+	got, err := newResourceWithBuilder(wantCtx, &Resource{}, func(ctx context.Context, _ ...resource.Option) (*resource.Resource, error) {
+		assert.Same(t, wantCtx, ctx)
+		return want, nil
+	})
+	require.NoError(t, err)
+	assert.Same(t, want, got)
+}
+
+type ctxKey struct{}

--- a/otelconf/x/config.go
+++ b/otelconf/x/config.go
@@ -121,7 +121,7 @@ func NewSDK(opts ...ConfigurationOption) (SDK, error) {
 		return noopSDK, nil
 	}
 
-	r, err := newResource(o.opentelemetryConfig.Resource)
+	r, err := newResource(o.ctx, o.opentelemetryConfig.Resource)
 	if err != nil {
 		return noopSDK, err
 	}

--- a/otelconf/x/resource.go
+++ b/otelconf/x/resource.go
@@ -52,7 +52,7 @@ func newResourceWithBuilder(ctx context.Context, r *Resource, build resourceBuil
 		schema = *r.SchemaUrl
 	}
 	opts := []resource.Option{
-		resource.WithAttributes(resource.Default().Attributes()...),
+		resource.WithAttributes(resource.DefaultWithContext(ctx).Attributes()...),
 		resource.WithAttributes(attrs...),
 		resource.WithSchemaURL(schema),
 	}

--- a/otelconf/x/resource.go
+++ b/otelconf/x/resource.go
@@ -31,9 +31,15 @@ func resourceOpts(detectors []ExperimentalResourceDetector) []resource.Option {
 	return opts
 }
 
-func newResource(r *Resource) (*resource.Resource, error) {
+type resourceBuilder func(context.Context, ...resource.Option) (*resource.Resource, error)
+
+func newResource(ctx context.Context, r *Resource) (*resource.Resource, error) {
+	return newResourceWithBuilder(ctx, r, resource.New)
+}
+
+func newResourceWithBuilder(ctx context.Context, r *Resource, build resourceBuilder) (*resource.Resource, error) {
 	if r == nil {
-		return resource.Default(), nil
+		return resource.DefaultWithContext(ctx), nil
 	}
 
 	attrs := make([]attribute.KeyValue, 0, len(r.Attributes))
@@ -55,5 +61,5 @@ func newResource(r *Resource) (*resource.Resource, error) {
 		opts = append(opts, resourceOpts(r.DetectionDevelopment.Detectors)...)
 	}
 
-	return resource.New(context.Background(), opts...)
+	return build(ctx, opts...)
 }

--- a/otelconf/x/resource_test.go
+++ b/otelconf/x/resource_test.go
@@ -4,6 +4,7 @@
 package x
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -76,7 +77,7 @@ func TestNewResource(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := newResource(tt.config)
+			got, err := newResource(t.Context(), tt.config)
 			require.ErrorIs(t, err, tt.wantErrT)
 
 			assert.Equal(t, tt.wantSchemaURL, got.SchemaURL())
@@ -93,6 +94,19 @@ func TestNewResource(t *testing.T) {
 		})
 	}
 }
+
+func TestNewResourceUsesContext(t *testing.T) {
+	wantCtx := context.WithValue(t.Context(), ctxKey{}, "resource")
+	want := resource.NewSchemaless(attribute.String("from", "builder"))
+	got, err := newResourceWithBuilder(wantCtx, &Resource{}, func(ctx context.Context, _ ...resource.Option) (*resource.Resource, error) {
+		assert.Same(t, wantCtx, ctx)
+		return want, nil
+	})
+	require.NoError(t, err)
+	assert.Same(t, want, got)
+}
+
+type ctxKey struct{}
 
 func TestResourceOptsWithDetectors(t *testing.T) {
 	tests := []struct {
@@ -143,7 +157,7 @@ func TestResourceOptsWithDetectors(t *testing.T) {
 					Detectors: tt.detectors,
 				},
 			}
-			got, err := newResource(config)
+			got, err := newResource(t.Context(), config)
 			require.NoError(t, err)
 			require.NotNil(t, got)
 


### PR DESCRIPTION
## Summary

This updates `go.opentelemetry.io/contrib/otelconf` and `go.opentelemetry.io/contrib/otelconf/x` so SDK resource construction uses the context configured with `WithContext`.

Previously, resource construction called `resource.New(context.Background(), ...)`, which meant caller cancellation and deadlines were not propagated to resource detector execution even though other SDK construction paths already used the configured context.

The change threads the SDK construction context into resource creation, covers both stable and experimental otelconf packages for consistency, and adds regression coverage around the context passed to resource builders.

Fixes #9158.

## Testing

- `go test ./...` from `otelconf`
- `make precommit`