### PR TITLE
Fix: histogram sum calculation using cumulative count

### DIFF
--- a/instrumentation/runtime/producer.go
+++ b/instrumentation/runtime/producer.go
@@ -105,8 +105,8 @@ func convertRuntimeHistogram(runtimeHist *metrics.Float64Histogram, ts time.Time
 		count += c
 		// This computed sum is an underestimate, since it assumes each
 		// observation happens at the bucket's lower bound.
-		if i > 0 && count != 0 {
-			sum += bounds[i-1] * float64(count)
+		if i > 0 && c != 0 {
+			sum += bounds[i-1] * float64(c)
 		}
 	}
 

--- a/instrumentation/runtime/producer_test.go
+++ b/instrumentation/runtime/producer_test.go
@@ -4,7 +4,10 @@
 package runtime // import "go.opentelemetry.io/contrib/instrumentation/runtime"
 
 import (
+	"math"
+	"runtime/metrics"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -43,4 +46,19 @@ func TestNewProducer(t *testing.T) {
 		},
 	}
 	metricdatatest.AssertEqual(t, expectedScopeMetric, rm.ScopeMetrics[0], metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
+}
+
+func TestConvertRuntimeHistogram(t *testing.T) {
+	hist := &metrics.Float64Histogram{
+		Counts:  []uint64{10, 20, 30, 40},
+		Buckets: []float64{0, 1, 2, 3, math.Inf(1)},
+	}
+	// Buckets after conversion: (-∞,1], (1,2], (2,3], (3,+∞)
+	// Expected sum: 1*20 + 2*30 + 3*40 = 200
+	dp := convertRuntimeHistogram(hist, time.Now())
+	require.Len(t, dp, 1)
+	assert.Equal(t, uint64(100), dp[0].Count)
+	assert.Equal(t, float64(200), dp[0].Sum)
+	assert.Equal(t, []float64{1, 2, 3}, dp[0].Bounds)
+	assert.Equal(t, []uint64{10, 20, 30, 40}, dp[0].BucketCounts)
 }


### PR DESCRIPTION
## Summary

### Content

The sum calculation incorrectly uses cumulative count instead of individual bucket counts, leading to incorrect sum values.

### What I have done

- Fixed the histogram sum calculation in `convertRuntimeHistogram` which was incorrectly using cumulative count instead of individual bucket counts.

- Changed the sum calculation loop to use `c` (bucket count) instead of `count` (cumulative count):

```go
- sum += bounds[i-1] * float64(count)
+ sum += bounds[i-1] * float64(c)
```

This ensures the computed sum accurately reflects the histogram distribution rather than producing inflated values.

### Motivation

The original implementation accumulated counts across all buckets, causing the sum to be calculated incorrectly. 
Each bucket's contribution should be based on its own count, not the cumulative total up to that point.

### Test Results
<img width="916" height="75" alt="screenshot 2026-06-21 14 56 29" src="https://github.com/user-attachments/assets/6f003300-1e3e-40b5-8f84-d7a8f50fd140" />
