### PR TITLE
otelconf: support wildcard include/exclude filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- Fix wildcard matching and exclusion precedence for include/exclude filters in `go.opentelemetry.io/contrib/otelconf`.
+- Fix wildcard matching and exclusion precedence for include/exclude filters in `go.opentelemetry.io/contrib/otelconf`. (#9301)
 - Fix Prometheus reader resource label filter configuration in `go.opentelemetry.io/contrib/otelconf/v0.2.0`. (#9045)
 - Apply `resource.detection/development.attributes.included` and `excluded` filtering to resource detector attributes in `go.opentelemetry.io/contrib/otelconf/x`. (#9131)
 - Honor the context configured with `WithContext` when constructing resources in `go.opentelemetry.io/contrib/otelconf` and `go.opentelemetry.io/contrib/otelconf/x`. (#9160)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Fix wildcard matching and exclusion precedence for include/exclude filters in `go.opentelemetry.io/contrib/otelconf`.
 - Fix Prometheus reader resource label filter configuration in `go.opentelemetry.io/contrib/otelconf/v0.2.0`. (#9045)
 - Apply `resource.detection/development.attributes.included` and `excluded` filtering to resource detector attributes in `go.opentelemetry.io/contrib/otelconf/x`. (#9131)
 - Honor the context configured with `WithContext` when constructing resources in `go.opentelemetry.io/contrib/otelconf` and `go.opentelemetry.io/contrib/otelconf/x`. (#9160)

--- a/otelconf/internal/wildcard/wildcard.go
+++ b/otelconf/internal/wildcard/wildcard.go
@@ -1,0 +1,146 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package wildcard matches strings against case-sensitive wildcard patterns.
+package wildcard // import "go.opentelemetry.io/contrib/otelconf/internal/wildcard"
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// Matcher matches strings against included and excluded wildcard patterns.
+// Patterns in each set are combined with a logical OR, and exclusions take
+// precedence over inclusions. An asterisk matches zero or more characters and
+// a question mark matches exactly one character.
+type Matcher struct {
+	included         patternSet
+	excluded         patternSet
+	includeAll       bool
+	excludeAll       bool
+	excludeNone      bool
+	includeExactOnly bool
+}
+
+type patternSet struct {
+	exact     map[string]struct{}
+	wildcards []string
+	matchAll  bool
+}
+
+// NewMatcher returns a Matcher for the included and excluded patterns.
+func NewMatcher(included, excluded []string) Matcher {
+	includedSet := newPatternSet(included)
+	excludedSet := newPatternSet(excluded)
+	return Matcher{
+		included:    includedSet,
+		excluded:    excludedSet,
+		includeAll:  len(included) == 0 || includedSet.matchAll,
+		excludeAll:  excludedSet.matchAll,
+		excludeNone: len(excluded) == 0,
+		includeExactOnly: len(included) > 0 && len(includedSet.wildcards) == 0 &&
+			!includedSet.matchAll && len(excluded) == 0,
+	}
+}
+
+func newPatternSet(patterns []string) patternSet {
+	set := patternSet{}
+	for _, pattern := range patterns {
+		if pattern == "*" {
+			set.matchAll = true
+			continue
+		}
+		if strings.ContainsAny(pattern, "*?") {
+			set.wildcards = append(set.wildcards, pattern)
+			continue
+		}
+
+		if set.exact == nil {
+			set.exact = make(map[string]struct{}, len(patterns))
+		}
+		set.exact[pattern] = struct{}{}
+	}
+	return set
+}
+
+// Match reports whether value is included and not excluded.
+func (m Matcher) Match(value string) bool {
+	if m.includeExactOnly {
+		_, ok := m.included.exact[value]
+		return ok
+	}
+	return m.match(value)
+}
+
+func (m Matcher) match(value string) bool {
+	if !m.includeAll {
+		if _, ok := m.included.exact[value]; !ok && !matchAny(m.included.wildcards, value) {
+			return false
+		}
+	}
+	if m.excludeNone {
+		return true
+	}
+	if m.excludeAll {
+		return false
+	}
+	if _, ok := m.excluded.exact[value]; ok {
+		return false
+	}
+	return !matchAny(m.excluded.wildcards, value)
+}
+
+func matchAny(patterns []string, value string) bool {
+	for _, pattern := range patterns {
+		if match(pattern, value) {
+			return true
+		}
+	}
+	return false
+}
+
+func match(pattern, value string) bool {
+	patternIndex := 0
+	valueIndex := 0
+	starIndex := -1
+	starValueIndex := 0
+
+	for valueIndex < len(value) {
+		if patternIndex < len(pattern) {
+			switch pattern[patternIndex] {
+			case '?':
+				_, size := utf8.DecodeRuneInString(value[valueIndex:])
+				patternIndex++
+				valueIndex += size
+				continue
+			case '*':
+				starIndex = patternIndex
+				starValueIndex = valueIndex
+				patternIndex++
+				continue
+			default:
+				_, patternSize := utf8.DecodeRuneInString(pattern[patternIndex:])
+				_, valueSize := utf8.DecodeRuneInString(value[valueIndex:])
+				if patternSize == valueSize &&
+					pattern[patternIndex:patternIndex+patternSize] == value[valueIndex:valueIndex+valueSize] {
+					patternIndex += patternSize
+					valueIndex += valueSize
+					continue
+				}
+			}
+		}
+
+		if starIndex < 0 {
+			return false
+		}
+		_, size := utf8.DecodeRuneInString(value[starValueIndex:])
+		starValueIndex += size
+		patternIndex = starIndex + 1
+		valueIndex = starValueIndex
+	}
+
+	for patternIndex < len(pattern) && pattern[patternIndex] == '*' {
+		patternIndex++
+	}
+	return patternIndex == len(pattern)
+}

--- a/otelconf/internal/wildcard/wildcard_test.go
+++ b/otelconf/internal/wildcard/wildcard_test.go
@@ -1,0 +1,148 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package wildcard
+
+import "testing"
+
+func TestMatcher(t *testing.T) {
+	tests := []struct {
+		name     string
+		included []string
+		excluded []string
+		value    string
+		want     bool
+	}{
+		{
+			name:  "no patterns includes all",
+			value: "service.name",
+			want:  true,
+		},
+		{
+			name:     "literal match",
+			included: []string{"service.name"},
+			value:    "service.name",
+			want:     true,
+		},
+		{
+			name:     "literal mismatch",
+			included: []string{"service.name"},
+			value:    "service.version",
+		},
+		{
+			name:     "case sensitive",
+			included: []string{"service.*"},
+			value:    "Service.name",
+		},
+		{
+			name:     "asterisk matches empty",
+			included: []string{"service.*"},
+			value:    "service.",
+			want:     true,
+		},
+		{
+			name:     "asterisk matches all",
+			included: []string{"*"},
+			want:     true,
+		},
+		{
+			name:     "asterisk matches characters",
+			included: []string{"service.*"},
+			value:    "service.instance.id",
+			want:     true,
+		},
+		{
+			name:     "asterisk matches slash",
+			included: []string{"service*id"},
+			value:    "service/instance/id",
+			want:     true,
+		},
+		{
+			name:     "question mark matches one character",
+			included: []string{"process.?ommand_args"},
+			value:    "process.command_args",
+			want:     true,
+		},
+		{
+			name:     "question mark does not match empty",
+			included: []string{"process.?ommand_args"},
+			value:    "process.ommand_args",
+		},
+		{
+			name:     "question mark does not match two characters",
+			included: []string{"process.?ommand_args"},
+			value:    "process.xxommand_args",
+		},
+		{
+			name:     "question mark matches one unicode character",
+			included: []string{"service.?"},
+			value:    "service.é",
+			want:     true,
+		},
+		{
+			name:     "patterns use logical OR",
+			included: []string{"host.*", "service.*"},
+			value:    "service.name",
+			want:     true,
+		},
+		{
+			name:     "multiple asterisks",
+			included: []string{"*service**name*"},
+			value:    "my.service.name.suffix",
+			want:     true,
+		},
+		{
+			name:     "brackets are literals",
+			included: []string{"service.[name]"},
+			value:    "service.[name]",
+			want:     true,
+		},
+		{
+			name:     "brackets do not form a character class",
+			included: []string{"service.[name]"},
+			value:    "service.n",
+		},
+		{
+			name:     "backslash is literal",
+			included: []string{`service.\*`},
+			value:    `service.\name`,
+			want:     true,
+		},
+		{
+			name:     "exclusion only",
+			excluded: []string{"secret.*"},
+			value:    "secret.token",
+		},
+		{
+			name:     "exclusion does not match",
+			excluded: []string{"secret.*"},
+			value:    "service.name",
+			want:     true,
+		},
+		{
+			name:     "literal exclusion takes precedence",
+			included: []string{"service.name"},
+			excluded: []string{"service.name"},
+			value:    "service.name",
+		},
+		{
+			name:     "wildcard exclusion takes precedence",
+			included: []string{"service.*"},
+			excluded: []string{"service.secret*"},
+			value:    "service.secret.token",
+		},
+		{
+			name:     "exclude all",
+			excluded: []string{"*"},
+			value:    "service.name",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			matcher := NewMatcher(test.included, test.excluded)
+			if got := matcher.Match(test.value); got != test.want {
+				t.Fatalf("Match(%q) = %v, want %v", test.value, got, test.want)
+			}
+		})
+	}
+}

--- a/otelconf/metric.go
+++ b/otelconf/metric.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc/credentials"
 
 	"go.opentelemetry.io/contrib/otelconf/internal/tls"
+	"go.opentelemetry.io/contrib/otelconf/internal/wildcard"
 )
 
 var zeroScope instrumentation.Scope
@@ -341,39 +342,23 @@ func lowMemory(ik sdkmetric.InstrumentKind) metricdata.Temporality {
 	}
 }
 
-// newIncludeExcludeFilter returns a Filter that includes attributes
-// in the include list and excludes attributes in the excludes list.
-// It returns an error if an attribute is in both lists
+// newIncludeExcludeFilter returns a Filter that includes attributes matching
+// the include patterns and excludes attributes matching the exclude patterns.
+// Exclude patterns take precedence over include patterns.
 //
-// If IncludeExclude is empty an include-all filter is returned.
+// If IncludeExclude is empty, an include-all filter is returned.
+//
+//nolint:unparam // Keep the error result consistent across versioned config builders.
 func newIncludeExcludeFilter(lists *IncludeExclude) (attribute.Filter, error) {
-	if lists == nil {
-		return func(attribute.KeyValue) bool { return true }, nil
+	var included, excluded []string
+	if lists != nil {
+		included = lists.Included
+		excluded = lists.Excluded
 	}
 
-	included := make(map[attribute.Key]struct{})
-	for _, k := range lists.Included {
-		included[attribute.Key(k)] = struct{}{}
-	}
-	excluded := make(map[attribute.Key]struct{})
-	for _, k := range lists.Excluded {
-		if _, ok := included[attribute.Key(k)]; ok {
-			return nil, fmt.Errorf("attribute cannot be in both include and exclude list: %s", k)
-		}
-		excluded[attribute.Key(k)] = struct{}{}
-	}
+	matcher := wildcard.NewMatcher(included, excluded)
 	return func(kv attribute.KeyValue) bool {
-		// check if a value is excluded first
-		if _, ok := excluded[kv.Key]; ok {
-			return false
-		}
-
-		if len(included) == 0 {
-			return true
-		}
-
-		_, ok := included[kv.Key]
-		return ok
+		return matcher.Match(string(kv.Key))
 	}, nil
 }
 

--- a/otelconf/metric_test.go
+++ b/otelconf/metric_test.go
@@ -9,7 +9,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -1447,27 +1446,113 @@ func TestNewIncludeExcludeFilter(t *testing.T) {
 			wantPass: []string{"bar"},
 			wantFail: []string{"foo"},
 		},
+		{
+			name: "filter-with-wildcard-include",
+			attributeKeys: ptr(IncludeExclude{
+				Included: []string{"service.*", "process.?ommand_args"},
+			}),
+			wantPass: []string{"service.", "service.name", "process.command_args"},
+			wantFail: []string{"Service.name", "process.ommand_args", "process.xxommand_args", "host.name"},
+		},
+		{
+			name: "filter-with-wildcard-exclude",
+			attributeKeys: ptr(IncludeExclude{
+				Excluded: []string{"secret.*", "process.?ommand_args"},
+			}),
+			wantPass: []string{"service.name"},
+			wantFail: []string{"secret.", "secret.token", "process.command_args"},
+		},
+		{
+			name: "filter-with-exclusion-precedence",
+			attributeKeys: ptr(IncludeExclude{
+				Included: []string{"service.*"},
+				Excluded: []string{"service.name", "service.secret*"},
+			}),
+			wantPass: []string{"service.version"},
+			wantFail: []string{"service.name", "service.secret.token", "host.name"},
+		},
+		{
+			name: "filter-with-identical-include-and-exclude",
+			attributeKeys: ptr(IncludeExclude{
+				Included: []string{"service.name"},
+				Excluded: []string{"service.name"},
+			}),
+			wantFail: []string{"service.name"},
+		},
 	}
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := newIncludeExcludeFilter(tt.attributeKeys)
 			require.NoError(t, err)
 			for _, pass := range tt.wantPass {
-				require.True(t, got(attribute.KeyValue{Key: attribute.Key(pass), Value: attribute.StringValue("")}))
+				require.True(t, got(attribute.KeyValue{Key: attribute.Key(pass), Value: attribute.StringValue("")}),
+					"expected %q to pass", pass)
 			}
 			for _, fail := range tt.wantFail {
-				require.False(t, got(attribute.KeyValue{Key: attribute.Key(fail), Value: attribute.StringValue("")}))
+				require.False(t, got(attribute.KeyValue{Key: attribute.Key(fail), Value: attribute.StringValue("")}),
+					"expected %q to fail", fail)
 			}
 		})
 	}
 }
 
-func TestNewIncludeExcludeFilterError(t *testing.T) {
-	_, err := newIncludeExcludeFilter(ptr(IncludeExclude{
-		Included: []string{"foo"},
-		Excluded: []string{"foo"},
-	}))
-	require.Equal(t, fmt.Errorf("attribute cannot be in both include and exclude list: foo"), err)
+func BenchmarkIncludeExcludeFilter(b *testing.B) {
+	benchmarks := []struct {
+		name          string
+		attributeKeys *IncludeExclude
+		key           string
+		want          bool
+	}{
+		{
+			name:          "exact-match",
+			attributeKeys: ptr(IncludeExclude{Included: []string{"service.name", "service.version"}}),
+			key:           "service.name",
+			want:          true,
+		},
+		{
+			name:          "exact-no-match",
+			attributeKeys: ptr(IncludeExclude{Included: []string{"service.name", "service.version"}}),
+			key:           "host.name",
+			want:          false,
+		},
+		{
+			name:          "wildcard-match",
+			attributeKeys: ptr(IncludeExclude{Included: []string{"service.*", "process.?ommand_args"}}),
+			key:           "service.name",
+			want:          true,
+		},
+		{
+			name:          "wildcard-no-match",
+			attributeKeys: ptr(IncludeExclude{Included: []string{"service.*", "process.?ommand_args"}}),
+			key:           "host.name",
+			want:          false,
+		},
+		{
+			name: "wildcard-excluded",
+			attributeKeys: ptr(IncludeExclude{
+				Included: []string{"service.*"},
+				Excluded: []string{"service.secret*"},
+			}),
+			key:  "service.secret.token",
+			want: false,
+		},
+	}
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			filter, err := newIncludeExcludeFilter(bm.attributeKeys)
+			require.NoError(b, err)
+			keyValue := attribute.String(bm.key, "")
+			var got bool
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				got = filter(keyValue)
+			}
+			if got != bm.want {
+				b.Fatalf("filter result = %v, want %v", got, bm.want)
+			}
+		})
+	}
 }
 
 func Test_otlpGRPCMetricExporter(t *testing.T) {

--- a/otelconf/v0.2.0/metric.go
+++ b/otelconf/v0.2.0/metric.go
@@ -31,6 +31,8 @@ import (
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/resource"
+
+	"go.opentelemetry.io/contrib/otelconf/internal/wildcard"
 )
 
 var zeroScope instrumentation.Scope
@@ -262,39 +264,23 @@ func lowMemory(ik sdkmetric.InstrumentKind) metricdata.Temporality {
 	}
 }
 
-// newIncludeExcludeFilter returns a Filter that includes attributes
-// in the include list and excludes attributes in the excludes list.
-// It returns an error if an attribute is in both lists
+// newIncludeExcludeFilter returns a Filter that includes attributes matching
+// the include patterns and excludes attributes matching the exclude patterns.
+// Exclude patterns take precedence over include patterns.
 //
-// If IncludeExclude is empty an include-all filter is returned.
+// If IncludeExclude is empty, an include-all filter is returned.
+//
+//nolint:unparam // Keep the error result consistent across versioned config builders.
 func newIncludeExcludeFilter(lists *IncludeExclude) (attribute.Filter, error) {
-	if lists == nil {
-		return func(attribute.KeyValue) bool { return true }, nil
+	var included, excluded []string
+	if lists != nil {
+		included = lists.Included
+		excluded = lists.Excluded
 	}
 
-	included := make(map[attribute.Key]struct{})
-	for _, k := range lists.Included {
-		included[attribute.Key(k)] = struct{}{}
-	}
-	excluded := make(map[attribute.Key]struct{})
-	for _, k := range lists.Excluded {
-		if _, ok := included[attribute.Key(k)]; ok {
-			return nil, fmt.Errorf("attribute cannot be in both include and exclude list: %s", k)
-		}
-		excluded[attribute.Key(k)] = struct{}{}
-	}
+	matcher := wildcard.NewMatcher(included, excluded)
 	return func(kv attribute.KeyValue) bool {
-		// check if a value is excluded first
-		if _, ok := excluded[kv.Key]; ok {
-			return false
-		}
-
-		if len(included) == 0 {
-			return true
-		}
-
-		_, ok := included[kv.Key]
-		return ok
+		return matcher.Match(string(kv.Key))
 	}, nil
 }
 

--- a/otelconf/v0.2.0/metric_test.go
+++ b/otelconf/v0.2.0/metric_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -1151,27 +1150,54 @@ func TestNewIncludeExcludeFilter(t *testing.T) {
 			wantPass: []string{"bar"},
 			wantFail: []string{"foo"},
 		},
+		{
+			name: "filter-with-wildcard-include",
+			attributeKeys: ptr(IncludeExclude{
+				Included: []string{"service.*", "process.?ommand_args"},
+			}),
+			wantPass: []string{"service.", "service.name", "process.command_args"},
+			wantFail: []string{"Service.name", "process.ommand_args", "process.xxommand_args", "host.name"},
+		},
+		{
+			name: "filter-with-wildcard-exclude",
+			attributeKeys: ptr(IncludeExclude{
+				Excluded: []string{"secret.*", "process.?ommand_args"},
+			}),
+			wantPass: []string{"service.name"},
+			wantFail: []string{"secret.", "secret.token", "process.command_args"},
+		},
+		{
+			name: "filter-with-exclusion-precedence",
+			attributeKeys: ptr(IncludeExclude{
+				Included: []string{"service.*"},
+				Excluded: []string{"service.name", "service.secret*"},
+			}),
+			wantPass: []string{"service.version"},
+			wantFail: []string{"service.name", "service.secret.token", "host.name"},
+		},
+		{
+			name: "filter-with-identical-include-and-exclude",
+			attributeKeys: ptr(IncludeExclude{
+				Included: []string{"service.name"},
+				Excluded: []string{"service.name"},
+			}),
+			wantFail: []string{"service.name"},
+		},
 	}
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := newIncludeExcludeFilter(tt.attributeKeys)
 			require.NoError(t, err)
 			for _, pass := range tt.wantPass {
-				require.True(t, got(attribute.KeyValue{Key: attribute.Key(pass), Value: attribute.StringValue("")}))
+				require.True(t, got(attribute.KeyValue{Key: attribute.Key(pass), Value: attribute.StringValue("")}),
+					"expected %q to pass", pass)
 			}
 			for _, fail := range tt.wantFail {
-				require.False(t, got(attribute.KeyValue{Key: attribute.Key(fail), Value: attribute.StringValue("")}))
+				require.False(t, got(attribute.KeyValue{Key: attribute.Key(fail), Value: attribute.StringValue("")}),
+					"expected %q to fail", fail)
 			}
 		})
 	}
-}
-
-func TestNewIncludeExcludeFilterError(t *testing.T) {
-	_, err := newIncludeExcludeFilter(ptr(IncludeExclude{
-		Included: []string{"foo"},
-		Excluded: []string{"foo"},
-	}))
-	require.Equal(t, fmt.Errorf("attribute cannot be in both include and exclude list: foo"), err)
 }
 
 func TestPrometheusIPv6(t *testing.T) {
@@ -1250,18 +1276,6 @@ func TestPrometheusReaderErrorCases(t *testing.T) {
 				WithResourceConstantLabels: &IncludeExclude{},
 			},
 			errMsg: "binding address",
-		},
-		{
-			name: "invalid with_resource_constant_labels",
-			config: &Prometheus{
-				Host: ptr("localhost"),
-				Port: ptr(0),
-				WithResourceConstantLabels: &IncludeExclude{
-					Included: []string{"foo"},
-					Excluded: []string{"foo"},
-				},
-			},
-			errMsg: "attribute cannot be in both include and exclude list",
 		},
 	}
 

--- a/otelconf/v0.3.0/metric.go
+++ b/otelconf/v0.3.0/metric.go
@@ -34,6 +34,7 @@ import (
 	"google.golang.org/grpc/credentials"
 
 	"go.opentelemetry.io/contrib/otelconf/internal/tls"
+	"go.opentelemetry.io/contrib/otelconf/internal/wildcard"
 )
 
 var zeroScope instrumentation.Scope
@@ -285,39 +286,23 @@ func lowMemory(ik sdkmetric.InstrumentKind) metricdata.Temporality {
 	}
 }
 
-// newIncludeExcludeFilter returns a Filter that includes attributes
-// in the include list and excludes attributes in the excludes list.
-// It returns an error if an attribute is in both lists
+// newIncludeExcludeFilter returns a Filter that includes attributes matching
+// the include patterns and excludes attributes matching the exclude patterns.
+// Exclude patterns take precedence over include patterns.
 //
-// If IncludeExclude is empty a include-all filter is returned.
+// If IncludeExclude is empty, an include-all filter is returned.
+//
+//nolint:unparam // Keep the error result consistent across versioned config builders.
 func newIncludeExcludeFilter(lists *IncludeExclude) (attribute.Filter, error) {
-	if lists == nil {
-		return func(attribute.KeyValue) bool { return true }, nil
+	var included, excluded []string
+	if lists != nil {
+		included = lists.Included
+		excluded = lists.Excluded
 	}
 
-	included := make(map[attribute.Key]struct{})
-	for _, k := range lists.Included {
-		included[attribute.Key(k)] = struct{}{}
-	}
-	excluded := make(map[attribute.Key]struct{})
-	for _, k := range lists.Excluded {
-		if _, ok := included[attribute.Key(k)]; ok {
-			return nil, fmt.Errorf("attribute cannot be in both include and exclude list: %s", k)
-		}
-		excluded[attribute.Key(k)] = struct{}{}
-	}
+	matcher := wildcard.NewMatcher(included, excluded)
 	return func(kv attribute.KeyValue) bool {
-		// check if a value is excluded first
-		if _, ok := excluded[kv.Key]; ok {
-			return false
-		}
-
-		if len(included) == 0 {
-			return true
-		}
-
-		_, ok := included[kv.Key]
-		return ok
+		return matcher.Match(string(kv.Key))
 	}, nil
 }
 

--- a/otelconf/v0.3.0/metric_test.go
+++ b/otelconf/v0.3.0/metric_test.go
@@ -9,7 +9,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -1343,27 +1342,54 @@ func TestNewIncludeExcludeFilter(t *testing.T) {
 			wantPass: []string{"bar"},
 			wantFail: []string{"foo"},
 		},
+		{
+			name: "filter-with-wildcard-include",
+			attributeKeys: ptr(IncludeExclude{
+				Included: []string{"service.*", "process.?ommand_args"},
+			}),
+			wantPass: []string{"service.", "service.name", "process.command_args"},
+			wantFail: []string{"Service.name", "process.ommand_args", "process.xxommand_args", "host.name"},
+		},
+		{
+			name: "filter-with-wildcard-exclude",
+			attributeKeys: ptr(IncludeExclude{
+				Excluded: []string{"secret.*", "process.?ommand_args"},
+			}),
+			wantPass: []string{"service.name"},
+			wantFail: []string{"secret.", "secret.token", "process.command_args"},
+		},
+		{
+			name: "filter-with-exclusion-precedence",
+			attributeKeys: ptr(IncludeExclude{
+				Included: []string{"service.*"},
+				Excluded: []string{"service.name", "service.secret*"},
+			}),
+			wantPass: []string{"service.version"},
+			wantFail: []string{"service.name", "service.secret.token", "host.name"},
+		},
+		{
+			name: "filter-with-identical-include-and-exclude",
+			attributeKeys: ptr(IncludeExclude{
+				Included: []string{"service.name"},
+				Excluded: []string{"service.name"},
+			}),
+			wantFail: []string{"service.name"},
+		},
 	}
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := newIncludeExcludeFilter(tt.attributeKeys)
 			require.NoError(t, err)
 			for _, pass := range tt.wantPass {
-				require.True(t, got(attribute.KeyValue{Key: attribute.Key(pass), Value: attribute.StringValue("")}))
+				require.True(t, got(attribute.KeyValue{Key: attribute.Key(pass), Value: attribute.StringValue("")}),
+					"expected %q to pass", pass)
 			}
 			for _, fail := range tt.wantFail {
-				require.False(t, got(attribute.KeyValue{Key: attribute.Key(fail), Value: attribute.StringValue("")}))
+				require.False(t, got(attribute.KeyValue{Key: attribute.Key(fail), Value: attribute.StringValue("")}),
+					"expected %q to fail", fail)
 			}
 		})
 	}
-}
-
-func TestNewIncludeExcludeFilterError(t *testing.T) {
-	_, err := newIncludeExcludeFilter(ptr(IncludeExclude{
-		Included: []string{"foo"},
-		Excluded: []string{"foo"},
-	}))
-	require.Equal(t, fmt.Errorf("attribute cannot be in both include and exclude list: foo"), err)
 }
 
 func TestPrometheusReaderOpts(t *testing.T) {

--- a/otelconf/x/metric.go
+++ b/otelconf/x/metric.go
@@ -34,6 +34,7 @@ import (
 	"google.golang.org/grpc/credentials"
 
 	"go.opentelemetry.io/contrib/otelconf/internal/tls"
+	"go.opentelemetry.io/contrib/otelconf/internal/wildcard"
 )
 
 var zeroScope instrumentation.Scope
@@ -356,39 +357,23 @@ func lowMemory(ik sdkmetric.InstrumentKind) metricdata.Temporality {
 	}
 }
 
-// newIncludeExcludeFilter returns a Filter that includes attributes
-// in the include list and excludes attributes in the excludes list.
-// It returns an error if an attribute is in both lists
+// newIncludeExcludeFilter returns a Filter that includes attributes matching
+// the include patterns and excludes attributes matching the exclude patterns.
+// Exclude patterns take precedence over include patterns.
 //
-// If IncludeExclude is empty an include-all filter is returned.
+// If IncludeExclude is empty, an include-all filter is returned.
+//
+//nolint:unparam // Keep the error result consistent across versioned config builders.
 func newIncludeExcludeFilter(lists *IncludeExclude) (attribute.Filter, error) {
-	if lists == nil {
-		return func(attribute.KeyValue) bool { return true }, nil
+	var included, excluded []string
+	if lists != nil {
+		included = lists.Included
+		excluded = lists.Excluded
 	}
 
-	included := make(map[attribute.Key]struct{})
-	for _, k := range lists.Included {
-		included[attribute.Key(k)] = struct{}{}
-	}
-	excluded := make(map[attribute.Key]struct{})
-	for _, k := range lists.Excluded {
-		if _, ok := included[attribute.Key(k)]; ok {
-			return nil, fmt.Errorf("attribute cannot be in both include and exclude list: %s", k)
-		}
-		excluded[attribute.Key(k)] = struct{}{}
-	}
+	matcher := wildcard.NewMatcher(included, excluded)
 	return func(kv attribute.KeyValue) bool {
-		// check if a value is excluded first
-		if _, ok := excluded[kv.Key]; ok {
-			return false
-		}
-
-		if len(included) == 0 {
-			return true
-		}
-
-		_, ok := included[kv.Key]
-		return ok
+		return matcher.Match(string(kv.Key))
 	}, nil
 }
 

--- a/otelconf/x/metric_test.go
+++ b/otelconf/x/metric_test.go
@@ -9,7 +9,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -1527,27 +1526,54 @@ func TestNewIncludeExcludeFilter(t *testing.T) {
 			wantPass: []string{"bar"},
 			wantFail: []string{"foo"},
 		},
+		{
+			name: "filter-with-wildcard-include",
+			attributeKeys: ptr(IncludeExclude{
+				Included: []string{"service.*", "process.?ommand_args"},
+			}),
+			wantPass: []string{"service.", "service.name", "process.command_args"},
+			wantFail: []string{"Service.name", "process.ommand_args", "process.xxommand_args", "host.name"},
+		},
+		{
+			name: "filter-with-wildcard-exclude",
+			attributeKeys: ptr(IncludeExclude{
+				Excluded: []string{"secret.*", "process.?ommand_args"},
+			}),
+			wantPass: []string{"service.name"},
+			wantFail: []string{"secret.", "secret.token", "process.command_args"},
+		},
+		{
+			name: "filter-with-exclusion-precedence",
+			attributeKeys: ptr(IncludeExclude{
+				Included: []string{"service.*"},
+				Excluded: []string{"service.name", "service.secret*"},
+			}),
+			wantPass: []string{"service.version"},
+			wantFail: []string{"service.name", "service.secret.token", "host.name"},
+		},
+		{
+			name: "filter-with-identical-include-and-exclude",
+			attributeKeys: ptr(IncludeExclude{
+				Included: []string{"service.name"},
+				Excluded: []string{"service.name"},
+			}),
+			wantFail: []string{"service.name"},
+		},
 	}
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := newIncludeExcludeFilter(tt.attributeKeys)
 			require.NoError(t, err)
 			for _, pass := range tt.wantPass {
-				require.True(t, got(attribute.KeyValue{Key: attribute.Key(pass), Value: attribute.StringValue("")}))
+				require.True(t, got(attribute.KeyValue{Key: attribute.Key(pass), Value: attribute.StringValue("")}),
+					"expected %q to pass", pass)
 			}
 			for _, fail := range tt.wantFail {
-				require.False(t, got(attribute.KeyValue{Key: attribute.Key(fail), Value: attribute.StringValue("")}))
+				require.False(t, got(attribute.KeyValue{Key: attribute.Key(fail), Value: attribute.StringValue("")}),
+					"expected %q to fail", fail)
 			}
 		})
 	}
-}
-
-func TestNewIncludeExcludeFilterError(t *testing.T) {
-	_, err := newIncludeExcludeFilter(ptr(IncludeExclude{
-		Included: []string{"foo"},
-		Excluded: []string{"foo"},
-	}))
-	require.Equal(t, fmt.Errorf("attribute cannot be in both include and exclude list: foo"), err)
 }
 
 func TestPrometheusReaderOpts(t *testing.T) {

--- a/otelconf/x/resource_test.go
+++ b/otelconf/x/resource_test.go
@@ -5,7 +5,6 @@ package x
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -296,20 +295,21 @@ func TestNewResourceWithDetectionDoesNotOverrideConfiguredAttributes(t *testing.
 	assert.Contains(t, gotAttrs, semconv.ServiceInstanceIDKey)
 }
 
-func TestNewResourceWithDetectionAttributesFilterError(t *testing.T) {
+func TestNewResourceWithDetectionAttributesFilterExclusionPrecedence(t *testing.T) {
 	got, err := newResource(t.Context(), &Resource{
 		DetectionDevelopment: &ExperimentalResourceDetection{
 			Detectors: []ExperimentalResourceDetector{
 				{Host: ExperimentalHostResourceDetector{}},
 			},
 			Attributes: &IncludeExclude{
-				Included: []string{"foo"},
-				Excluded: []string{"foo"},
+				Included: []string{"host.*"},
+				Excluded: []string{"host.name"},
 			},
 		},
 	})
-	require.Equal(t, fmt.Errorf("attribute cannot be in both include and exclude list: foo"), err)
+	require.NoError(t, err)
 	assert.True(t, got.Set().HasValue(semconv.ServiceNameKey))
+	assert.NotContains(t, attrMap(got.Attributes()), semconv.HostNameKey)
 }
 
 func attrMap(attrs []attribute.KeyValue) map[attribute.Key]attribute.Value {


### PR DESCRIPTION
## Summary

- support case-sensitive `*` and `?` patterns in `IncludeExclude` filters
- apply exclusions after inclusions across stable, `x`, `v0.2.0`, and `v0.3.0`
- preserve the zero-allocation literal fast path and add regression coverage

## Details

`newIncludeExcludeFilter` stored configuration entries as literal attribute keys, so wildcard patterns never matched. It also rejected identical entries in the include and exclude lists even though the configuration contract gives exclusions precedence.

This change adds a shared internal matcher that separates literal and wildcard patterns. `*` matches zero or more characters, `?` matches exactly one character, matching is case-sensitive, and exclusions always win.

Fixes #9300.

## Testing

- `make precommit`
- `go test -race ./...` from `otelconf`
- `go test -run '^$' -bench '^BenchmarkIncludeExcludeFilter' -benchmem -count=10 .`

## Benchmarks

All cases report `0 B/op` and `0 allocs/op`.

| Case | Before | After | Delta |
| --- | ---: | ---: | ---: |
| Exact match | 5.667 ns/op | 5.732 ns/op | +1.16% |
| Exact no match | 7.203 ns/op | 6.971 ns/op | -3.21% |
| Wildcard match | — | 27.40 ns/op | — |
| Wildcard no match | — | 12.00 ns/op | — |
| Wildcard excluded | — | 75.00 ns/op | — |
