### PR TITLE
fix(otelmongo): strip connection number from connection ID before deriving network.peer.address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Honor the context configured with `WithContext` when constructing resources in `go.opentelemetry.io/contrib/otelconf` and `go.opentelemetry.io/contrib/otelconf/x`. (#9160)
 - Handle nil response bodies from custom `RoundTripper` implementations in `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp` without panicking. (#9184)
 - Fix incorrect (overestimated) sum calculation for runtime histograms in `go.opentelemetry.io/contrib/instrumentation/runtime`. (#9063)
+- Strip the connection number from the driver's connection ID before deriving `network.peer.address` in `go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver/v2/mongo/otelmongo`. The address previously fell back to the full connection ID, which is unique per pooled connection and gave the recorded metrics unbounded cardinality. (#9274)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/instrumentation/go.mongodb.org/mongo-driver/v2/mongo/otelmongo/mongo.go
+++ b/instrumentation/go.mongodb.org/mongo-driver/v2/mongo/otelmongo/mongo.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"net"
 	"strconv"
+	"strings"
 	"sync"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -209,9 +210,38 @@ func NewMonitor(opts ...Option) *event.CommandMonitor {
 	}
 }
 
+// trimConnectionNumber removes the connection number that the driver appends to the
+// connection ID. The driver formats the ID as "<address>[-<connection number>]", for
+// example "127.0.0.1:27017[-13]".
+//
+// The suffix has to be removed before the address is parsed: net.SplitHostPort rejects
+// the trailing "]", so leaving it in place makes the parse in peerInfo fail and fall back
+// to using the whole connection ID as the peer address. The connection number is unique
+// per pooled connection, so that fallback gives network.peer.address a new value for every
+// connection the pool opens, growing the cardinality of the metrics recorded with it
+// without bound.
+//
+// Requiring the bracket to open after the final colon keeps a bracketed IPv6 literal such
+// as "[::1]" from being truncated.
+func trimConnectionNumber(connectionID string) string {
+	if !strings.HasSuffix(connectionID, "]") {
+		return connectionID
+	}
+
+	open := strings.LastIndexByte(connectionID, '[')
+	if open <= 0 || open < strings.LastIndexByte(connectionID, ':') {
+		return connectionID
+	}
+
+	return connectionID[:open]
+}
+
 // peerInfo will parse the hostname and port from the mongo connection ID.
 func peerInfo(connectionID string) (hostname string, port int) {
 	defaultMongoPort := 27017
+
+	connectionID = trimConnectionNumber(connectionID)
+
 	hostname, portStr, err := net.SplitHostPort(connectionID)
 	if err != nil {
 		// If parsing fails, assume default MongoDB port and return the entire ConnectionID as hostname

--- a/instrumentation/go.mongodb.org/mongo-driver/v2/mongo/otelmongo/mongo_test.go
+++ b/instrumentation/go.mongodb.org/mongo-driver/v2/mongo/otelmongo/mongo_test.go
@@ -370,6 +370,30 @@ func TestPeerInfo(t *testing.T) {
 			expectedHost: "example.com",
 			expectedPort: 27017,
 		},
+		{
+			name:         "IPv4 with port and connection number",
+			connectionID: "127.0.0.1:27018[-13]",
+			expectedHost: "127.0.0.1",
+			expectedPort: 27018,
+		},
+		{
+			name:         "IPv6 with port and connection number",
+			connectionID: "[::1]:27019[-13]",
+			expectedHost: "::1",
+			expectedPort: 27019,
+		},
+		{
+			name:         "Hostname with port and connection number",
+			connectionID: "example.com:27020[-13]",
+			expectedHost: "example.com",
+			expectedPort: 27020,
+		},
+		{
+			name:         "Hostname without port with connection number",
+			connectionID: "example.com[-13]",
+			expectedHost: "example.com",
+			expectedPort: 27017,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Problem

`peerInfo` passes the driver's connection ID straight to `net.SplitHostPort`. The v2 driver formats that ID as `<address>[-<connection number>]` ([`topology.newConnection`](https://github.com/mongodb/mongo-go-driver/blob/master/x/mongo/driver/topology/connection.go)), for example `127.0.0.1:27017[-13]`.

`net.SplitHostPort` rejects the trailing `]` (`unexpected ']' in address`), so `peerInfo` falls into its fallback branch and uses the **entire connection ID** as the hostname:

```go
hostname, portStr, err := net.SplitHostPort(connectionID)
if err != nil {
	// If parsing fails, assume default MongoDB port and return the entire ConnectionID as hostname
	hostname = connectionID
	port = defaultMongoPort
	return hostname, port
}
```

The connection number is unique per pooled connection, so `network.peer.address` takes a new value for **every connection the pool opens**. On spans this is merely noisy, but `db.client.operation.duration` is recorded with the same attribute set, so the metric's cardinality grows without bound for the lifetime of the process.

## Impact

This took down monitoring for our service in production. A single pod reached:

- **5,305** distinct `network.peer.address` values (e.g. `10.0.0.1:27017[-1708]`)
- **54,570** `db_client_operation_duration_seconds` bucket series — ~96% of all series the process exported
- a **24.7 MB** `/metrics` payload

which exceeded the scrape size limit, so the scrape was rejected **outright** — and *every* metric from the process disappeared, not just the MongoDB ones. It came back on restart (fresh registry) and then grew back over the following hours.

## Fix

Strip the connection number before parsing, so the attribute becomes the MongoDB host and stays bounded by the size of the replica set.

The bracket is only trimmed when it opens **after the final colon**, which leaves bracketed IPv6 literals such as `[::1]` intact — the existing `IPv6 without port with square brackets` test case covers that and still passes.

## Tests

Four cases added to the existing `TestPeerInfo` table, covering the format the driver actually emits (which was previously untested):

| connection ID | host | port |
| --- | --- | --- |
| `127.0.0.1:27018[-13]` | `127.0.0.1` | 27018 |
| `[::1]:27019[-13]` | `::1` | 27019 |
| `example.com:27020[-13]` | `example.com` | 27020 |
| `example.com[-13]` | `example.com` | 27017 |

All pre-existing cases still pass.
