### PR TITLE
feat(samplers/jaegerremote): add OTEP 235 tracestate probability sampling support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Add `WithTraceStateSamplingEnabled` option to `go.opentelemetry.io/contrib/samplers/jaegerremote`, implementing the OpenTelemetry tracestate probability sampling specification (OTEP 235) for the probabilistic and per-operation sampling strategies. (#TODO)
 - Add `go.opentelemetry.io/contrib/detectors/k8sapi`, a new resource detector that queries the Kubernetes API. Detects `k8s.node.name` and `k8s.node.uid` when `K8S_NODE_NAME` is set via the downward API, and `k8s.cluster.uid` derived from the kube-system namespace UID (works on any Kubernetes distribution). (#9108)
 - Add new `elasticbeanstalk` resource detector for AWS Elastic Beanstalk, ported from `processor/resourcedetectionprocessor/internal/aws/elasticbeanstalk` in opentelemetry-collector-contrib. (#8993)
 - The resource created by `go.opentelemetry.io/contrib/otelconf` now includes [default SDK attributes](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/resource#Default). (#8990)

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,3 +1,4 @@
 exclude_path = [
-  "zpages/internal/templates/summary.html" # This template's URLs are only expected to be valid on the compiled file
+  "zpages/internal/templates/summary.html", # This template's URLs are only expected to be valid on the compiled file
+  "samplers/jaegerremote/sampler_remote_test.go" # Contains a deliberately malformed "endpoint=..." test fixture that lychee mis-parses as a URL
 ]

--- a/samplers/jaegerremote/README.md
+++ b/samplers/jaegerremote/README.md
@@ -43,6 +43,26 @@ Notes:
   the backend for the sampling strategy for this service.
 * Both Jaeger Agent and OpenTelemetry Collector implement the Jaeger sampling service endpoint.
 
+## Consistent probability sampling (tracestate)
+
+By default, the probabilistic and per-operation sampling strategies make sampling decisions the same way they always have and do not touch the [W3C `tracestate`](https://www.w3.org/TR/trace-context/#tracestate-header) header.
+
+Passing `jaegerremote.WithTraceStateSamplingEnabled()` to `New` switches those strategies to the OpenTelemetry [tracestate probability sampling](https://opentelemetry.io/docs/specs/otel/trace/tracestate-probability-sampling/) specification (OTEP 235).
+The sampling decision is made by comparing a 56-bit randomness value (an explicit `rv` tracestate value if present, otherwise the trace ID's least significant 56 bits) against a rejection threshold derived from the configured sampling rate.
+On a positive decision, that threshold is published via the `th` sub-key of the `ot` tracestate entry.
+This lets downstream consumers, such as span-to-metrics extrapolation, compute a reliable adjusted count for sampled spans.
+
+```go
+	jaegerRemoteSampler := jaegerremote.New(
+		"your-service-name",
+		jaegerremote.WithSamplingServerURL("http://{sampling_service_host_name}:5778/sampling"),
+		jaegerremote.WithTraceStateSamplingEnabled(),
+	)
+```
+
+Enabling this changes *which* trace IDs get sampled for a given rate (the overall sampling rate is unaffected), so it defaults to disabled for backwards compatibility.
+Rate-limiting strategies, including the "guaranteed throughput" lower bound used by per-operation sampling, are not probabilistic and never set `th`; adjusted counts should not be computed for spans sampled that way.
+
 ## Example
 
 [example/](./example) shows how to host remote sampling strategies using the OpenTelemetry Collector.

--- a/samplers/jaegerremote/sampler.go
+++ b/samplers/jaegerremote/sampler.go
@@ -19,11 +19,15 @@
 package jaegerremote // import "go.opentelemetry.io/contrib/samplers/jaegerremote"
 
 import (
+	"encoding/binary"
 	"fmt"
 	"math"
+	"strconv"
+	"strings"
 	"sync"
 
 	jaeger_api_v2 "github.com/jaegertracing/jaeger-idl/proto-gen/api_v2"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/trace"
 	oteltrace "go.opentelemetry.io/otel/trace"
@@ -42,6 +46,23 @@ const (
 	samplerTypeValueRateLimiting  = "ratelimiting"
 )
 
+// Constants implementing the OpenTelemetry tracestate probability sampling
+// specification (OTEP 235), used by probabilisticSampler when
+// traceStateSamplingEnabled is set. See
+// https://opentelemetry.io/docs/specs/otel/trace/tracestate-probability-sampling/
+const (
+	// samplingPrecision is the default precision, in hex digits, used when
+	// encoding a sampling threshold into the tracestate "th" sub-key.
+	samplingPrecision = 4
+	// maxAdjustedCount is 2^56, the number of distinct 56-bit randomness
+	// values defined by the specification.
+	maxAdjustedCount = 1 << 56
+	// randomnessMask isolates the least significant 56 bits of a trace ID,
+	// the presumed source of randomness per W3C Trace Context Level 2 when
+	// no explicit "rv" tracestate value is present.
+	randomnessMask = maxAdjustedCount - 1
+)
+
 // -----------------------
 
 // probabilisticSampler is a sampler that randomly samples a certain percentage
@@ -51,13 +72,21 @@ type probabilisticSampler struct {
 	sampler            trace.Sampler
 	attributes         []attribute.KeyValue
 	attributesDisabled bool
+
+	// traceStateSamplingEnabled switches ShouldSample to the OTEP 235
+	// threshold/tracestate algorithm; threshold and thkv are derived from
+	// samplingRate in init and are only meaningful when it is set.
+	traceStateSamplingEnabled bool
+	threshold                 uint64
+	thkv                      string
 }
 
 // newProbabilisticSampler creates a sampler that randomly samples a certain percentage of traces specified by the
 // samplingRate, in the range between 0.0 and 1.0. it utilizes the SDK `trace.TraceIDRatioBased` sampler.
-func newProbabilisticSampler(samplingRate float64, attributesDisabled bool) *probabilisticSampler {
+func newProbabilisticSampler(samplingRate float64, attributesDisabled, traceStateSamplingEnabled bool) *probabilisticSampler {
 	s := &probabilisticSampler{
-		attributesDisabled: attributesDisabled,
+		attributesDisabled:        attributesDisabled,
+		traceStateSamplingEnabled: traceStateSamplingEnabled,
 	}
 	return s.init(samplingRate)
 }
@@ -65,11 +94,45 @@ func newProbabilisticSampler(samplingRate float64, attributesDisabled bool) *pro
 func (s *probabilisticSampler) init(samplingRate float64) *probabilisticSampler {
 	s.samplingRate = math.Max(0.0, math.Min(samplingRate, 1.0))
 	s.sampler = trace.TraceIDRatioBased(s.samplingRate)
+	if s.traceStateSamplingEnabled {
+		s.threshold, s.thkv = probabilityToThreshold(s.samplingRate)
+	}
 	if s.attributesDisabled {
 		return s
 	}
 	s.attributes = []attribute.KeyValue{attribute.String(samplerTypeKey, samplerTypeValueProbabilistic), attribute.Float64(samplerParamKey, s.samplingRate)}
 	return s
+}
+
+// probabilityToThreshold converts a sampling probability into its 56-bit
+// rejection threshold and the corresponding trimmed "th:<hex>" tracestate
+// key-value, following the OpenTelemetry tracestate probability sampling
+// specification.
+func probabilityToThreshold(probability float64) (threshold uint64, thkv string) {
+	const (
+		maxPrecision = 14
+		hexBits      = 4
+	)
+	if probability >= 1.0 {
+		return 0, "th:0"
+	}
+
+	_, expF := math.Frexp(probability)
+	_, expR := math.Frexp(1 - probability)
+	precision := min(maxPrecision, max(samplingPrecision+expF/-hexBits, samplingPrecision+expR/-hexBits))
+
+	scaled := uint64(math.Round(probability * float64(maxAdjustedCount)))
+	threshold = maxAdjustedCount - scaled
+
+	if shift := hexBits * (maxPrecision - precision); shift != 0 {
+		half := uint64(1) << (shift - 1)
+		threshold += half
+		threshold >>= shift
+		threshold <<= shift
+	}
+
+	tvalue := strings.TrimRight(strconv.FormatUint(maxAdjustedCount+threshold, 16)[1:], "0")
+	return threshold, "th:" + tvalue
 }
 
 // SamplingRate returns the sampling probability this sampled was constructed with.
@@ -78,18 +141,62 @@ func (s *probabilisticSampler) SamplingRate() float64 {
 }
 
 func (s *probabilisticSampler) ShouldSample(p trace.SamplingParameters) trace.SamplingResult {
-	r := s.sampler.ShouldSample(p)
-	if r.Decision == trace.Drop {
+	if !s.traceStateSamplingEnabled {
+		r := s.sampler.ShouldSample(p)
+		if r.Decision == trace.Drop {
+			return r
+		}
+		r.Attributes = s.attributes
 		return r
 	}
-	r.Attributes = s.attributes
-	return r
+	return s.shouldSampleWithTraceState(p)
+}
+
+// shouldSampleWithTraceState implements the OpenTelemetry tracestate
+// probability sampling specification (OTEP 235): it derives a 56-bit
+// randomness value from an explicit "rv" tracestate sub-key if present,
+// else presumes the trace ID's least significant 56 bits are random, and
+// compares it against the sampler's rejection threshold. On a positive
+// decision, it publishes the threshold via the "th" tracestate sub-key so
+// downstream consumers can compute an adjusted count.
+func (s *probabilisticSampler) shouldSampleWithTraceState(p trace.SamplingParameters) trace.SamplingResult {
+	psc := oteltrace.SpanContextFromContext(p.ParentContext)
+	state := psc.TraceState()
+	existingOtts := state.Get("ot")
+
+	var randomness uint64
+	var hasRandomness bool
+	if existingOtts != "" {
+		randomness, hasRandomness = tracestateRandomness(existingOtts)
+	}
+	if !hasRandomness {
+		randomness = binary.BigEndian.Uint64(p.TraceID[8:16]) & randomnessMask
+	}
+
+	if s.threshold > randomness {
+		return trace.SamplingResult{Decision: trace.Drop, Tracestate: state}
+	}
+
+	newOtts := insertOrUpdateTraceStateThKeyValue(existingOtts, s.thkv)
+	newState := state
+	if newOtts != existingOtts {
+		updated, err := state.Insert("ot", newOtts)
+		if err != nil {
+			// This should never happen in practice, but fall back to the
+			// unmodified state rather than dropping the span's tracestate.
+			otel.Handle(fmt.Errorf("jaegerremote: could not update tracestate: %w", err))
+		} else {
+			newState = updated
+		}
+	}
+	return trace.SamplingResult{Decision: trace.RecordAndSample, Tracestate: newState, Attributes: s.attributes}
 }
 
 // Equal compares with another sampler.
 func (s *probabilisticSampler) Equal(other trace.Sampler) bool {
 	if o, ok := other.(*probabilisticSampler); ok {
-		return math.Abs(s.samplingRate-o.samplingRate) < 1e-9 // consider equal if within 0.000001%
+		return math.Abs(s.samplingRate-o.samplingRate) < 1e-9 && // consider equal if within 0.000001%
+			s.traceStateSamplingEnabled == o.traceStateSamplingEnabled
 	}
 	return false
 }
@@ -188,18 +295,20 @@ func (*rateLimitingSampler) Description() string {
 // The probabilisticSampler is given higher priority when tags are emitted, ie. if IsSampled() for both
 // samplers return true, the tags for probabilisticSampler will be used.
 type guaranteedThroughputProbabilisticSampler struct {
-	probabilisticSampler *probabilisticSampler
-	lowerBoundSampler    *rateLimitingSampler
-	samplingRate         float64
-	lowerBound           float64
-	attributesDisabled   bool
+	probabilisticSampler      *probabilisticSampler
+	lowerBoundSampler         *rateLimitingSampler
+	samplingRate              float64
+	lowerBound                float64
+	attributesDisabled        bool
+	traceStateSamplingEnabled bool
 }
 
-func newGuaranteedThroughputProbabilisticSampler(lowerBound, samplingRate float64, attributesDisabled bool) *guaranteedThroughputProbabilisticSampler {
+func newGuaranteedThroughputProbabilisticSampler(lowerBound, samplingRate float64, attributesDisabled, traceStateSamplingEnabled bool) *guaranteedThroughputProbabilisticSampler {
 	s := &guaranteedThroughputProbabilisticSampler{
-		lowerBoundSampler:  newRateLimitingSampler(lowerBound, attributesDisabled),
-		lowerBound:         lowerBound,
-		attributesDisabled: attributesDisabled,
+		lowerBoundSampler:         newRateLimitingSampler(lowerBound, attributesDisabled),
+		lowerBound:                lowerBound,
+		attributesDisabled:        attributesDisabled,
+		traceStateSamplingEnabled: traceStateSamplingEnabled,
 	}
 	s.setProbabilisticSampler(samplingRate)
 	return s
@@ -207,7 +316,7 @@ func newGuaranteedThroughputProbabilisticSampler(lowerBound, samplingRate float6
 
 func (s *guaranteedThroughputProbabilisticSampler) setProbabilisticSampler(samplingRate float64) {
 	if s.probabilisticSampler == nil {
-		s.probabilisticSampler = newProbabilisticSampler(samplingRate, s.attributesDisabled)
+		s.probabilisticSampler = newProbabilisticSampler(samplingRate, s.attributesDisabled, s.traceStateSamplingEnabled)
 	} else if s.samplingRate != samplingRate {
 		s.probabilisticSampler.init(samplingRate)
 	}
@@ -220,6 +329,9 @@ func (s *guaranteedThroughputProbabilisticSampler) ShouldSample(p trace.Sampling
 		s.lowerBoundSampler.ShouldSample(p)
 		return result
 	}
+	// The lower-bound guarantee is a rate-limited decision, not a fixed
+	// probability, so it never sets a tracestate "th" value (rateLimitingSampler
+	// leaves Tracestate untouched); its adjusted count is not well defined.
 	result := s.lowerBoundSampler.ShouldSample(p)
 	return result
 }
@@ -250,8 +362,9 @@ type perOperationSampler struct {
 	maxOperations  int
 
 	// see description in perOperationSamplerParams
-	operationNameLateBinding bool
-	attributesDisabled       bool
+	operationNameLateBinding  bool
+	attributesDisabled        bool
+	traceStateSamplingEnabled bool
 }
 
 // perOperationSamplerParams defines parameters when creating perOperationSampler.
@@ -272,7 +385,7 @@ type perOperationSamplerParams struct {
 }
 
 // newPerOperationSampler returns a new perOperationSampler.
-func newPerOperationSampler(params perOperationSamplerParams, attributesDisabled bool) *perOperationSampler {
+func newPerOperationSampler(params perOperationSamplerParams, attributesDisabled, traceStateSamplingEnabled bool) *perOperationSampler {
 	if params.MaxOperations <= 0 {
 		params.MaxOperations = defaultMaxOperations
 	}
@@ -282,16 +395,18 @@ func newPerOperationSampler(params perOperationSamplerParams, attributesDisabled
 			params.Strategies.DefaultLowerBoundTracesPerSecond,
 			strategy.ProbabilisticSampling.SamplingRate,
 			attributesDisabled,
+			traceStateSamplingEnabled,
 		)
 		samplers[strategy.Operation] = sampler
 	}
 	return &perOperationSampler{
-		samplers:                 samplers,
-		defaultSampler:           newProbabilisticSampler(params.Strategies.DefaultSamplingProbability, attributesDisabled),
-		lowerBound:               params.Strategies.DefaultLowerBoundTracesPerSecond,
-		maxOperations:            params.MaxOperations,
-		operationNameLateBinding: params.OperationNameLateBinding,
-		attributesDisabled:       attributesDisabled,
+		samplers:                  samplers,
+		defaultSampler:            newProbabilisticSampler(params.Strategies.DefaultSamplingProbability, attributesDisabled, traceStateSamplingEnabled),
+		lowerBound:                params.Strategies.DefaultLowerBoundTracesPerSecond,
+		maxOperations:             params.MaxOperations,
+		operationNameLateBinding:  params.OperationNameLateBinding,
+		attributesDisabled:        attributesDisabled,
+		traceStateSamplingEnabled: traceStateSamplingEnabled,
 	}
 }
 
@@ -320,7 +435,7 @@ func (s *perOperationSampler) getSamplerForOperation(operation string) trace.Sam
 	if len(s.samplers) >= s.maxOperations {
 		return s.defaultSampler
 	}
-	newSampler := newGuaranteedThroughputProbabilisticSampler(s.lowerBound, s.defaultSampler.SamplingRate(), s.attributesDisabled)
+	newSampler := newGuaranteedThroughputProbabilisticSampler(s.lowerBound, s.defaultSampler.SamplingRate(), s.attributesDisabled, s.traceStateSamplingEnabled)
 	s.samplers[operation] = newSampler
 	return newSampler
 }
@@ -345,13 +460,14 @@ func (s *perOperationSampler) update(strategies *jaeger_api_v2.PerOperationSampl
 				lowerBound,
 				samplingRate,
 				s.attributesDisabled,
+				s.traceStateSamplingEnabled,
 			)
 			newSamplers[operation] = sampler
 		}
 	}
 	s.lowerBound = strategies.DefaultLowerBoundTracesPerSecond
 	if s.defaultSampler.SamplingRate() != strategies.DefaultSamplingProbability {
-		s.defaultSampler = newProbabilisticSampler(strategies.DefaultSamplingProbability, s.attributesDisabled)
+		s.defaultSampler = newProbabilisticSampler(strategies.DefaultSamplingProbability, s.attributesDisabled, s.traceStateSamplingEnabled)
 	}
 	s.samplers = newSamplers
 }

--- a/samplers/jaegerremote/sampler_remote.go
+++ b/samplers/jaegerremote/sampler_remote.go
@@ -191,7 +191,8 @@ func (s *Sampler) updateSamplerViaUpdaters(strategy any) error {
 
 // probabilisticSamplerUpdater is used by Sampler to parse sampling configuration.
 type probabilisticSamplerUpdater struct {
-	attributesDisabled bool
+	attributesDisabled        bool
+	traceStateSamplingEnabled bool
 }
 
 // Update implements Update of samplerUpdater.
@@ -208,7 +209,7 @@ func (u *probabilisticSamplerUpdater) Update(sampler trace.Sampler, strategy any
 				}
 				return sampler, nil
 			}
-			return newProbabilisticSampler(probabilistic.SamplingRate, u.attributesDisabled), nil
+			return newProbabilisticSampler(probabilistic.SamplingRate, u.attributesDisabled, u.traceStateSamplingEnabled), nil
 		}
 	}
 	return nil, nil
@@ -245,9 +246,10 @@ func (u *rateLimitingSamplerUpdater) Update(sampler trace.Sampler, strategy any)
 // perOperationSamplerUpdater is used by Sampler to parse sampling configuration.
 // Fields have the same meaning as in perOperationSamplerParams.
 type perOperationSamplerUpdater struct {
-	MaxOperations            int
-	OperationNameLateBinding bool
-	attributesDisabled       bool
+	MaxOperations             int
+	OperationNameLateBinding  bool
+	attributesDisabled        bool
+	traceStateSamplingEnabled bool
 }
 
 // Update implements Update of samplerUpdater.
@@ -266,7 +268,7 @@ func (u *perOperationSamplerUpdater) Update(sampler trace.Sampler, strategy any)
 				MaxOperations:            u.MaxOperations,
 				OperationNameLateBinding: u.OperationNameLateBinding,
 				Strategies:               operations,
-			}, u.attributesDisabled), nil
+			}, u.attributesDisabled, u.traceStateSamplingEnabled), nil
 		}
 	}
 	return nil, nil

--- a/samplers/jaegerremote/sampler_remote_options.go
+++ b/samplers/jaegerremote/sampler_remote_options.go
@@ -30,15 +30,16 @@ import (
 )
 
 type config struct {
-	sampler                 trace.Sampler
-	samplingServerURL       string
-	samplingRefreshInterval time.Duration
-	samplingFetcher         SamplingStrategyFetcher
-	samplingParser          samplingStrategyParser
-	updaters                []samplerUpdater
-	posParams               perOperationSamplerParams
-	logger                  logr.Logger
-	attributesDisabled      bool
+	sampler                   trace.Sampler
+	samplingServerURL         string
+	samplingRefreshInterval   time.Duration
+	samplingFetcher           SamplingStrategyFetcher
+	samplingParser            samplingStrategyParser
+	updaters                  []samplerUpdater
+	posParams                 perOperationSamplerParams
+	logger                    logr.Logger
+	attributesDisabled        bool
+	traceStateSamplingEnabled bool
 }
 
 func getEnvOptions() ([]Option, []error) {
@@ -113,16 +114,17 @@ func newConfig(options ...Option) config {
 	}
 	c.updaters = []samplerUpdater{
 		&perOperationSamplerUpdater{
-			MaxOperations:            c.posParams.MaxOperations,
-			OperationNameLateBinding: c.posParams.OperationNameLateBinding,
-			attributesDisabled:       c.attributesDisabled,
+			MaxOperations:             c.posParams.MaxOperations,
+			OperationNameLateBinding:  c.posParams.OperationNameLateBinding,
+			attributesDisabled:        c.attributesDisabled,
+			traceStateSamplingEnabled: c.traceStateSamplingEnabled,
 		},
-		&probabilisticSamplerUpdater{attributesDisabled: c.attributesDisabled},
+		&probabilisticSamplerUpdater{attributesDisabled: c.attributesDisabled, traceStateSamplingEnabled: c.traceStateSamplingEnabled},
 		&rateLimitingSamplerUpdater{attributesDisabled: c.attributesDisabled},
 	}
 
 	if c.sampler == nil {
-		c.sampler = newProbabilisticSampler(0.001, c.attributesDisabled)
+		c.sampler = newProbabilisticSampler(0.001, c.attributesDisabled, c.traceStateSamplingEnabled)
 	}
 
 	return c
@@ -201,6 +203,35 @@ func WithSamplingStrategyFetcher(fetcher SamplingStrategyFetcher) Option {
 func WithAttributesDisabled() Option {
 	return optionFunc(func(c *config) {
 		c.attributesDisabled = true
+	})
+}
+
+// WithTraceStateSamplingEnabled configures the sampler to implement the
+// OpenTelemetry tracestate probability sampling specification (OTEP 235)
+// for its probabilistic sampling strategies, including the default and
+// per-operation override rates used by the "probabilistic" and "per
+// operation" Jaeger remote sampling strategy types.
+//
+// When enabled, a sampling decision is made by comparing a 56-bit
+// randomness value - taken from an explicit "rv" sub-key in the incoming
+// tracestate, or else presumed from the trace ID's least significant 56
+// bits - against a rejection threshold derived from the configured
+// sampling rate. On a positive decision, that threshold is published via
+// the "th" sub-key of the "ot" tracestate entry, so downstream consumers
+// (for example span-to-metrics extrapolation) can compute a reliable
+// adjusted count.
+//
+// Enabling this changes which trace IDs are sampled for a given rate (the
+// overall sampling rate itself is unaffected), so it defaults to disabled
+// for backwards compatibility. Rate-limiting strategies, including the
+// "guaranteed throughput" lower bound used by per-operation sampling, are
+// not probabilistic and never set "th".
+//
+// See https://opentelemetry.io/docs/specs/otel/trace/tracestate-probability-sampling/
+// for details.
+func WithTraceStateSamplingEnabled() Option {
+	return optionFunc(func(c *config) {
+		c.traceStateSamplingEnabled = true
 	})
 }
 

--- a/samplers/jaegerremote/sampler_remote_test.go
+++ b/samplers/jaegerremote/sampler_remote_test.go
@@ -38,7 +38,7 @@ import (
 )
 
 func TestRemotelyControlledSampler_updateConcurrentSafe(*testing.T) {
-	initSampler := newProbabilisticSampler(0.123, false)
+	initSampler := newProbabilisticSampler(0.123, false, false)
 	fetcher := &testSamplingStrategyFetcher{response: []byte("probabilistic")}
 	parser := new(testSamplingStrategyParser)
 	sampler := New(
@@ -101,7 +101,7 @@ func (*testSamplingStrategyParser) Parse(response []byte) (any, error) {
 }
 
 func TestRemoteSamplerOptions(t *testing.T) {
-	initSampler := newProbabilisticSampler(0.123, false)
+	initSampler := newProbabilisticSampler(0.123, false, false)
 	fetcher := new(fakeSamplingFetcher)
 	parser := new(samplingStrategyParserImpl)
 	logger := testr.New(t)
@@ -144,7 +144,7 @@ func initAgent(t *testing.T) (*testutils.MockAgent, *Sampler) {
 	agent, err := testutils.StartMockAgent()
 	require.NoError(t, err)
 
-	initialSampler := newProbabilisticSampler(0.001, false)
+	initialSampler := newProbabilisticSampler(0.001, false, false)
 	sampler := New(
 		"client app",
 		WithSamplingServerURL("http://"+agent.SamplingServerAddr()),
@@ -171,7 +171,7 @@ func TestRemotelyControlledSampler(t *testing.T) {
 	agent, remoteSampler := initAgent(t)
 	defer agent.Close()
 
-	defaultSampler := newProbabilisticSampler(0.001, false)
+	defaultSampler := newProbabilisticSampler(0.001, false, false)
 	remoteSampler.setSampler(defaultSampler)
 
 	agent.AddSamplingStrategy("client app",
@@ -304,7 +304,7 @@ func TestRemotelyControlledSampler_updateSampler(t *testing.T) {
 }
 
 func TestRemotelyControlledSampler_ImmediatelyUpdateOnStartup(t *testing.T) {
-	initSampler := newProbabilisticSampler(0.123, false)
+	initSampler := newProbabilisticSampler(0.123, false, false)
 	fetcher := &testSamplingStrategyFetcher{response: []byte("rateLimiting")}
 	parser := new(testSamplingStrategyParser)
 	sampler := New(
@@ -402,7 +402,7 @@ func TestRemotelyControlledSampler_updateSamplerFromAdaptiveSampler(t *testing.T
 	adaptiveSampler := newPerOperationSampler(perOperationSamplerParams{
 		MaxOperations: testDefaultMaxOperations,
 		Strategies:    strategies,
-	}, false)
+	}, false, false)
 
 	// Overwrite the sampler with an adaptive sampler
 	remoteSampler.setSampler(adaptiveSampler)
@@ -435,9 +435,9 @@ func TestRemotelyControlledSampler_updateSamplerFromAdaptiveSampler(t *testing.T
 }
 
 func TestRemotelyControlledSampler_updateRateLimitingOrProbabilisticSampler(t *testing.T) {
-	probabilisticSampler := newProbabilisticSampler(0.002, false)
-	otherProbabilisticSampler := newProbabilisticSampler(0.003, false)
-	maxProbabilisticSampler := newProbabilisticSampler(1.0, false)
+	probabilisticSampler := newProbabilisticSampler(0.002, false, false)
+	otherProbabilisticSampler := newProbabilisticSampler(0.003, false, false)
+	maxProbabilisticSampler := newProbabilisticSampler(1.0, false, false)
 
 	rateLimitingSampler := newRateLimitingSampler(2, false)
 	otherRateLimitingSampler := newRateLimitingSampler(3, false)

--- a/samplers/jaegerremote/sampler_test.go
+++ b/samplers/jaegerremote/sampler_test.go
@@ -68,7 +68,7 @@ func defaultIDGenerator() *randomIDGenerator {
 func TestProbabilisticSampler(t *testing.T) {
 	var traceID oteltrace.TraceID
 
-	sampler := newProbabilisticSampler(0.5, false)
+	sampler := newProbabilisticSampler(0.5, false, false)
 	binary.BigEndian.PutUint64(traceID[8:], testMaxID+10)
 	result := sampler.ShouldSample(trace.SamplingParameters{TraceID: traceID})
 	assert.Equal(t, trace.Drop, result.Decision)
@@ -89,7 +89,7 @@ func TestProbabilisticSampler(t *testing.T) {
 	t.Run("test_parity", func(t *testing.T) {
 		numTests := 1000
 
-		sampler := newProbabilisticSampler(0.5, true)
+		sampler := newProbabilisticSampler(0.5, true, false)
 		oracle := trace.TraceIDRatioBased(0.5)
 		idGenerator := defaultIDGenerator()
 
@@ -104,11 +104,11 @@ func TestProbabilisticSampler(t *testing.T) {
 	})
 
 	t.Run("Equals", func(t *testing.T) {
-		sampler := newProbabilisticSampler(0.5, false)
-		assert.True(t, sampler.Equal(newProbabilisticSampler(0.5, false)))
-		assert.False(t, sampler.Equal(newProbabilisticSampler(0.0, false)))
-		assert.False(t, sampler.Equal(newProbabilisticSampler(0.75, false)))
-		assert.False(t, sampler.Equal(newProbabilisticSampler(1.0, false)))
+		sampler := newProbabilisticSampler(0.5, false, false)
+		assert.True(t, sampler.Equal(newProbabilisticSampler(0.5, false, false)))
+		assert.False(t, sampler.Equal(newProbabilisticSampler(0.0, false, false)))
+		assert.False(t, sampler.Equal(newProbabilisticSampler(0.75, false, false)))
+		assert.False(t, sampler.Equal(newProbabilisticSampler(1.0, false, false)))
 	})
 }
 
@@ -135,7 +135,7 @@ func TestRateLimitingSampler(t *testing.T) {
 func TestGuaranteedThroughputProbabilisticSamplerUpdate(t *testing.T) {
 	samplingRate := 0.5
 	lowerBound := 2.0
-	sampler := newGuaranteedThroughputProbabilisticSampler(lowerBound, samplingRate, false)
+	sampler := newGuaranteedThroughputProbabilisticSampler(lowerBound, samplingRate, false, false)
 	assert.Equal(t, lowerBound, sampler.lowerBound)
 	assert.Equal(t, samplingRate, sampler.samplingRate)
 
@@ -166,16 +166,16 @@ func TestAdaptiveSampler(t *testing.T) {
 	sampler := newPerOperationSampler(perOperationSamplerParams{
 		Strategies:    strategies,
 		MaxOperations: 42,
-	}, false)
+	}, false, false)
 	assert.Equal(t, 42, sampler.maxOperations)
 
-	sampler = newPerOperationSampler(perOperationSamplerParams{Strategies: strategies}, false)
+	sampler = newPerOperationSampler(perOperationSamplerParams{Strategies: strategies}, false, false)
 	assert.Equal(t, 2000, sampler.maxOperations, "default MaxOperations applied")
 
 	sampler = newPerOperationSampler(perOperationSamplerParams{
 		MaxOperations: testDefaultMaxOperations,
 		Strategies:    strategies,
-	}, false)
+	}, false, false)
 
 	result := sampler.ShouldSample(makeSamplingParameters(testMaxID+10, testOperationName))
 	assert.Equal(t, trace.RecordAndSample, result.Decision)
@@ -206,14 +206,14 @@ func TestAdaptiveSamplerErrors(t *testing.T) {
 	sampler := newPerOperationSampler(perOperationSamplerParams{
 		MaxOperations: testDefaultMaxOperations,
 		Strategies:    strategies,
-	}, false)
+	}, false, false)
 	assert.Equal(t, 0.0, sampler.samplers[testOperationName].samplingRate)
 
 	strategies.PerOperationStrategies[0].ProbabilisticSampling.SamplingRate = 1.1
 	sampler = newPerOperationSampler(perOperationSamplerParams{
 		MaxOperations: testDefaultMaxOperations,
 		Strategies:    strategies,
-	}, false)
+	}, false, false)
 	assert.Equal(t, 1.0, sampler.samplers[testOperationName].samplingRate)
 }
 
@@ -235,7 +235,7 @@ func TestAdaptiveSamplerUpdate(t *testing.T) {
 	sampler := newPerOperationSampler(perOperationSamplerParams{
 		MaxOperations: testDefaultMaxOperations,
 		Strategies:    strategies,
-	}, false)
+	}, false, false)
 
 	assert.Equal(t, lowerBound, sampler.lowerBound)
 	assert.Equal(t, testDefaultSamplingProbability, sampler.defaultSampler.SamplingRate())
@@ -283,7 +283,7 @@ func TestMaxOperations(t *testing.T) {
 	sampler := newPerOperationSampler(perOperationSamplerParams{
 		MaxOperations: 1,
 		Strategies:    strategies,
-	}, false)
+	}, false, false)
 
 	result := sampler.ShouldSample(makeSamplingParameters(testMaxID-10, testFirstTimeOperationName))
 	assert.Equal(t, trace.RecordAndSample, result.Decision)
@@ -296,7 +296,7 @@ func TestAttributes(t *testing.T) {
 		t.Parallel()
 
 		var traceID oteltrace.TraceID
-		s := newProbabilisticSampler(0.5, false)
+		s := newProbabilisticSampler(0.5, false, false)
 		binary.BigEndian.PutUint64(traceID[:8], math.MaxUint64)
 		binary.BigEndian.PutUint64(traceID[8:], testMaxID+10)
 		result := s.ShouldSample(trace.SamplingParameters{TraceID: traceID})
@@ -308,7 +308,7 @@ func TestAttributes(t *testing.T) {
 		assert.Equal(t, trace.RecordAndSample, result.Decision)
 		assert.Equal(t, []attribute.KeyValue{attribute.String(samplerTypeKey, samplerTypeValueProbabilistic), attribute.Float64(samplerParamKey, 0.5)}, result.Attributes)
 
-		s = newProbabilisticSampler(1.0, false)
+		s = newProbabilisticSampler(1.0, false, false)
 		result = s.ShouldSample(trace.SamplingParameters{TraceID: traceID})
 		assert.Equal(t, trace.RecordAndSample, result.Decision)
 		assert.Equal(t, []attribute.KeyValue{attribute.String(samplerTypeKey, samplerTypeValueProbabilistic), attribute.Float64(samplerParamKey, 1.0)}, result.Attributes)
@@ -318,7 +318,7 @@ func TestAttributes(t *testing.T) {
 		t.Parallel()
 
 		var traceID oteltrace.TraceID
-		s := newProbabilisticSampler(0.5, true)
+		s := newProbabilisticSampler(0.5, true, false)
 		binary.BigEndian.PutUint64(traceID[:8], math.MaxUint64)
 		binary.BigEndian.PutUint64(traceID[8:], testMaxID+10)
 		result := s.ShouldSample(trace.SamplingParameters{TraceID: traceID})
@@ -380,7 +380,7 @@ func TestAttributes(t *testing.T) {
 		s := newPerOperationSampler(perOperationSamplerParams{
 			MaxOperations: testDefaultMaxOperations,
 			Strategies:    strategies,
-		}, false)
+		}, false, false)
 
 		result := s.ShouldSample(makeSamplingParameters(testMaxID+10, testOperationName))
 		assert.Equal(t, trace.RecordAndSample, result.Decision)
@@ -417,7 +417,7 @@ func TestAttributes(t *testing.T) {
 		s := newPerOperationSampler(perOperationSamplerParams{
 			MaxOperations: testDefaultMaxOperations,
 			Strategies:    strategies,
-		}, true)
+		}, true, false)
 
 		result := s.ShouldSample(makeSamplingParameters(testMaxID+10, testOperationName))
 		assert.Equal(t, trace.RecordAndSample, result.Decision)

--- a/samplers/jaegerremote/sampler_tracestate_test.go
+++ b/samplers/jaegerremote/sampler_tracestate_test.go
@@ -1,0 +1,164 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package jaegerremote
+
+import (
+	"context"
+	"encoding/binary"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/sdk/trace"
+	oteltrace "go.opentelemetry.io/otel/trace"
+)
+
+// contextWithTraceState builds a ParentContext carrying the given TraceID and
+// (parsed) W3C tracestate, for exercising shouldSampleWithTraceState.
+func contextWithTraceState(t *testing.T, traceID oteltrace.TraceID, tracestate string) context.Context {
+	t.Helper()
+	state, err := oteltrace.ParseTraceState(tracestate)
+	require.NoError(t, err)
+	return oteltrace.ContextWithSpanContext(t.Context(), oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+		TraceID:    traceID,
+		TraceState: state,
+	}))
+}
+
+func TestProbabilisticSamplerTraceStateThreshold(t *testing.T) {
+	for _, tc := range []struct {
+		prob      float64
+		threshold uint64
+	}{
+		{0.5, 0x80000000000000},
+		{1 / 3.0, 0xaaab0000000000},
+		{2 / 3.0, 0x55550000000000},
+		{1, 0},
+		{1.5, 0},
+		{0, maxAdjustedCount},
+	} {
+		s := newProbabilisticSampler(tc.prob, false, true)
+		assert.Equal(t, tc.threshold, s.threshold, "probability %g", tc.prob)
+	}
+}
+
+func TestProbabilisticSamplerTraceStateShouldSample(t *testing.T) {
+	const threshold50 = uint64(0x80000000000000)
+
+	t.Run("disabled path is unaffected", func(t *testing.T) {
+		s := newProbabilisticSampler(0.5, false, false)
+		var traceID oteltrace.TraceID
+		binary.BigEndian.PutUint64(traceID[8:], threshold50)
+		result := s.ShouldSample(trace.SamplingParameters{TraceID: traceID})
+		assert.Equal(t, trace.RecordAndSample, result.Decision)
+		assert.Empty(t, result.Tracestate.Get("ot"))
+	})
+
+	t.Run("root span sample and drop via trace ID randomness", func(t *testing.T) {
+		s := newProbabilisticSampler(0.5, false, true)
+
+		var traceIDSample oteltrace.TraceID
+		binary.BigEndian.PutUint64(traceIDSample[8:], threshold50)
+		result := s.ShouldSample(trace.SamplingParameters{TraceID: traceIDSample})
+		assert.Equal(t, trace.RecordAndSample, result.Decision)
+		ot := result.Tracestate.Get("ot")
+		require.NotEmpty(t, ot)
+		assert.True(t, strings.HasPrefix(ot, "th:8"), "got %q", ot)
+
+		var traceIDDrop oteltrace.TraceID
+		binary.BigEndian.PutUint64(traceIDDrop[8:], threshold50-1)
+		result = s.ShouldSample(trace.SamplingParameters{TraceID: traceIDDrop})
+		assert.Equal(t, trace.Drop, result.Decision)
+		assert.Empty(t, result.Tracestate.Get("ot"))
+	})
+
+	t.Run("existing th and other ot keys are replaced in place, vendors preserved", func(t *testing.T) {
+		s := newProbabilisticSampler(0.5, false, true)
+		var traceID oteltrace.TraceID
+		binary.BigEndian.PutUint64(traceID[8:], threshold50)
+		ctx := contextWithTraceState(t, traceID, "ot=th:0ad;other:value,vendor=v")
+
+		result := s.ShouldSample(trace.SamplingParameters{ParentContext: ctx, TraceID: traceID})
+		assert.Equal(t, trace.RecordAndSample, result.Decision)
+		ot := result.Tracestate.Get("ot")
+		assert.True(t, strings.HasPrefix(ot, "th:8"), "got %q", ot)
+		assert.Contains(t, ot, "other:value")
+		assert.Equal(t, "v", result.Tracestate.Get("vendor"))
+	})
+
+	t.Run("explicit rv in tracestate is honored over trace ID", func(t *testing.T) {
+		s := newProbabilisticSampler(0.5, false, true)
+		var traceID oteltrace.TraceID
+		binary.BigEndian.PutUint64(traceID[8:], 1) // would drop if used directly
+		ctx := contextWithTraceState(t, traceID, "ot=rv:80000000000000,vendor=value")
+
+		result := s.ShouldSample(trace.SamplingParameters{ParentContext: ctx, TraceID: traceID})
+		assert.Equal(t, trace.RecordAndSample, result.Decision, "rv value should be used for sampling decision")
+		assert.Contains(t, result.Tracestate.Get("ot"), "th:")
+		assert.Equal(t, "value", result.Tracestate.Get("vendor"))
+	})
+
+	t.Run("probability one uses th:0 and always samples", func(t *testing.T) {
+		s := newProbabilisticSampler(1, false, true)
+		var traceID oteltrace.TraceID // all zero, would drop at any positive threshold
+		result := s.ShouldSample(trace.SamplingParameters{TraceID: traceID})
+		assert.Equal(t, trace.RecordAndSample, result.Decision)
+		assert.Equal(t, "th:0", result.Tracestate.Get("ot"))
+	})
+}
+
+// TestRateLimitingDoesNotSetTracestateThreshold guards the documented
+// limitation that rate-limiting decisions - including the guaranteed lower
+// bound used by guaranteedThroughputProbabilisticSampler - never add a
+// tracestate "th" value, because they are not fixed-probability decisions.
+func TestRateLimitingDoesNotSetTracestateThreshold(t *testing.T) {
+	t.Run("standalone rate limiting sampler", func(t *testing.T) {
+		s := newRateLimitingSampler(1000, false)
+		result := s.ShouldSample(trace.SamplingParameters{Name: testOperationName})
+		assert.Equal(t, trace.RecordAndSample, result.Decision)
+		assert.Empty(t, result.Tracestate.Get("ot"))
+	})
+
+	t.Run("guaranteed throughput fallback", func(t *testing.T) {
+		// samplingRate 0 with traceStateSamplingEnabled makes the probabilistic
+		// branch always drop, forcing the rate-limiting lower bound to decide.
+		gt := newGuaranteedThroughputProbabilisticSampler(1000, 0, false, true)
+		var traceID oteltrace.TraceID
+		result := gt.ShouldSample(trace.SamplingParameters{TraceID: traceID})
+		assert.Equal(t, trace.RecordAndSample, result.Decision)
+		assert.Empty(t, result.Tracestate.Get("ot"))
+	})
+}
+
+func TestWithTraceStateSamplingEnabled(t *testing.T) {
+	c := newConfig(WithTraceStateSamplingEnabled())
+	require.True(t, c.traceStateSamplingEnabled)
+	sampler, ok := c.sampler.(*probabilisticSampler)
+	require.True(t, ok)
+	assert.True(t, sampler.traceStateSamplingEnabled)
+}
+
+func BenchmarkProbabilisticSamplerShouldSample(b *testing.B) {
+	var traceIDSample oteltrace.TraceID
+	binary.BigEndian.PutUint64(traceIDSample[8:], uint64(0x80000000000000))
+	params := trace.SamplingParameters{TraceID: traceIDSample}
+
+	cases := []struct {
+		name    string
+		sampler *probabilisticSampler
+	}{
+		{"trace_state_disabled", newProbabilisticSampler(0.5, false, false)},
+		{"trace_state_enabled", newProbabilisticSampler(0.5, false, true)},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				_ = tc.sampler.ShouldSample(params)
+			}
+		})
+	}
+}

--- a/samplers/jaegerremote/tracestate.go
+++ b/samplers/jaegerremote/tracestate.go
@@ -1,0 +1,65 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package jaegerremote // import "go.opentelemetry.io/contrib/samplers/jaegerremote"
+
+import (
+	"strconv"
+	"strings"
+)
+
+// insertOrUpdateTraceStateThKeyValue inserts or updates the threshold (th)
+// key-value in the OpenTelemetry tracestate "ot" field, preserving any other
+// key-values already present.
+func insertOrUpdateTraceStateThKeyValue(existingOtts, thkv string) string {
+	if existingOtts == "" {
+		return thkv
+	}
+
+	start := -1
+	var end int
+	if strings.HasPrefix(existingOtts, "th:") {
+		start = 0
+	} else if idx := strings.Index(existingOtts, ";th:"); idx != -1 {
+		start = idx + 1
+	}
+	if start == -1 {
+		return thkv + ";" + existingOtts
+	}
+
+	for end = start; end < len(existingOtts); end++ {
+		if existingOtts[end] == ';' {
+			end++
+			break
+		}
+	}
+
+	if end == len(existingOtts) {
+		return strings.TrimSuffix(thkv+";"+existingOtts[0:start], ";")
+	}
+	return thkv + ";" + existingOtts[0:start] + existingOtts[end:]
+}
+
+// tracestateRandomness determines whether there is a randomness "rv"
+// sub-key in otts (the top-level OpenTelemetry tracestate "ot" field). If
+// present, "rv" is a 56-bit unsigned integer, encoded in 14 hex digits.
+func tracestateRandomness(otts string) (randomness uint64, hasRandomness bool) {
+	var start int
+	if strings.HasPrefix(otts, "rv:") {
+		start = 3
+	} else if idx := strings.Index(otts, ";rv:"); idx != -1 {
+		start = idx + 4
+	} else {
+		return 0, false
+	}
+
+	if len(otts) < start+14 || (len(otts) > start+14 && otts[start+14] != ';') {
+		return 0, false
+	}
+
+	rv, err := strconv.ParseUint(otts[start:start+14], 16, 56)
+	if err != nil {
+		return 0, false
+	}
+	return rv, true
+}

--- a/samplers/jaegerremote/tracestate_test.go
+++ b/samplers/jaegerremote/tracestate_test.go
@@ -1,0 +1,81 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package jaegerremote
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTracestateRandomness(t *testing.T) {
+	const validRV = "0123456789abcd"
+	const validRVValue uint64 = 0x0123456789abcd
+
+	testCases := []struct {
+		name       string
+		otts       string
+		wantRandom uint64
+		wantHasRV  bool
+	}{
+		{"rv at beginning", "rv:" + validRV, validRVValue, true},
+		{"rv at beginning with more keys", "rv:" + validRV + ";th:0;other:value", validRVValue, true},
+		{"rv in middle", "th:0;rv:" + validRV + ";other:value", validRVValue, true},
+		{"rv at end", "th:0;other:value;rv:" + validRV, validRVValue, true},
+		{"rv with max 56-bit value", "rv:0fffffffffffff", 0x0fffffffffffff, true},
+		{"no rv key", "th:0;other:value", 0, false},
+		{"empty string", "", 0, false},
+		{"rv value too short", "rv:0123456789abc", 0, false},
+		{"rv value too long", "rv:0123456789abcdef", 0, false},
+		{"rv with invalid hex", "rv:0123456789abcg", 0, false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotRandom, gotHasRV := tracestateRandomness(tc.otts)
+			assert.Equal(t, tc.wantHasRV, gotHasRV)
+			if tc.wantHasRV {
+				assert.Equal(t, tc.wantRandom, gotRandom)
+			}
+		})
+	}
+}
+
+func TestInsertOrUpdateTraceStateThKeyValue(t *testing.T) {
+	testCases := []struct {
+		name         string
+		existingOtts string
+		thkv         string
+		want         string
+	}{
+		{"empty existing adds th at front", "", "th:123456789abcd", "th:123456789abcd"},
+		{
+			"no th in existing adds th at front",
+			"rv:0123456789abcd;other:value",
+			"th:fedcba98765432",
+			"th:fedcba98765432;rv:0123456789abcd;other:value",
+		},
+		{
+			"existing th is replaced",
+			"rv:0123456789abcd;th:0ad;other:value",
+			"th:0e1",
+			"th:0e1;rv:0123456789abcd;other:value",
+		},
+		{"th at front is replaced", "th:0ad;rv:0123456789abcd", "th:0e1", "th:0e1;rv:0123456789abcd"},
+		{"only th in existing is replaced", "th:0ad", "th:0e1", "th:0e1"},
+		{
+			"th substring in another key (path:0) is left intact; th prepended",
+			"path:0;rv:0123456789abcd",
+			"th:fedcba98765432",
+			"th:fedcba98765432;path:0;rv:0123456789abcd",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := insertOrUpdateTraceStateThKeyValue(tc.existingOtts, tc.thkv)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Hi! This PR adds an opt-in `WithTraceStateSamplingEnabled()` option that implements the OpenTelemetry tracestate probability sampling specification (OTEP 235).

While it samples at the same rate, it changes _which_ traces are sampled so the option is disabled by default to be backwards compatibility. Rate-limiting strategies are not probabilistic and never set th.