### PR TITLE
Add iblancasa as EC2 v2 code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -32,7 +32,7 @@ bridges/otelzap/                                                        @open-te
 bridges/otellogr/                                                       @open-telemetry/go-approvers @pellared
 
 detectors/autodetect                                                    @open-telemetry/go-approvers @MrAlias
-detectors/aws/ec2/v2                                                    @open-telemetry/go-approvers
+detectors/aws/ec2/v2                                                    @open-telemetry/go-approvers @iblancasa
 detectors/aws/ecs                                                       @open-telemetry/go-approvers @pyohannes
 detectors/aws/eks                                                       @open-telemetry/go-approvers @pyohannes
 detectors/aws/lambda                                                    @open-telemetry/go-approvers


### PR DESCRIPTION
## Summary

- add `@iblancasa` as a code owner for `go.opentelemetry.io/contrib/detectors/aws/ec2/v2`
- retain the EC2 v2 detector with an accountable module owner

## Validation

- `make precommit`

Closes #9215
