### PR TITLE
fix(detectors/azurecontainerapps): use azure.container_app.instance.id for replica name instead of service.instance.id

### DIFF
--- a/detectors/azure/azurecontainerapps/detector.go
+++ b/detectors/azure/azurecontainerapps/detector.go
@@ -71,10 +71,13 @@ func (d *ResourceDetector) Detect(context.Context) (*resource.Resource, error) {
 		semconv.ServiceName(appName),
 	}
 
+	// azure.container_app.instance.id is a platform-specific attribute for the replica name
+	// as there lacks an appropriate attribute in semantic conventions. This is planned
+	// to be added to semantic conventions.
 	var partialErr error
 	replicaName := os.Getenv(containerAppReplicaNameEnvVar)
 	if replicaName != "" {
-		attrs = append(attrs, semconv.FaaSInstance(replicaName))
+		attrs = append(attrs, attribute.String("azure.container_app.instance.id", replicaName))
 	} else {
 		partialErr = fmt.Errorf("%w: %s not set", resource.ErrPartialResource, containerAppReplicaNameEnvVar)
 	}

--- a/detectors/azure/azurecontainerapps/detector.go
+++ b/detectors/azure/azurecontainerapps/detector.go
@@ -74,7 +74,7 @@ func (d *ResourceDetector) Detect(context.Context) (*resource.Resource, error) {
 	var partialErr error
 	replicaName := os.Getenv(containerAppReplicaNameEnvVar)
 	if replicaName != "" {
-		attrs = append(attrs, semconv.ServiceInstanceID(replicaName))
+		attrs = append(attrs, semconv.FaaSInstance(replicaName))
 	} else {
 		partialErr = fmt.Errorf("%w: %s not set", resource.ErrPartialResource, containerAppReplicaNameEnvVar)
 	}

--- a/detectors/azure/azurecontainerapps/detector_test.go
+++ b/detectors/azure/azurecontainerapps/detector_test.go
@@ -22,7 +22,7 @@ func TestWithAttributeFilter(t *testing.T) {
 	t.Setenv("CONTAINER_APP_REPLICA_NAME", "my-app--abc123-0")
 
 	filter := func(kv attribute.KeyValue) bool {
-		return strings.HasPrefix(string(kv.Key), "service.")
+		return strings.HasPrefix(string(kv.Key), "cloud.")
 	}
 	detector := NewResourceDetector(WithAttributeFilter(filter))
 	res, err := detector.Detect(t.Context())
@@ -30,8 +30,8 @@ func TestWithAttributeFilter(t *testing.T) {
 	assert.NoError(t, err)
 	expected := resource.NewWithAttributes(
 		semconv.SchemaURL,
-		semconv.ServiceName("my-app"),
-		semconv.ServiceInstanceID("my-app--abc123-0"),
+		semconv.CloudProviderAzure,
+		semconv.CloudPlatformAzureContainerApps,
 	)
 	assert.Equal(t, expected, res)
 }
@@ -45,7 +45,7 @@ func TestDetectSuccess(t *testing.T) {
 		semconv.CloudProviderAzure,
 		semconv.CloudPlatformAzureContainerApps,
 		semconv.ServiceName("my-app"),
-		semconv.ServiceInstanceID("my-app--abc123-0"),
+		semconv.FaaSInstance("my-app--abc123-0"),
 	}
 	expectedResource := resource.NewWithAttributes(semconv.SchemaURL, attributes...)
 	detector := ResourceDetector{}

--- a/detectors/azure/azurecontainerapps/detector_test.go
+++ b/detectors/azure/azurecontainerapps/detector_test.go
@@ -45,7 +45,7 @@ func TestDetectSuccess(t *testing.T) {
 		semconv.CloudProviderAzure,
 		semconv.CloudPlatformAzureContainerApps,
 		semconv.ServiceName("my-app"),
-		semconv.FaaSInstance("my-app--abc123-0"),
+		attribute.String("azure.container_app.instance.id", "my-app--abc123-0"),
 	}
 	expectedResource := resource.NewWithAttributes(semconv.SchemaURL, attributes...)
 	detector := ResourceDetector{}

--- a/detectors/azure/azurecontainerapps/doc.go
+++ b/detectors/azure/azurecontainerapps/doc.go
@@ -7,15 +7,16 @@ detecting attributes specific to Azure Container Apps.
 
 Note: Azure Container Apps jobs are not supported.
 
-According to semantic conventions for [cloud] and [service] attributes,
+According to semantic conventions for [cloud], [service], and [faas] attributes,
 the following attributes are added when running on Azure Container Apps:
 
   - cloud.provider
   - cloud.platform
   - service.name
-  - service.instance.id
+  - faas.instance
 
 [cloud]: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/cloud.md
 [service]: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/service.md
+[faas]: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/faas.md
 */
 package azurecontainerapps // import "go.opentelemetry.io/contrib/detectors/azure/azurecontainerapps"

--- a/detectors/azure/azurecontainerapps/doc.go
+++ b/detectors/azure/azurecontainerapps/doc.go
@@ -7,16 +7,15 @@ detecting attributes specific to Azure Container Apps.
 
 Note: Azure Container Apps jobs are not supported.
 
-According to semantic conventions for [cloud], [service], and [faas] attributes,
+According to semantic conventions for [cloud] and [service] attributes, and a custom attribute for Azure Container App replicas,
 the following attributes are added when running on Azure Container Apps:
 
   - cloud.provider
   - cloud.platform
   - service.name
-  - faas.instance
+  - azure.container_app.instance.id
 
 [cloud]: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/cloud.md
 [service]: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/service.md
-[faas]: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/faas.md
 */
 package azurecontainerapps // import "go.opentelemetry.io/contrib/detectors/azure/azurecontainerapps"


### PR DESCRIPTION
Changes the resource attribute used for the Azure Container Apps replica name from `service.instance.id` to `azure.container_app.instance.id`.

The Go SDK's default resource detector auto-populates `service.instance.id` [with a random UUID](https://github.com/open-telemetry/opentelemetry-go/blob/18ef80827fc3965a41742417b6937c370f8d9817/sdk/resource/builtin.go#L108), which would conflict with the Azure Container App detector's replica name value for Go users. `azure.container_app.instance.id` avoids that collision, is more precise, and is consistent with the precedent set by the [Node.js SDK](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/resource-detector-azure#readme). A follow-up PR will be made in the semantic-conventions repo to make this a semantic convention.

This was raised during review of the collector-contrib adapter PR for this detector: [discussion 1](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/49342#discussion_r3492746358), [discussion 2](https://github.com/open-telemetry/opentelemetry-go-contrib/pull/8939#issuecomment-4835231076)

Link to tracking issue: https://github.com/open-telemetry/opentelemetry-go-contrib/issues/8984

Follow up to PR #8939

## Testing
Updated existing tests to use faas.instance. All tests pass.

## Documentation
Updated doc.go to reference faas.instance and link to the FaaS semantic conventions.