### PR TITLE
instrumentation/otelgrpc: add WithSpanStatusFn for custom span status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Add `WithSpanStatusFn` option for `NewServerHandler` and `NewClientHandler` in `go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc` to allow per-method override of the default gRPC → OTel span status mapping. (#9189)
 - The resource created by `go.opentelemetry.io/contrib/otelconf` now includes [default SDK attributes](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/resource#Default). (#8990)
 - Add `azurecontainerapps` resource detector for Azure Container Apps. (#8939)
 

--- a/instrumentation/google.golang.org/grpc/otelgrpc/config.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/config.go
@@ -10,10 +10,12 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/stats"
+	"google.golang.org/grpc/status"
 )
 
 // ScopeName is the instrumentation scope name.
@@ -39,6 +41,16 @@ const (
 	semconvModeDup
 )
 
+// SpanStatusFn is a function that determines the OpenTelemetry span status
+// for a gRPC call. fullMethod is the full gRPC method name (e.g.
+// "/package.Service/Method"). grpcStatus is the parsed gRPC status returned
+// by the server; it is nil when the call succeeded (OK).
+//
+// This can be used to override the default status mapping, for example to
+// treat codes.NotFound as a non-error for specific methods, or to always
+// treat codes.Canceled as an error on the client side.
+type SpanStatusFn func(ctx context.Context, fullMethod string, grpcStatus *status.Status) (codes.Code, string)
+
 // config is a group of options for this instrumentation.
 type config struct {
 	Filter             Filter
@@ -51,6 +63,7 @@ type config struct {
 	MetricAttributes   []attribute.KeyValue
 	MetricAttributesFn func(ctx context.Context) []attribute.KeyValue
 
+	SpanStatusFn     SpanStatusFn
 	PublicEndpoint   bool
 	PublicEndpointFn func(ctx context.Context, info *stats.RPCTagInfo) bool
 
@@ -241,6 +254,22 @@ func WithMetricAttributesFn(fn func(ctx context.Context) []attribute.KeyValue) O
 	return optionFunc(func(c *config) {
 		if fn != nil {
 			c.MetricAttributesFn = fn
+		}
+	})
+}
+
+// WithSpanStatusFn sets a custom function to determine the span status code
+// and message for a gRPC call. When set, this function is called instead of
+// the default status mapping defined by the OpenTelemetry gRPC semantic
+// conventions. The grpcStatus argument is nil when the call succeeded (OK).
+//
+// This adheres to the semantic conventions, which use SHOULD rather than MUST,
+// allowing per-method customisation — for example, treating codes.NotFound as
+// a non-error for a lookup RPC while keeping it as an error for all other methods.
+func WithSpanStatusFn(fn SpanStatusFn) Option {
+	return optionFunc(func(c *config) {
+		if fn != nil {
+			c.SpanStatusFn = fn
 		}
 	})
 }

--- a/instrumentation/google.golang.org/grpc/otelgrpc/config_test.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/config_test.go
@@ -4,9 +4,12 @@
 package otelgrpc
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/codes"
+	grpc_status "google.golang.org/grpc/status"
 )
 
 func TestParseSemconvMode(t *testing.T) {
@@ -59,4 +62,48 @@ func TestParseSemconvMode(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestWithSpanStatusFn(t *testing.T) {
+	t.Run("configures fn and wires it correctly", func(t *testing.T) {
+		expectedCode := codes.Error
+		expectedMsg := "custom error message"
+
+		customFn := func(_ context.Context, _ string, _ *grpc_status.Status) (codes.Code, string) {
+			return expectedCode, expectedMsg
+		}
+
+		c := newConfig([]Option{WithSpanStatusFn(customFn)})
+
+		if c.SpanStatusFn == nil {
+			t.Fatal("expected SpanStatusFn to be configured, got nil")
+		}
+
+		code, msg := c.SpanStatusFn(t.Context(), "/pkg.Service/Method", nil)
+		assert.Equal(t, expectedCode, code)
+		assert.Equal(t, expectedMsg, msg)
+	})
+
+	t.Run("nil fn is ignored", func(t *testing.T) {
+		c := newConfig([]Option{WithSpanStatusFn(nil)})
+		assert.Nil(t, c.SpanStatusFn)
+	})
+
+	t.Run("receives fullMethod and grpcStatus", func(t *testing.T) {
+		var gotMethod string
+		var gotStatus *grpc_status.Status
+
+		customFn := func(_ context.Context, fullMethod string, grpcStatus *grpc_status.Status) (codes.Code, string) {
+			gotMethod = fullMethod
+			gotStatus = grpcStatus
+			return codes.Unset, ""
+		}
+
+		c := newConfig([]Option{WithSpanStatusFn(customFn)})
+		s := grpc_status.New(0 /* OK */, "")
+		c.SpanStatusFn(t.Context(), "/mypackage.MyService/MyMethod", s)
+
+		assert.Equal(t, "/mypackage.MyService/MyMethod", gotMethod)
+		assert.Equal(t, s, gotStatus)
+	})
 }

--- a/instrumentation/google.golang.org/grpc/otelgrpc/grpc_stats_handler_test.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/grpc_stats_handler_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
+	otelcodes "go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
@@ -808,4 +809,146 @@ func TestMetricsSemconvOptIn(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestSpanStatusFn(t *testing.T) {
+	end := func(err error) *stats.End {
+		now := time.Now()
+		return &stats.End{Error: err, BeginTime: now, EndTime: now}
+	}
+
+	t.Run("server: fn receives correct fullMethod and grpcStatus", func(t *testing.T) {
+		var (
+			gotMethod string
+			gotCode   codes.Code
+		)
+
+		sr := tracetest.NewSpanRecorder()
+		tp := trace.NewTracerProvider(trace.WithSpanProcessor(sr))
+
+		h := otelgrpc.NewServerHandler(
+			otelgrpc.WithTracerProvider(tp),
+			otelgrpc.WithSpanStatusFn(func(_ context.Context, fullMethod string, grpcStatus *status.Status) (otelcodes.Code, string) {
+				gotMethod = fullMethod
+				if grpcStatus != nil {
+					gotCode = grpcStatus.Code()
+				}
+				return otelcodes.Unset, ""
+			}),
+		)
+
+		ctx := h.TagRPC(t.Context(), &stats.RPCTagInfo{FullMethodName: "/pkg.Svc/Method"})
+		h.HandleRPC(ctx, end(status.Error(codes.NotFound, "not found")))
+
+		require.Len(t, sr.Ended(), 1)
+		assert.Equal(t, "/pkg.Svc/Method", gotMethod)
+		assert.Equal(t, codes.NotFound, gotCode)
+	})
+
+	t.Run("server: fn promotes NotFound to error (overrides default non-error)", func(t *testing.T) {
+		sr := tracetest.NewSpanRecorder()
+		tp := trace.NewTracerProvider(trace.WithSpanProcessor(sr))
+
+		h := otelgrpc.NewServerHandler(
+			otelgrpc.WithTracerProvider(tp),
+			otelgrpc.WithSpanStatusFn(func(_ context.Context, _ string, grpcStatus *status.Status) (otelcodes.Code, string) {
+				if grpcStatus != nil && grpcStatus.Code() == codes.NotFound {
+					return otelcodes.Error, grpcStatus.Message()
+				}
+				return otelcodes.Unset, ""
+			}),
+		)
+
+		ctx := h.TagRPC(t.Context(), &stats.RPCTagInfo{FullMethodName: "/pkg.Svc/Find"})
+		h.HandleRPC(ctx, end(status.Error(codes.NotFound, "item not found")))
+
+		spans := sr.Ended()
+		require.Len(t, spans, 1)
+		assert.Equal(t, otelcodes.Error, spans[0].Status().Code)
+		assert.Equal(t, "item not found", spans[0].Status().Description)
+	})
+
+	t.Run("server: fn suppresses INTERNAL error for a specific method", func(t *testing.T) {
+		sr := tracetest.NewSpanRecorder()
+		tp := trace.NewTracerProvider(trace.WithSpanProcessor(sr))
+
+		const silenced = "/pkg.Svc/IgnoreInternal"
+		h := otelgrpc.NewServerHandler(
+			otelgrpc.WithTracerProvider(tp),
+			otelgrpc.WithSpanStatusFn(func(_ context.Context, fullMethod string, grpcStatus *status.Status) (otelcodes.Code, string) {
+				if fullMethod == silenced {
+					return otelcodes.Unset, ""
+				}
+				if grpcStatus != nil {
+					switch grpcStatus.Code() {
+					case codes.Unknown, codes.DeadlineExceeded, codes.Unimplemented,
+						codes.Internal, codes.Unavailable, codes.DataLoss:
+						return otelcodes.Error, grpcStatus.Message()
+					}
+				}
+				return otelcodes.Unset, ""
+			}),
+		)
+
+		ctx := h.TagRPC(t.Context(), &stats.RPCTagInfo{FullMethodName: silenced})
+		h.HandleRPC(ctx, end(status.Error(codes.Internal, "internal error")))
+
+		spans := sr.Ended()
+		require.Len(t, spans, 1)
+		assert.Equal(t, otelcodes.Unset, spans[0].Status().Code)
+	})
+
+	t.Run("client: fn treats NotFound as non-error (overrides default all-errors)", func(t *testing.T) {
+		sr := tracetest.NewSpanRecorder()
+		tp := trace.NewTracerProvider(trace.WithSpanProcessor(sr))
+
+		h := otelgrpc.NewClientHandler(
+			otelgrpc.WithTracerProvider(tp),
+			otelgrpc.WithSpanStatusFn(func(_ context.Context, _ string, grpcStatus *status.Status) (otelcodes.Code, string) {
+				if grpcStatus != nil && grpcStatus.Code() == codes.NotFound {
+					return otelcodes.Unset, ""
+				}
+				if grpcStatus != nil {
+					return otelcodes.Error, grpcStatus.Message()
+				}
+				return otelcodes.Unset, ""
+			}),
+		)
+
+		ctx := h.TagRPC(t.Context(), &stats.RPCTagInfo{FullMethodName: "/pkg.Svc/Get"})
+		h.HandleRPC(ctx, end(status.Error(codes.NotFound, "not found")))
+
+		spans := sr.Ended()
+		require.Len(t, spans, 1)
+		assert.Equal(t, otelcodes.Unset, spans[0].Status().Code)
+	})
+
+	t.Run("server: no fn → default mapping (NotFound is NOT an error)", func(t *testing.T) {
+		sr := tracetest.NewSpanRecorder()
+		tp := trace.NewTracerProvider(trace.WithSpanProcessor(sr))
+
+		h := otelgrpc.NewServerHandler(otelgrpc.WithTracerProvider(tp))
+
+		ctx := h.TagRPC(t.Context(), &stats.RPCTagInfo{FullMethodName: "/pkg.Svc/Get"})
+		h.HandleRPC(ctx, end(status.Error(codes.NotFound, "not found")))
+
+		spans := sr.Ended()
+		require.Len(t, spans, 1)
+		assert.Equal(t, otelcodes.Unset, spans[0].Status().Code)
+	})
+
+	t.Run("client: no fn → default mapping (NotFound IS an error)", func(t *testing.T) {
+		sr := tracetest.NewSpanRecorder()
+		tp := trace.NewTracerProvider(trace.WithSpanProcessor(sr))
+
+		h := otelgrpc.NewClientHandler(otelgrpc.WithTracerProvider(tp))
+
+		ctx := h.TagRPC(t.Context(), &stats.RPCTagInfo{FullMethodName: "/pkg.Svc/Get"})
+		h.HandleRPC(ctx, end(status.Error(codes.NotFound, "not found")))
+
+		spans := sr.Ended()
+		require.Len(t, spans, 1)
+		assert.Equal(t, otelcodes.Error, spans[0].Status().Code)
+		assert.Equal(t, "not found", spans[0].Status().Description)
+	})
 }

--- a/instrumentation/google.golang.org/grpc/otelgrpc/stats_handler.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/stats_handler.go
@@ -34,6 +34,7 @@ type dialTargetContextKey struct{}
 type gRPCContext struct {
 	metricAttrs []attribute.KeyValue
 	record      bool
+	fullMethod  string
 }
 
 type serverHandler struct {
@@ -152,6 +153,7 @@ func (h *serverHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) cont
 	gctx := gRPCContext{
 		metricAttrs: append(attrs, h.MetricAttributes...),
 		record:      record,
+		fullMethod:  info.FullMethodName,
 	}
 
 	if h.MetricAttributesFn != nil {
@@ -276,6 +278,7 @@ func (h *clientHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) cont
 	gctx := gRPCContext{
 		metricAttrs: append(attrs, h.MetricAttributes...),
 		record:      record,
+		fullMethod:  info.FullMethodName,
 	}
 
 	if h.MetricAttributesFn != nil {
@@ -317,7 +320,7 @@ func (*clientHandler) HandleConn(context.Context, stats.ConnStats) {
 	// no-op
 }
 
-func (*config) handleRPC(
+func (c *config) handleRPC(
 	ctx context.Context,
 	rs stats.RPCStats,
 	duration metric.Float64Histogram,
@@ -383,10 +386,18 @@ func (*config) handleRPC(
 			rpcStatusAttr = semconv.RPCResponseStatusCode(canonicalString(grpc_codes.OK))
 		}
 		if span.IsRecording() {
-			if s != nil {
-				c, m := recordStatus(s)
-				span.SetStatus(c, m)
+			if c.SpanStatusFn != nil {
+				var fullMethod string
+				if gctx != nil {
+					fullMethod = gctx.fullMethod
+				}
+				code, msg := c.SpanStatusFn(ctx, fullMethod, s)
+				span.SetStatus(code, msg)
+			} else if s != nil {
+				code, msg := recordStatus(s)
+				span.SetStatus(code, msg)
 			}
+
 			span.SetAttributes(rpcStatusAttr)
 			span.End()
 		}


### PR DESCRIPTION
## Description

Implements #9189.

The `otelgrpc` stats handlers currently use a fixed mapping from gRPC status codes to OpenTelemetry span status:

* **Server:** only `UNKNOWN`, `DEADLINE_EXCEEDED`, `UNIMPLEMENTED`, `INTERNAL`, `UNAVAILABLE`, and `DATA_LOSS` are marked as span errors.
* **Client:** every non-`OK` status is marked as an error.

This makes it difficult to customize span status for specific RPCs or status codes without adding a separate interceptor.

## Changes

This PR adds a `SpanStatusFn` type along with a `WithSpanStatusFn` option for both `NewServerHandler` and `NewClientHandler`.

When provided, the callback replaces the default status mapping. It receives:

* The full gRPC method name (for example, `/package.Service/Method`)
* The parsed `*status.Status` (`nil` when the RPC completed successfully)

The function returns the OpenTelemetry `codes.Code` and description that should be applied to the span.

This follows the gRPC semantic conventions, which describe span status classification as a **SHOULD**, allowing applications to override the default behaviour when it better matches their use case.

### Example

```go
// Treat NotFound as a non-error for lookup RPCs only.
otelgrpc.NewServerHandler(
    otelgrpc.WithSpanStatusFn(func(_ context.Context, fullMethod string, grpcStatus *status.Status) (codes.Code, string) {
        if grpcStatus != nil && grpcStatus.Code() == grpc_codes.NotFound {
            return otelcodes.Unset, ""
        }

        switch grpcStatus.Code() {
        case grpc_codes.Unknown, grpc_codes.DeadlineExceeded, grpc_codes.Unimplemented,
            grpc_codes.Internal, grpc_codes.Unavailable, grpc_codes.DataLoss:
            return otelcodes.Error, grpcStatus.Message()
        }

        return otelcodes.Unset, ""
    }),
)
```

## Testing

Added unit tests in `config_test.go` covering:

* Option wiring
* Nil callback guard
* Argument passthrough

Added integration tests in `grpc_stats_handler_test.go` covering:

* Server: overriding the default behaviour to treat `NotFound` as an error
* Server: suppressing `Internal` for a specific RPC method
* Client: treating `NotFound` as a non-error instead of the default error behaviour
* Default client and server behaviour when no custom callback is configured

Verified with:

```bash
go test -race ./...
```
