### PR TITLE
bridges/logutil: fix recursive log conversion crash by adding cycle detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Fix recursive log value conversion crash on cyclic data by adding path-local cycle detection in `go.opentelemetry.io/contrib/bridges/otellogr`, `go.opentelemetry.io/contrib/bridges/otellogrus`, `go.opentelemetry.io/contrib/bridges/otelslog`, and `go.opentelemetry.io/contrib/bridges/otelzap`.
 - Fix Prometheus reader resource label filter configuration in `go.opentelemetry.io/contrib/otelconf/v0.2.0`. (#9045)
 - Apply `resource.detection/development.attributes.included` and `excluded` filtering to resource detector attributes in `go.opentelemetry.io/contrib/otelconf/x`. (#9131)
 - Honor the context configured with `WithContext` when constructing resources in `go.opentelemetry.io/contrib/otelconf` and `go.opentelemetry.io/contrib/otelconf/x`. (#9160)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- Fix recursive log value conversion crash on cyclic data by adding path-local cycle detection in `go.opentelemetry.io/contrib/bridges/otellogr`, `go.opentelemetry.io/contrib/bridges/otellogrus`, `go.opentelemetry.io/contrib/bridges/otelslog`, and `go.opentelemetry.io/contrib/bridges/otelzap`.
+- Fix recursive log value conversion crash on cyclic data by adding path-local cycle detection in `go.opentelemetry.io/contrib/bridges/otellogr`, `go.opentelemetry.io/contrib/bridges/otellogrus`, `go.opentelemetry.io/contrib/bridges/otelslog`, and `go.opentelemetry.io/contrib/bridges/otelzap`.(#9398)
 - Fix Prometheus reader resource label filter configuration in `go.opentelemetry.io/contrib/otelconf/v0.2.0`. (#9045)
 - Apply `resource.detection/development.attributes.included` and `excluded` filtering to resource detector attributes in `go.opentelemetry.io/contrib/otelconf/x`. (#9131)
 - Honor the context configured with `WithContext` when constructing resources in `go.opentelemetry.io/contrib/otelconf` and `go.opentelemetry.io/contrib/otelconf/x`. (#9160)

--- a/bridges/otellogr/convert.go
+++ b/bridges/otellogr/convert.go
@@ -11,67 +11,34 @@ import (
 	"math"
 	"reflect"
 	"strconv"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 )
 
-// convertValue converts various types to attribute.Value.
-func convertValue(v any) attribute.Value {
-	return convertValueVisited(v, nil)
+var visitedMapPool = sync.Pool{
+	New: func() any {
+		return make(map[uintptr]bool)
+	},
 }
 
-func convertValueVisited(v any, visited []uintptr) attribute.Value {
-	// Handling the most common types without reflect is a small perf win.
-	switch val := v.(type) {
-	case bool:
-		return attribute.BoolValue(val)
-	case string:
-		return attribute.StringValue(val)
-	case int:
-		return attribute.Int64Value(int64(val))
-	case int8:
-		return attribute.Int64Value(int64(val))
-	case int16:
-		return attribute.Int64Value(int64(val))
-	case int32:
-		return attribute.Int64Value(int64(val))
-	case int64:
-		return attribute.Int64Value(val)
-	case uint:
-		return convertUintValue(uint64(val))
-	case uint8:
-		return attribute.Int64Value(int64(val))
-	case uint16:
-		return attribute.Int64Value(int64(val))
-	case uint32:
-		return attribute.Int64Value(int64(val))
-	case uint64:
-		return convertUintValue(val)
-	case uintptr:
-		return convertUintValue(uint64(val))
-	case float32:
-		return attribute.Float64Value(float64(val))
-	case float64:
-		return attribute.Float64Value(val)
-	case time.Duration:
-		return attribute.Int64Value(val.Nanoseconds())
-	case complex64:
-		r := attribute.Float64("r", real(complex128(val)))
-		i := attribute.Float64("i", imag(complex128(val)))
-		return attribute.MapValue(r, i)
-	case complex128:
-		r := attribute.Float64("r", real(val))
-		i := attribute.Float64("i", imag(val))
-		return attribute.MapValue(r, i)
-	case time.Time:
-		return attribute.Int64Value(val.UnixNano())
-	case []byte:
-		return attribute.ByteSliceValue(val)
-	case error:
-		return attribute.StringValue(val.Error())
-	case attribute.Value:
-		return val
+// convertValue converts various types to attribute.Value.
+func convertValue(v any) attribute.Value {
+	if res, ok := fastConvertValue(v); ok {
+		return res
+	}
+
+	visited := visitedMapPool.Get().(map[uintptr]bool)
+	res := convertValueVisited(v, visited)
+	clear(visited)
+	visitedMapPool.Put(visited)
+	return res
+}
+
+func convertValueVisited(v any, visited map[uintptr]bool) attribute.Value {
+	if res, ok := fastConvertValue(v); ok {
+		return res
 	}
 
 	t := reflect.TypeOf(v)
@@ -83,21 +50,17 @@ func convertValueVisited(v any, visited []uintptr) attribute.Value {
 	case reflect.Struct:
 		return attribute.StringValue(fmt.Sprintf("%+v", v))
 	case reflect.Slice, reflect.Array:
-		if val.Len() == 0 {
-			return attribute.SliceValue()
-		}
 		if t.Kind() == reflect.Slice {
 			if val.IsNil() {
 				return attribute.Value{}
 			}
 			ptr := val.Pointer()
 			if ptr != 0 {
-				for _, p := range visited {
-					if p == ptr {
-						return attribute.StringValue("<cycle>")
-					}
+				if visited[ptr] {
+					return attribute.StringValue("<cycle>")
 				}
-				visited = append(visited, ptr)
+				visited[ptr] = true
+				defer delete(visited, ptr)
 			}
 		}
 		items := make([]attribute.Value, 0, val.Len())
@@ -109,17 +72,13 @@ func convertValueVisited(v any, visited []uintptr) attribute.Value {
 		if val.IsNil() {
 			return attribute.Value{}
 		}
-		if val.Len() == 0 {
-			return attribute.MapValue()
-		}
 		ptr := val.Pointer()
 		if ptr != 0 {
-			for _, p := range visited {
-				if p == ptr {
-					return attribute.StringValue("<cycle>")
-				}
+			if visited[ptr] {
+				return attribute.StringValue("<cycle>")
 			}
-			visited = append(visited, ptr)
+			visited[ptr] = true
+			defer delete(visited, ptr)
 		}
 		kvs := make([]attribute.KeyValue, 0, val.Len())
 		for _, k := range val.MapKeys() {
@@ -142,12 +101,11 @@ func convertValueVisited(v any, visited []uintptr) attribute.Value {
 		}
 		ptr := val.Pointer()
 		if ptr != 0 {
-			for _, p := range visited {
-				if p == ptr {
-					return attribute.StringValue("<cycle>")
-				}
+			if visited[ptr] {
+				return attribute.StringValue("<cycle>")
 			}
-			visited = append(visited, ptr)
+			visited[ptr] = true
+			defer delete(visited, ptr)
 		}
 		return convertValueVisited(val.Elem().Interface(), visited)
 	case reflect.Interface:
@@ -163,6 +121,61 @@ func convertValueVisited(v any, visited []uintptr) attribute.Value {
 	// asking why their attributes have a "unhandled: " prefix than
 	// say that their code is panicking.
 	return attribute.StringValue(fmt.Sprintf("unhandled: (%s) %+v", t, v))
+}
+
+// fastConvertValue handles common primitive types without reflection or pool overhead.
+func fastConvertValue(v any) (attribute.Value, bool) {
+	switch val := v.(type) {
+	case bool:
+		return attribute.BoolValue(val), true
+	case string:
+		return attribute.StringValue(val), true
+	case int:
+		return attribute.Int64Value(int64(val)), true
+	case int8:
+		return attribute.Int64Value(int64(val)), true
+	case int16:
+		return attribute.Int64Value(int64(val)), true
+	case int32:
+		return attribute.Int64Value(int64(val)), true
+	case int64:
+		return attribute.Int64Value(val), true
+	case uint:
+		return convertUintValue(uint64(val)), true
+	case uint8:
+		return attribute.Int64Value(int64(val)), true
+	case uint16:
+		return attribute.Int64Value(int64(val)), true
+	case uint32:
+		return attribute.Int64Value(int64(val)), true
+	case uint64:
+		return convertUintValue(val), true
+	case uintptr:
+		return convertUintValue(uint64(val)), true
+	case float32:
+		return attribute.Float64Value(float64(val)), true
+	case float64:
+		return attribute.Float64Value(val), true
+	case time.Duration:
+		return attribute.Int64Value(val.Nanoseconds()), true
+	case complex64:
+		r := attribute.Float64("r", real(complex128(val)))
+		i := attribute.Float64("i", imag(complex128(val)))
+		return attribute.MapValue(r, i), true
+	case complex128:
+		r := attribute.Float64("r", real(val))
+		i := attribute.Float64("i", imag(val))
+		return attribute.MapValue(r, i), true
+	case time.Time:
+		return attribute.Int64Value(val.UnixNano()), true
+	case []byte:
+		return attribute.ByteSliceValue(val), true
+	case error:
+		return attribute.StringValue(val.Error()), true
+	case attribute.Value:
+		return val, true
+	}
+	return attribute.Value{}, false
 }
 
 // convertUintValue converts a uint64 to an attribute.Value.

--- a/bridges/otellogr/convert.go
+++ b/bridges/otellogr/convert.go
@@ -50,10 +50,10 @@ func convertValueVisited(v any, visited map[uintptr]bool) attribute.Value {
 	case reflect.Struct:
 		return attribute.StringValue(fmt.Sprintf("%+v", v))
 	case reflect.Slice, reflect.Array:
+		if val.Len() == 0 {
+			return attribute.SliceValue()
+		}
 		if t.Kind() == reflect.Slice {
-			if val.IsNil() {
-				return attribute.Value{}
-			}
 			ptr := val.Pointer()
 			if ptr != 0 {
 				if visited[ptr] {
@@ -69,8 +69,8 @@ func convertValueVisited(v any, visited map[uintptr]bool) attribute.Value {
 		}
 		return attribute.SliceValue(items...)
 	case reflect.Map:
-		if val.IsNil() {
-			return attribute.Value{}
+		if val.Len() == 0 {
+			return attribute.MapValue()
 		}
 		ptr := val.Pointer()
 		if ptr != 0 {

--- a/bridges/otellogr/convert.go
+++ b/bridges/otellogr/convert.go
@@ -18,6 +18,10 @@ import (
 
 // convertValue converts various types to attribute.Value.
 func convertValue(v any) attribute.Value {
+	return convertValueVisited(v, nil)
+}
+
+func convertValueVisited(v any, visited []uintptr) attribute.Value {
 	// Handling the most common types without reflect is a small perf win.
 	switch val := v.(type) {
 	case bool:
@@ -79,12 +83,44 @@ func convertValue(v any) attribute.Value {
 	case reflect.Struct:
 		return attribute.StringValue(fmt.Sprintf("%+v", v))
 	case reflect.Slice, reflect.Array:
+		if val.Len() == 0 {
+			return attribute.SliceValue()
+		}
+		if t.Kind() == reflect.Slice {
+			if val.IsNil() {
+				return attribute.Value{}
+			}
+			ptr := val.Pointer()
+			if ptr != 0 {
+				for _, p := range visited {
+					if p == ptr {
+						return attribute.StringValue("<cycle>")
+					}
+				}
+				visited = append(visited, ptr)
+			}
+		}
 		items := make([]attribute.Value, 0, val.Len())
 		for i := range val.Len() {
-			items = append(items, convertValue(val.Index(i).Interface()))
+			items = append(items, convertValueVisited(val.Index(i).Interface(), visited))
 		}
 		return attribute.SliceValue(items...)
 	case reflect.Map:
+		if val.IsNil() {
+			return attribute.Value{}
+		}
+		if val.Len() == 0 {
+			return attribute.MapValue()
+		}
+		ptr := val.Pointer()
+		if ptr != 0 {
+			for _, p := range visited {
+				if p == ptr {
+					return attribute.StringValue("<cycle>")
+				}
+			}
+			visited = append(visited, ptr)
+		}
 		kvs := make([]attribute.KeyValue, 0, val.Len())
 		for _, k := range val.MapKeys() {
 			var key string
@@ -96,15 +132,29 @@ func convertValue(v any) attribute.Value {
 			}
 			kvs = append(kvs, attribute.KeyValue{
 				Key:   attribute.Key(key),
-				Value: convertValue(val.MapIndex(k).Interface()),
+				Value: convertValueVisited(val.MapIndex(k).Interface(), visited),
 			})
 		}
 		return attribute.MapValue(kvs...)
-	case reflect.Pointer, reflect.Interface:
+	case reflect.Pointer:
 		if val.IsNil() {
 			return attribute.Value{}
 		}
-		return convertValue(val.Elem().Interface())
+		ptr := val.Pointer()
+		if ptr != 0 {
+			for _, p := range visited {
+				if p == ptr {
+					return attribute.StringValue("<cycle>")
+				}
+			}
+			visited = append(visited, ptr)
+		}
+		return convertValueVisited(val.Elem().Interface(), visited)
+	case reflect.Interface:
+		if val.IsNil() {
+			return attribute.Value{}
+		}
+		return convertValueVisited(val.Elem().Interface(), visited)
 	}
 
 	// Try to handle this as gracefully as possible.

--- a/bridges/otellogr/convert.go
+++ b/bridges/otellogr/convert.go
@@ -17,9 +17,15 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
+type visitKey struct {
+	typ reflect.Type
+	ptr uintptr
+	len int
+}
+
 var visitedMapPool = sync.Pool{
 	New: func() any {
-		return make(map[uintptr]bool)
+		return make(map[visitKey]bool)
 	},
 }
 
@@ -29,14 +35,14 @@ func convertValue(v any) attribute.Value {
 		return res
 	}
 
-	visited := visitedMapPool.Get().(map[uintptr]bool)
+	visited := visitedMapPool.Get().(map[visitKey]bool)
 	res := convertValueVisited(v, visited)
 	clear(visited)
 	visitedMapPool.Put(visited)
 	return res
 }
 
-func convertValueVisited(v any, visited map[uintptr]bool) attribute.Value {
+func convertValueVisited(v any, visited map[visitKey]bool) attribute.Value {
 	if res, ok := fastConvertValue(v); ok {
 		return res
 	}
@@ -56,11 +62,12 @@ func convertValueVisited(v any, visited map[uintptr]bool) attribute.Value {
 		if t.Kind() == reflect.Slice {
 			ptr := val.Pointer()
 			if ptr != 0 {
-				if visited[ptr] {
+				key := visitKey{typ: t, ptr: ptr, len: val.Len()}
+				if visited[key] {
 					return attribute.StringValue("<cycle>")
 				}
-				visited[ptr] = true
-				defer delete(visited, ptr)
+				visited[key] = true
+				defer delete(visited, key)
 			}
 		}
 		items := make([]attribute.Value, 0, val.Len())
@@ -74,11 +81,12 @@ func convertValueVisited(v any, visited map[uintptr]bool) attribute.Value {
 		}
 		ptr := val.Pointer()
 		if ptr != 0 {
-			if visited[ptr] {
+			key := visitKey{typ: t, ptr: ptr}
+			if visited[key] {
 				return attribute.StringValue("<cycle>")
 			}
-			visited[ptr] = true
-			defer delete(visited, ptr)
+			visited[key] = true
+			defer delete(visited, key)
 		}
 		kvs := make([]attribute.KeyValue, 0, val.Len())
 		for _, k := range val.MapKeys() {
@@ -101,11 +109,12 @@ func convertValueVisited(v any, visited map[uintptr]bool) attribute.Value {
 		}
 		ptr := val.Pointer()
 		if ptr != 0 {
-			if visited[ptr] {
+			key := visitKey{typ: t, ptr: ptr}
+			if visited[key] {
 				return attribute.StringValue("<cycle>")
 			}
-			visited[ptr] = true
-			defer delete(visited, ptr)
+			visited[key] = true
+			defer delete(visited, key)
 		}
 		return convertValueVisited(val.Elem().Interface(), visited)
 	case reflect.Interface:

--- a/bridges/otellogr/convert_test.go
+++ b/bridges/otellogr/convert_test.go
@@ -165,6 +165,25 @@ func TestConvertValue(t *testing.T) {
 			wantValue: attribute.BoolValue(true),
 		},
 		{
+			name:      "nil_slice",
+			value:     ([]int)(nil),
+			wantValue: attribute.SliceValue(),
+		},
+		{
+			name:      "nil_map",
+			value:     (map[string]int)(nil),
+			wantValue: attribute.MapValue(),
+		},
+		{
+			name: "empty_subslice_sharing_parent_array",
+			value: func() any {
+				parent := []any{1}
+				parent[0] = parent[:0]
+				return parent
+			}(),
+			wantValue: attribute.SliceValue(attribute.SliceValue()),
+		},
+		{
 			name:      "int_empty_array",
 			value:     []int{},
 			wantValue: attribute.SliceValue([]attribute.Value{}...),

--- a/bridges/otellogr/convert_test.go
+++ b/bridges/otellogr/convert_test.go
@@ -337,6 +337,32 @@ func TestConvertValue(t *testing.T) {
 				attribute.Map("right", attribute.Int64("one", 1)),
 			),
 		},
+		{
+			name: "branching_cyclic_map",
+			value: func() any {
+				m := map[string]any{}
+				m["a"] = m
+				m["b"] = m
+				return m
+			}(),
+			wantValue: attribute.MapValue(
+				attribute.String("a", "<cycle>"),
+				attribute.String("b", "<cycle>"),
+			),
+		},
+		{
+			name: "branching_cyclic_slice",
+			value: func() any {
+				s := make([]any, 2)
+				s[0] = s
+				s[1] = s
+				return s
+			}(),
+			wantValue: attribute.SliceValue(
+				attribute.StringValue("<cycle>"),
+				attribute.StringValue("<cycle>"),
+			),
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.wantValue, convertValue(tt.value))

--- a/bridges/otellogr/convert_test.go
+++ b/bridges/otellogr/convert_test.go
@@ -261,6 +261,82 @@ func TestConvertValue(t *testing.T) {
 			value:     chan int(nil),
 			wantValue: attribute.StringValue("unhandled: (chan int) <nil>"),
 		},
+		{
+			name: "cyclic_map",
+			value: func() any {
+				m := map[string]any{}
+				m["self"] = m
+				return m
+			}(),
+			wantValue: attribute.MapValue(
+				attribute.String("self", "<cycle>"),
+			),
+		},
+		{
+			name: "cyclic_slice",
+			value: func() any {
+				s := make([]any, 1)
+				s[0] = s
+				return s
+			}(),
+			wantValue: attribute.SliceValue(
+				attribute.StringValue("<cycle>"),
+			),
+		},
+		{
+			name: "cyclic_pointer",
+			value: func() any {
+				var p1, p2 any
+				p1 = &p2
+				p2 = &p1
+				return p1
+			}(),
+			wantValue: attribute.StringValue("<cycle>"),
+		},
+		{
+			name: "indirect_cyclic_map",
+			value: func() any {
+				m1 := map[string]any{}
+				m2 := map[string]any{}
+				m1["next"] = m2
+				m2["next"] = m1
+				return m1
+			}(),
+			wantValue: attribute.MapValue(
+				attribute.Map("next",
+					attribute.String("next", "<cycle>"),
+				),
+			),
+		},
+		{
+			name: "indirect_cyclic_slice",
+			value: func() any {
+				s1 := make([]any, 1)
+				s2 := make([]any, 1)
+				s1[0] = s2
+				s2[0] = s1
+				return s1
+			}(),
+			wantValue: attribute.SliceValue(
+				attribute.SliceValue(
+					attribute.StringValue("<cycle>"),
+				),
+			),
+		},
+		{
+			name: "non_cyclic_dag",
+			value: func() any {
+				shared := map[string]int{"one": 1}
+				return map[string]any{
+					"left":  shared,
+					"right": shared,
+				}
+			}(),
+			wantValue: attribute.MapValue(
+				attribute.Map("left", attribute.Int64("one", 1)),
+				attribute.Map("right", attribute.Int64("one", 1)),
+			),
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.wantValue, convertValue(tt.value))

--- a/bridges/otellogr/convert_test.go
+++ b/bridges/otellogr/convert_test.go
@@ -184,6 +184,30 @@ func TestConvertValue(t *testing.T) {
 			wantValue: attribute.SliceValue(attribute.SliceValue()),
 		},
 		{
+			name: "overlapping_subslice_non_cyclic",
+			value: func() any {
+				parent := []any{42, nil}
+				parent[1] = parent[:1]
+				return parent
+			}(),
+			wantValue: attribute.SliceValue(
+				attribute.Int64Value(42),
+				attribute.SliceValue(attribute.Int64Value(42)),
+			),
+		},
+		{
+			name: "overlapping_pointer_to_first_element_non_cyclic",
+			value: func() any {
+				parent := &[2]any{42, nil}
+				parent[1] = &parent[0]
+				return parent
+			}(),
+			wantValue: attribute.SliceValue(
+				attribute.Int64Value(42),
+				attribute.Int64Value(42),
+			),
+		},
+		{
 			name:      "int_empty_array",
 			value:     []int{},
 			wantValue: attribute.SliceValue([]attribute.Value{}...),

--- a/bridges/otellogrus/convert.go
+++ b/bridges/otellogrus/convert.go
@@ -11,67 +11,34 @@ import (
 	"math"
 	"reflect"
 	"strconv"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 )
 
-// convertValue converts various types to attribute.Value.
-func convertValue(v any) attribute.Value {
-	return convertValueVisited(v, nil)
+var visitedMapPool = sync.Pool{
+	New: func() any {
+		return make(map[uintptr]bool)
+	},
 }
 
-func convertValueVisited(v any, visited []uintptr) attribute.Value {
-	// Handling the most common types without reflect is a small perf win.
-	switch val := v.(type) {
-	case bool:
-		return attribute.BoolValue(val)
-	case string:
-		return attribute.StringValue(val)
-	case int:
-		return attribute.Int64Value(int64(val))
-	case int8:
-		return attribute.Int64Value(int64(val))
-	case int16:
-		return attribute.Int64Value(int64(val))
-	case int32:
-		return attribute.Int64Value(int64(val))
-	case int64:
-		return attribute.Int64Value(val)
-	case uint:
-		return convertUintValue(uint64(val))
-	case uint8:
-		return attribute.Int64Value(int64(val))
-	case uint16:
-		return attribute.Int64Value(int64(val))
-	case uint32:
-		return attribute.Int64Value(int64(val))
-	case uint64:
-		return convertUintValue(val)
-	case uintptr:
-		return convertUintValue(uint64(val))
-	case float32:
-		return attribute.Float64Value(float64(val))
-	case float64:
-		return attribute.Float64Value(val)
-	case time.Duration:
-		return attribute.Int64Value(val.Nanoseconds())
-	case complex64:
-		r := attribute.Float64("r", real(complex128(val)))
-		i := attribute.Float64("i", imag(complex128(val)))
-		return attribute.MapValue(r, i)
-	case complex128:
-		r := attribute.Float64("r", real(val))
-		i := attribute.Float64("i", imag(val))
-		return attribute.MapValue(r, i)
-	case time.Time:
-		return attribute.Int64Value(val.UnixNano())
-	case []byte:
-		return attribute.ByteSliceValue(val)
-	case error:
-		return attribute.StringValue(val.Error())
-	case attribute.Value:
-		return val
+// convertValue converts various types to attribute.Value.
+func convertValue(v any) attribute.Value {
+	if res, ok := fastConvertValue(v); ok {
+		return res
+	}
+
+	visited := visitedMapPool.Get().(map[uintptr]bool)
+	res := convertValueVisited(v, visited)
+	clear(visited)
+	visitedMapPool.Put(visited)
+	return res
+}
+
+func convertValueVisited(v any, visited map[uintptr]bool) attribute.Value {
+	if res, ok := fastConvertValue(v); ok {
+		return res
 	}
 
 	t := reflect.TypeOf(v)
@@ -83,21 +50,17 @@ func convertValueVisited(v any, visited []uintptr) attribute.Value {
 	case reflect.Struct:
 		return attribute.StringValue(fmt.Sprintf("%+v", v))
 	case reflect.Slice, reflect.Array:
-		if val.Len() == 0 {
-			return attribute.SliceValue()
-		}
 		if t.Kind() == reflect.Slice {
 			if val.IsNil() {
 				return attribute.Value{}
 			}
 			ptr := val.Pointer()
 			if ptr != 0 {
-				for _, p := range visited {
-					if p == ptr {
-						return attribute.StringValue("<cycle>")
-					}
+				if visited[ptr] {
+					return attribute.StringValue("<cycle>")
 				}
-				visited = append(visited, ptr)
+				visited[ptr] = true
+				defer delete(visited, ptr)
 			}
 		}
 		items := make([]attribute.Value, 0, val.Len())
@@ -109,17 +72,13 @@ func convertValueVisited(v any, visited []uintptr) attribute.Value {
 		if val.IsNil() {
 			return attribute.Value{}
 		}
-		if val.Len() == 0 {
-			return attribute.MapValue()
-		}
 		ptr := val.Pointer()
 		if ptr != 0 {
-			for _, p := range visited {
-				if p == ptr {
-					return attribute.StringValue("<cycle>")
-				}
+			if visited[ptr] {
+				return attribute.StringValue("<cycle>")
 			}
-			visited = append(visited, ptr)
+			visited[ptr] = true
+			defer delete(visited, ptr)
 		}
 		kvs := make([]attribute.KeyValue, 0, val.Len())
 		for _, k := range val.MapKeys() {
@@ -142,12 +101,11 @@ func convertValueVisited(v any, visited []uintptr) attribute.Value {
 		}
 		ptr := val.Pointer()
 		if ptr != 0 {
-			for _, p := range visited {
-				if p == ptr {
-					return attribute.StringValue("<cycle>")
-				}
+			if visited[ptr] {
+				return attribute.StringValue("<cycle>")
 			}
-			visited = append(visited, ptr)
+			visited[ptr] = true
+			defer delete(visited, ptr)
 		}
 		return convertValueVisited(val.Elem().Interface(), visited)
 	case reflect.Interface:
@@ -163,6 +121,61 @@ func convertValueVisited(v any, visited []uintptr) attribute.Value {
 	// asking why their attributes have a "unhandled: " prefix than
 	// say that their code is panicking.
 	return attribute.StringValue(fmt.Sprintf("unhandled: (%s) %+v", t, v))
+}
+
+// fastConvertValue handles common primitive types without reflection or pool overhead.
+func fastConvertValue(v any) (attribute.Value, bool) {
+	switch val := v.(type) {
+	case bool:
+		return attribute.BoolValue(val), true
+	case string:
+		return attribute.StringValue(val), true
+	case int:
+		return attribute.Int64Value(int64(val)), true
+	case int8:
+		return attribute.Int64Value(int64(val)), true
+	case int16:
+		return attribute.Int64Value(int64(val)), true
+	case int32:
+		return attribute.Int64Value(int64(val)), true
+	case int64:
+		return attribute.Int64Value(val), true
+	case uint:
+		return convertUintValue(uint64(val)), true
+	case uint8:
+		return attribute.Int64Value(int64(val)), true
+	case uint16:
+		return attribute.Int64Value(int64(val)), true
+	case uint32:
+		return attribute.Int64Value(int64(val)), true
+	case uint64:
+		return convertUintValue(val), true
+	case uintptr:
+		return convertUintValue(uint64(val)), true
+	case float32:
+		return attribute.Float64Value(float64(val)), true
+	case float64:
+		return attribute.Float64Value(val), true
+	case time.Duration:
+		return attribute.Int64Value(val.Nanoseconds()), true
+	case complex64:
+		r := attribute.Float64("r", real(complex128(val)))
+		i := attribute.Float64("i", imag(complex128(val)))
+		return attribute.MapValue(r, i), true
+	case complex128:
+		r := attribute.Float64("r", real(val))
+		i := attribute.Float64("i", imag(val))
+		return attribute.MapValue(r, i), true
+	case time.Time:
+		return attribute.Int64Value(val.UnixNano()), true
+	case []byte:
+		return attribute.ByteSliceValue(val), true
+	case error:
+		return attribute.StringValue(val.Error()), true
+	case attribute.Value:
+		return val, true
+	}
+	return attribute.Value{}, false
 }
 
 // convertUintValue converts a uint64 to an attribute.Value.

--- a/bridges/otellogrus/convert.go
+++ b/bridges/otellogrus/convert.go
@@ -50,10 +50,10 @@ func convertValueVisited(v any, visited map[uintptr]bool) attribute.Value {
 	case reflect.Struct:
 		return attribute.StringValue(fmt.Sprintf("%+v", v))
 	case reflect.Slice, reflect.Array:
+		if val.Len() == 0 {
+			return attribute.SliceValue()
+		}
 		if t.Kind() == reflect.Slice {
-			if val.IsNil() {
-				return attribute.Value{}
-			}
 			ptr := val.Pointer()
 			if ptr != 0 {
 				if visited[ptr] {
@@ -69,8 +69,8 @@ func convertValueVisited(v any, visited map[uintptr]bool) attribute.Value {
 		}
 		return attribute.SliceValue(items...)
 	case reflect.Map:
-		if val.IsNil() {
-			return attribute.Value{}
+		if val.Len() == 0 {
+			return attribute.MapValue()
 		}
 		ptr := val.Pointer()
 		if ptr != 0 {

--- a/bridges/otellogrus/convert.go
+++ b/bridges/otellogrus/convert.go
@@ -18,6 +18,10 @@ import (
 
 // convertValue converts various types to attribute.Value.
 func convertValue(v any) attribute.Value {
+	return convertValueVisited(v, nil)
+}
+
+func convertValueVisited(v any, visited []uintptr) attribute.Value {
 	// Handling the most common types without reflect is a small perf win.
 	switch val := v.(type) {
 	case bool:
@@ -79,12 +83,44 @@ func convertValue(v any) attribute.Value {
 	case reflect.Struct:
 		return attribute.StringValue(fmt.Sprintf("%+v", v))
 	case reflect.Slice, reflect.Array:
+		if val.Len() == 0 {
+			return attribute.SliceValue()
+		}
+		if t.Kind() == reflect.Slice {
+			if val.IsNil() {
+				return attribute.Value{}
+			}
+			ptr := val.Pointer()
+			if ptr != 0 {
+				for _, p := range visited {
+					if p == ptr {
+						return attribute.StringValue("<cycle>")
+					}
+				}
+				visited = append(visited, ptr)
+			}
+		}
 		items := make([]attribute.Value, 0, val.Len())
 		for i := range val.Len() {
-			items = append(items, convertValue(val.Index(i).Interface()))
+			items = append(items, convertValueVisited(val.Index(i).Interface(), visited))
 		}
 		return attribute.SliceValue(items...)
 	case reflect.Map:
+		if val.IsNil() {
+			return attribute.Value{}
+		}
+		if val.Len() == 0 {
+			return attribute.MapValue()
+		}
+		ptr := val.Pointer()
+		if ptr != 0 {
+			for _, p := range visited {
+				if p == ptr {
+					return attribute.StringValue("<cycle>")
+				}
+			}
+			visited = append(visited, ptr)
+		}
 		kvs := make([]attribute.KeyValue, 0, val.Len())
 		for _, k := range val.MapKeys() {
 			var key string
@@ -96,15 +132,29 @@ func convertValue(v any) attribute.Value {
 			}
 			kvs = append(kvs, attribute.KeyValue{
 				Key:   attribute.Key(key),
-				Value: convertValue(val.MapIndex(k).Interface()),
+				Value: convertValueVisited(val.MapIndex(k).Interface(), visited),
 			})
 		}
 		return attribute.MapValue(kvs...)
-	case reflect.Pointer, reflect.Interface:
+	case reflect.Pointer:
 		if val.IsNil() {
 			return attribute.Value{}
 		}
-		return convertValue(val.Elem().Interface())
+		ptr := val.Pointer()
+		if ptr != 0 {
+			for _, p := range visited {
+				if p == ptr {
+					return attribute.StringValue("<cycle>")
+				}
+			}
+			visited = append(visited, ptr)
+		}
+		return convertValueVisited(val.Elem().Interface(), visited)
+	case reflect.Interface:
+		if val.IsNil() {
+			return attribute.Value{}
+		}
+		return convertValueVisited(val.Elem().Interface(), visited)
 	}
 
 	// Try to handle this as gracefully as possible.

--- a/bridges/otellogrus/convert.go
+++ b/bridges/otellogrus/convert.go
@@ -17,9 +17,15 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
+type visitKey struct {
+	typ reflect.Type
+	ptr uintptr
+	len int
+}
+
 var visitedMapPool = sync.Pool{
 	New: func() any {
-		return make(map[uintptr]bool)
+		return make(map[visitKey]bool)
 	},
 }
 
@@ -29,14 +35,14 @@ func convertValue(v any) attribute.Value {
 		return res
 	}
 
-	visited := visitedMapPool.Get().(map[uintptr]bool)
+	visited := visitedMapPool.Get().(map[visitKey]bool)
 	res := convertValueVisited(v, visited)
 	clear(visited)
 	visitedMapPool.Put(visited)
 	return res
 }
 
-func convertValueVisited(v any, visited map[uintptr]bool) attribute.Value {
+func convertValueVisited(v any, visited map[visitKey]bool) attribute.Value {
 	if res, ok := fastConvertValue(v); ok {
 		return res
 	}
@@ -56,11 +62,12 @@ func convertValueVisited(v any, visited map[uintptr]bool) attribute.Value {
 		if t.Kind() == reflect.Slice {
 			ptr := val.Pointer()
 			if ptr != 0 {
-				if visited[ptr] {
+				key := visitKey{typ: t, ptr: ptr, len: val.Len()}
+				if visited[key] {
 					return attribute.StringValue("<cycle>")
 				}
-				visited[ptr] = true
-				defer delete(visited, ptr)
+				visited[key] = true
+				defer delete(visited, key)
 			}
 		}
 		items := make([]attribute.Value, 0, val.Len())
@@ -74,11 +81,12 @@ func convertValueVisited(v any, visited map[uintptr]bool) attribute.Value {
 		}
 		ptr := val.Pointer()
 		if ptr != 0 {
-			if visited[ptr] {
+			key := visitKey{typ: t, ptr: ptr}
+			if visited[key] {
 				return attribute.StringValue("<cycle>")
 			}
-			visited[ptr] = true
-			defer delete(visited, ptr)
+			visited[key] = true
+			defer delete(visited, key)
 		}
 		kvs := make([]attribute.KeyValue, 0, val.Len())
 		for _, k := range val.MapKeys() {
@@ -101,11 +109,12 @@ func convertValueVisited(v any, visited map[uintptr]bool) attribute.Value {
 		}
 		ptr := val.Pointer()
 		if ptr != 0 {
-			if visited[ptr] {
+			key := visitKey{typ: t, ptr: ptr}
+			if visited[key] {
 				return attribute.StringValue("<cycle>")
 			}
-			visited[ptr] = true
-			defer delete(visited, ptr)
+			visited[key] = true
+			defer delete(visited, key)
 		}
 		return convertValueVisited(val.Elem().Interface(), visited)
 	case reflect.Interface:

--- a/bridges/otellogrus/convert_test.go
+++ b/bridges/otellogrus/convert_test.go
@@ -165,6 +165,25 @@ func TestConvertValue(t *testing.T) {
 			wantValue: attribute.BoolValue(true),
 		},
 		{
+			name:      "nil_slice",
+			value:     ([]int)(nil),
+			wantValue: attribute.SliceValue(),
+		},
+		{
+			name:      "nil_map",
+			value:     (map[string]int)(nil),
+			wantValue: attribute.MapValue(),
+		},
+		{
+			name: "empty_subslice_sharing_parent_array",
+			value: func() any {
+				parent := []any{1}
+				parent[0] = parent[:0]
+				return parent
+			}(),
+			wantValue: attribute.SliceValue(attribute.SliceValue()),
+		},
+		{
 			name:      "int_empty_array",
 			value:     []int{},
 			wantValue: attribute.SliceValue([]attribute.Value{}...),

--- a/bridges/otellogrus/convert_test.go
+++ b/bridges/otellogrus/convert_test.go
@@ -337,6 +337,32 @@ func TestConvertValue(t *testing.T) {
 				attribute.Map("right", attribute.Int64("one", 1)),
 			),
 		},
+		{
+			name: "branching_cyclic_map",
+			value: func() any {
+				m := map[string]any{}
+				m["a"] = m
+				m["b"] = m
+				return m
+			}(),
+			wantValue: attribute.MapValue(
+				attribute.String("a", "<cycle>"),
+				attribute.String("b", "<cycle>"),
+			),
+		},
+		{
+			name: "branching_cyclic_slice",
+			value: func() any {
+				s := make([]any, 2)
+				s[0] = s
+				s[1] = s
+				return s
+			}(),
+			wantValue: attribute.SliceValue(
+				attribute.StringValue("<cycle>"),
+				attribute.StringValue("<cycle>"),
+			),
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.wantValue, convertValue(tt.value))

--- a/bridges/otellogrus/convert_test.go
+++ b/bridges/otellogrus/convert_test.go
@@ -261,6 +261,82 @@ func TestConvertValue(t *testing.T) {
 			value:     chan int(nil),
 			wantValue: attribute.StringValue("unhandled: (chan int) <nil>"),
 		},
+		{
+			name: "cyclic_map",
+			value: func() any {
+				m := map[string]any{}
+				m["self"] = m
+				return m
+			}(),
+			wantValue: attribute.MapValue(
+				attribute.String("self", "<cycle>"),
+			),
+		},
+		{
+			name: "cyclic_slice",
+			value: func() any {
+				s := make([]any, 1)
+				s[0] = s
+				return s
+			}(),
+			wantValue: attribute.SliceValue(
+				attribute.StringValue("<cycle>"),
+			),
+		},
+		{
+			name: "cyclic_pointer",
+			value: func() any {
+				var p1, p2 any
+				p1 = &p2
+				p2 = &p1
+				return p1
+			}(),
+			wantValue: attribute.StringValue("<cycle>"),
+		},
+		{
+			name: "indirect_cyclic_map",
+			value: func() any {
+				m1 := map[string]any{}
+				m2 := map[string]any{}
+				m1["next"] = m2
+				m2["next"] = m1
+				return m1
+			}(),
+			wantValue: attribute.MapValue(
+				attribute.Map("next",
+					attribute.String("next", "<cycle>"),
+				),
+			),
+		},
+		{
+			name: "indirect_cyclic_slice",
+			value: func() any {
+				s1 := make([]any, 1)
+				s2 := make([]any, 1)
+				s1[0] = s2
+				s2[0] = s1
+				return s1
+			}(),
+			wantValue: attribute.SliceValue(
+				attribute.SliceValue(
+					attribute.StringValue("<cycle>"),
+				),
+			),
+		},
+		{
+			name: "non_cyclic_dag",
+			value: func() any {
+				shared := map[string]int{"one": 1}
+				return map[string]any{
+					"left":  shared,
+					"right": shared,
+				}
+			}(),
+			wantValue: attribute.MapValue(
+				attribute.Map("left", attribute.Int64("one", 1)),
+				attribute.Map("right", attribute.Int64("one", 1)),
+			),
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.wantValue, convertValue(tt.value))

--- a/bridges/otellogrus/convert_test.go
+++ b/bridges/otellogrus/convert_test.go
@@ -184,6 +184,30 @@ func TestConvertValue(t *testing.T) {
 			wantValue: attribute.SliceValue(attribute.SliceValue()),
 		},
 		{
+			name: "overlapping_subslice_non_cyclic",
+			value: func() any {
+				parent := []any{42, nil}
+				parent[1] = parent[:1]
+				return parent
+			}(),
+			wantValue: attribute.SliceValue(
+				attribute.Int64Value(42),
+				attribute.SliceValue(attribute.Int64Value(42)),
+			),
+		},
+		{
+			name: "overlapping_pointer_to_first_element_non_cyclic",
+			value: func() any {
+				parent := &[2]any{42, nil}
+				parent[1] = &parent[0]
+				return parent
+			}(),
+			wantValue: attribute.SliceValue(
+				attribute.Int64Value(42),
+				attribute.Int64Value(42),
+			),
+		},
+		{
 			name:      "int_empty_array",
 			value:     []int{},
 			wantValue: attribute.SliceValue([]attribute.Value{}...),

--- a/bridges/otelslog/convert.go
+++ b/bridges/otelslog/convert.go
@@ -11,67 +11,34 @@ import (
 	"math"
 	"reflect"
 	"strconv"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 )
 
-// convertValue converts various types to attribute.Value.
-func convertValue(v any) attribute.Value {
-	return convertValueVisited(v, nil)
+var visitedMapPool = sync.Pool{
+	New: func() any {
+		return make(map[uintptr]bool)
+	},
 }
 
-func convertValueVisited(v any, visited []uintptr) attribute.Value {
-	// Handling the most common types without reflect is a small perf win.
-	switch val := v.(type) {
-	case bool:
-		return attribute.BoolValue(val)
-	case string:
-		return attribute.StringValue(val)
-	case int:
-		return attribute.Int64Value(int64(val))
-	case int8:
-		return attribute.Int64Value(int64(val))
-	case int16:
-		return attribute.Int64Value(int64(val))
-	case int32:
-		return attribute.Int64Value(int64(val))
-	case int64:
-		return attribute.Int64Value(val)
-	case uint:
-		return convertUintValue(uint64(val))
-	case uint8:
-		return attribute.Int64Value(int64(val))
-	case uint16:
-		return attribute.Int64Value(int64(val))
-	case uint32:
-		return attribute.Int64Value(int64(val))
-	case uint64:
-		return convertUintValue(val)
-	case uintptr:
-		return convertUintValue(uint64(val))
-	case float32:
-		return attribute.Float64Value(float64(val))
-	case float64:
-		return attribute.Float64Value(val)
-	case time.Duration:
-		return attribute.Int64Value(val.Nanoseconds())
-	case complex64:
-		r := attribute.Float64("r", real(complex128(val)))
-		i := attribute.Float64("i", imag(complex128(val)))
-		return attribute.MapValue(r, i)
-	case complex128:
-		r := attribute.Float64("r", real(val))
-		i := attribute.Float64("i", imag(val))
-		return attribute.MapValue(r, i)
-	case time.Time:
-		return attribute.Int64Value(val.UnixNano())
-	case []byte:
-		return attribute.ByteSliceValue(val)
-	case error:
-		return attribute.StringValue(val.Error())
-	case attribute.Value:
-		return val
+// convertValue converts various types to attribute.Value.
+func convertValue(v any) attribute.Value {
+	if res, ok := fastConvertValue(v); ok {
+		return res
+	}
+
+	visited := visitedMapPool.Get().(map[uintptr]bool)
+	res := convertValueVisited(v, visited)
+	clear(visited)
+	visitedMapPool.Put(visited)
+	return res
+}
+
+func convertValueVisited(v any, visited map[uintptr]bool) attribute.Value {
+	if res, ok := fastConvertValue(v); ok {
+		return res
 	}
 
 	t := reflect.TypeOf(v)
@@ -83,21 +50,17 @@ func convertValueVisited(v any, visited []uintptr) attribute.Value {
 	case reflect.Struct:
 		return attribute.StringValue(fmt.Sprintf("%+v", v))
 	case reflect.Slice, reflect.Array:
-		if val.Len() == 0 {
-			return attribute.SliceValue()
-		}
 		if t.Kind() == reflect.Slice {
 			if val.IsNil() {
 				return attribute.Value{}
 			}
 			ptr := val.Pointer()
 			if ptr != 0 {
-				for _, p := range visited {
-					if p == ptr {
-						return attribute.StringValue("<cycle>")
-					}
+				if visited[ptr] {
+					return attribute.StringValue("<cycle>")
 				}
-				visited = append(visited, ptr)
+				visited[ptr] = true
+				defer delete(visited, ptr)
 			}
 		}
 		items := make([]attribute.Value, 0, val.Len())
@@ -109,17 +72,13 @@ func convertValueVisited(v any, visited []uintptr) attribute.Value {
 		if val.IsNil() {
 			return attribute.Value{}
 		}
-		if val.Len() == 0 {
-			return attribute.MapValue()
-		}
 		ptr := val.Pointer()
 		if ptr != 0 {
-			for _, p := range visited {
-				if p == ptr {
-					return attribute.StringValue("<cycle>")
-				}
+			if visited[ptr] {
+				return attribute.StringValue("<cycle>")
 			}
-			visited = append(visited, ptr)
+			visited[ptr] = true
+			defer delete(visited, ptr)
 		}
 		kvs := make([]attribute.KeyValue, 0, val.Len())
 		for _, k := range val.MapKeys() {
@@ -142,12 +101,11 @@ func convertValueVisited(v any, visited []uintptr) attribute.Value {
 		}
 		ptr := val.Pointer()
 		if ptr != 0 {
-			for _, p := range visited {
-				if p == ptr {
-					return attribute.StringValue("<cycle>")
-				}
+			if visited[ptr] {
+				return attribute.StringValue("<cycle>")
 			}
-			visited = append(visited, ptr)
+			visited[ptr] = true
+			defer delete(visited, ptr)
 		}
 		return convertValueVisited(val.Elem().Interface(), visited)
 	case reflect.Interface:
@@ -163,6 +121,61 @@ func convertValueVisited(v any, visited []uintptr) attribute.Value {
 	// asking why their attributes have a "unhandled: " prefix than
 	// say that their code is panicking.
 	return attribute.StringValue(fmt.Sprintf("unhandled: (%s) %+v", t, v))
+}
+
+// fastConvertValue handles common primitive types without reflection or pool overhead.
+func fastConvertValue(v any) (attribute.Value, bool) {
+	switch val := v.(type) {
+	case bool:
+		return attribute.BoolValue(val), true
+	case string:
+		return attribute.StringValue(val), true
+	case int:
+		return attribute.Int64Value(int64(val)), true
+	case int8:
+		return attribute.Int64Value(int64(val)), true
+	case int16:
+		return attribute.Int64Value(int64(val)), true
+	case int32:
+		return attribute.Int64Value(int64(val)), true
+	case int64:
+		return attribute.Int64Value(val), true
+	case uint:
+		return convertUintValue(uint64(val)), true
+	case uint8:
+		return attribute.Int64Value(int64(val)), true
+	case uint16:
+		return attribute.Int64Value(int64(val)), true
+	case uint32:
+		return attribute.Int64Value(int64(val)), true
+	case uint64:
+		return convertUintValue(val), true
+	case uintptr:
+		return convertUintValue(uint64(val)), true
+	case float32:
+		return attribute.Float64Value(float64(val)), true
+	case float64:
+		return attribute.Float64Value(val), true
+	case time.Duration:
+		return attribute.Int64Value(val.Nanoseconds()), true
+	case complex64:
+		r := attribute.Float64("r", real(complex128(val)))
+		i := attribute.Float64("i", imag(complex128(val)))
+		return attribute.MapValue(r, i), true
+	case complex128:
+		r := attribute.Float64("r", real(val))
+		i := attribute.Float64("i", imag(val))
+		return attribute.MapValue(r, i), true
+	case time.Time:
+		return attribute.Int64Value(val.UnixNano()), true
+	case []byte:
+		return attribute.ByteSliceValue(val), true
+	case error:
+		return attribute.StringValue(val.Error()), true
+	case attribute.Value:
+		return val, true
+	}
+	return attribute.Value{}, false
 }
 
 // convertUintValue converts a uint64 to an attribute.Value.

--- a/bridges/otelslog/convert.go
+++ b/bridges/otelslog/convert.go
@@ -50,10 +50,10 @@ func convertValueVisited(v any, visited map[uintptr]bool) attribute.Value {
 	case reflect.Struct:
 		return attribute.StringValue(fmt.Sprintf("%+v", v))
 	case reflect.Slice, reflect.Array:
+		if val.Len() == 0 {
+			return attribute.SliceValue()
+		}
 		if t.Kind() == reflect.Slice {
-			if val.IsNil() {
-				return attribute.Value{}
-			}
 			ptr := val.Pointer()
 			if ptr != 0 {
 				if visited[ptr] {
@@ -69,8 +69,8 @@ func convertValueVisited(v any, visited map[uintptr]bool) attribute.Value {
 		}
 		return attribute.SliceValue(items...)
 	case reflect.Map:
-		if val.IsNil() {
-			return attribute.Value{}
+		if val.Len() == 0 {
+			return attribute.MapValue()
 		}
 		ptr := val.Pointer()
 		if ptr != 0 {

--- a/bridges/otelslog/convert.go
+++ b/bridges/otelslog/convert.go
@@ -18,6 +18,10 @@ import (
 
 // convertValue converts various types to attribute.Value.
 func convertValue(v any) attribute.Value {
+	return convertValueVisited(v, nil)
+}
+
+func convertValueVisited(v any, visited []uintptr) attribute.Value {
 	// Handling the most common types without reflect is a small perf win.
 	switch val := v.(type) {
 	case bool:
@@ -79,12 +83,44 @@ func convertValue(v any) attribute.Value {
 	case reflect.Struct:
 		return attribute.StringValue(fmt.Sprintf("%+v", v))
 	case reflect.Slice, reflect.Array:
+		if val.Len() == 0 {
+			return attribute.SliceValue()
+		}
+		if t.Kind() == reflect.Slice {
+			if val.IsNil() {
+				return attribute.Value{}
+			}
+			ptr := val.Pointer()
+			if ptr != 0 {
+				for _, p := range visited {
+					if p == ptr {
+						return attribute.StringValue("<cycle>")
+					}
+				}
+				visited = append(visited, ptr)
+			}
+		}
 		items := make([]attribute.Value, 0, val.Len())
 		for i := range val.Len() {
-			items = append(items, convertValue(val.Index(i).Interface()))
+			items = append(items, convertValueVisited(val.Index(i).Interface(), visited))
 		}
 		return attribute.SliceValue(items...)
 	case reflect.Map:
+		if val.IsNil() {
+			return attribute.Value{}
+		}
+		if val.Len() == 0 {
+			return attribute.MapValue()
+		}
+		ptr := val.Pointer()
+		if ptr != 0 {
+			for _, p := range visited {
+				if p == ptr {
+					return attribute.StringValue("<cycle>")
+				}
+			}
+			visited = append(visited, ptr)
+		}
 		kvs := make([]attribute.KeyValue, 0, val.Len())
 		for _, k := range val.MapKeys() {
 			var key string
@@ -96,15 +132,29 @@ func convertValue(v any) attribute.Value {
 			}
 			kvs = append(kvs, attribute.KeyValue{
 				Key:   attribute.Key(key),
-				Value: convertValue(val.MapIndex(k).Interface()),
+				Value: convertValueVisited(val.MapIndex(k).Interface(), visited),
 			})
 		}
 		return attribute.MapValue(kvs...)
-	case reflect.Pointer, reflect.Interface:
+	case reflect.Pointer:
 		if val.IsNil() {
 			return attribute.Value{}
 		}
-		return convertValue(val.Elem().Interface())
+		ptr := val.Pointer()
+		if ptr != 0 {
+			for _, p := range visited {
+				if p == ptr {
+					return attribute.StringValue("<cycle>")
+				}
+			}
+			visited = append(visited, ptr)
+		}
+		return convertValueVisited(val.Elem().Interface(), visited)
+	case reflect.Interface:
+		if val.IsNil() {
+			return attribute.Value{}
+		}
+		return convertValueVisited(val.Elem().Interface(), visited)
 	}
 
 	// Try to handle this as gracefully as possible.

--- a/bridges/otelslog/convert.go
+++ b/bridges/otelslog/convert.go
@@ -17,9 +17,15 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
+type visitKey struct {
+	typ reflect.Type
+	ptr uintptr
+	len int
+}
+
 var visitedMapPool = sync.Pool{
 	New: func() any {
-		return make(map[uintptr]bool)
+		return make(map[visitKey]bool)
 	},
 }
 
@@ -29,14 +35,14 @@ func convertValue(v any) attribute.Value {
 		return res
 	}
 
-	visited := visitedMapPool.Get().(map[uintptr]bool)
+	visited := visitedMapPool.Get().(map[visitKey]bool)
 	res := convertValueVisited(v, visited)
 	clear(visited)
 	visitedMapPool.Put(visited)
 	return res
 }
 
-func convertValueVisited(v any, visited map[uintptr]bool) attribute.Value {
+func convertValueVisited(v any, visited map[visitKey]bool) attribute.Value {
 	if res, ok := fastConvertValue(v); ok {
 		return res
 	}
@@ -56,11 +62,12 @@ func convertValueVisited(v any, visited map[uintptr]bool) attribute.Value {
 		if t.Kind() == reflect.Slice {
 			ptr := val.Pointer()
 			if ptr != 0 {
-				if visited[ptr] {
+				key := visitKey{typ: t, ptr: ptr, len: val.Len()}
+				if visited[key] {
 					return attribute.StringValue("<cycle>")
 				}
-				visited[ptr] = true
-				defer delete(visited, ptr)
+				visited[key] = true
+				defer delete(visited, key)
 			}
 		}
 		items := make([]attribute.Value, 0, val.Len())
@@ -74,11 +81,12 @@ func convertValueVisited(v any, visited map[uintptr]bool) attribute.Value {
 		}
 		ptr := val.Pointer()
 		if ptr != 0 {
-			if visited[ptr] {
+			key := visitKey{typ: t, ptr: ptr}
+			if visited[key] {
 				return attribute.StringValue("<cycle>")
 			}
-			visited[ptr] = true
-			defer delete(visited, ptr)
+			visited[key] = true
+			defer delete(visited, key)
 		}
 		kvs := make([]attribute.KeyValue, 0, val.Len())
 		for _, k := range val.MapKeys() {
@@ -101,11 +109,12 @@ func convertValueVisited(v any, visited map[uintptr]bool) attribute.Value {
 		}
 		ptr := val.Pointer()
 		if ptr != 0 {
-			if visited[ptr] {
+			key := visitKey{typ: t, ptr: ptr}
+			if visited[key] {
 				return attribute.StringValue("<cycle>")
 			}
-			visited[ptr] = true
-			defer delete(visited, ptr)
+			visited[key] = true
+			defer delete(visited, key)
 		}
 		return convertValueVisited(val.Elem().Interface(), visited)
 	case reflect.Interface:

--- a/bridges/otelslog/convert_test.go
+++ b/bridges/otelslog/convert_test.go
@@ -165,6 +165,25 @@ func TestConvertValue(t *testing.T) {
 			wantValue: attribute.BoolValue(true),
 		},
 		{
+			name:      "nil_slice",
+			value:     ([]int)(nil),
+			wantValue: attribute.SliceValue(),
+		},
+		{
+			name:      "nil_map",
+			value:     (map[string]int)(nil),
+			wantValue: attribute.MapValue(),
+		},
+		{
+			name: "empty_subslice_sharing_parent_array",
+			value: func() any {
+				parent := []any{1}
+				parent[0] = parent[:0]
+				return parent
+			}(),
+			wantValue: attribute.SliceValue(attribute.SliceValue()),
+		},
+		{
 			name:      "int_empty_array",
 			value:     []int{},
 			wantValue: attribute.SliceValue([]attribute.Value{}...),

--- a/bridges/otelslog/convert_test.go
+++ b/bridges/otelslog/convert_test.go
@@ -337,6 +337,32 @@ func TestConvertValue(t *testing.T) {
 				attribute.Map("right", attribute.Int64("one", 1)),
 			),
 		},
+		{
+			name: "branching_cyclic_map",
+			value: func() any {
+				m := map[string]any{}
+				m["a"] = m
+				m["b"] = m
+				return m
+			}(),
+			wantValue: attribute.MapValue(
+				attribute.String("a", "<cycle>"),
+				attribute.String("b", "<cycle>"),
+			),
+		},
+		{
+			name: "branching_cyclic_slice",
+			value: func() any {
+				s := make([]any, 2)
+				s[0] = s
+				s[1] = s
+				return s
+			}(),
+			wantValue: attribute.SliceValue(
+				attribute.StringValue("<cycle>"),
+				attribute.StringValue("<cycle>"),
+			),
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.wantValue, convertValue(tt.value))

--- a/bridges/otelslog/convert_test.go
+++ b/bridges/otelslog/convert_test.go
@@ -261,6 +261,82 @@ func TestConvertValue(t *testing.T) {
 			value:     chan int(nil),
 			wantValue: attribute.StringValue("unhandled: (chan int) <nil>"),
 		},
+		{
+			name: "cyclic_map",
+			value: func() any {
+				m := map[string]any{}
+				m["self"] = m
+				return m
+			}(),
+			wantValue: attribute.MapValue(
+				attribute.String("self", "<cycle>"),
+			),
+		},
+		{
+			name: "cyclic_slice",
+			value: func() any {
+				s := make([]any, 1)
+				s[0] = s
+				return s
+			}(),
+			wantValue: attribute.SliceValue(
+				attribute.StringValue("<cycle>"),
+			),
+		},
+		{
+			name: "cyclic_pointer",
+			value: func() any {
+				var p1, p2 any
+				p1 = &p2
+				p2 = &p1
+				return p1
+			}(),
+			wantValue: attribute.StringValue("<cycle>"),
+		},
+		{
+			name: "indirect_cyclic_map",
+			value: func() any {
+				m1 := map[string]any{}
+				m2 := map[string]any{}
+				m1["next"] = m2
+				m2["next"] = m1
+				return m1
+			}(),
+			wantValue: attribute.MapValue(
+				attribute.Map("next",
+					attribute.String("next", "<cycle>"),
+				),
+			),
+		},
+		{
+			name: "indirect_cyclic_slice",
+			value: func() any {
+				s1 := make([]any, 1)
+				s2 := make([]any, 1)
+				s1[0] = s2
+				s2[0] = s1
+				return s1
+			}(),
+			wantValue: attribute.SliceValue(
+				attribute.SliceValue(
+					attribute.StringValue("<cycle>"),
+				),
+			),
+		},
+		{
+			name: "non_cyclic_dag",
+			value: func() any {
+				shared := map[string]int{"one": 1}
+				return map[string]any{
+					"left":  shared,
+					"right": shared,
+				}
+			}(),
+			wantValue: attribute.MapValue(
+				attribute.Map("left", attribute.Int64("one", 1)),
+				attribute.Map("right", attribute.Int64("one", 1)),
+			),
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.wantValue, convertValue(tt.value))

--- a/bridges/otelslog/convert_test.go
+++ b/bridges/otelslog/convert_test.go
@@ -184,6 +184,30 @@ func TestConvertValue(t *testing.T) {
 			wantValue: attribute.SliceValue(attribute.SliceValue()),
 		},
 		{
+			name: "overlapping_subslice_non_cyclic",
+			value: func() any {
+				parent := []any{42, nil}
+				parent[1] = parent[:1]
+				return parent
+			}(),
+			wantValue: attribute.SliceValue(
+				attribute.Int64Value(42),
+				attribute.SliceValue(attribute.Int64Value(42)),
+			),
+		},
+		{
+			name: "overlapping_pointer_to_first_element_non_cyclic",
+			value: func() any {
+				parent := &[2]any{42, nil}
+				parent[1] = &parent[0]
+				return parent
+			}(),
+			wantValue: attribute.SliceValue(
+				attribute.Int64Value(42),
+				attribute.Int64Value(42),
+			),
+		},
+		{
 			name:      "int_empty_array",
 			value:     []int{},
 			wantValue: attribute.SliceValue([]attribute.Value{}...),

--- a/bridges/otelzap/convert.go
+++ b/bridges/otelzap/convert.go
@@ -11,67 +11,34 @@ import (
 	"math"
 	"reflect"
 	"strconv"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 )
 
-// convertValue converts various types to attribute.Value.
-func convertValue(v any) attribute.Value {
-	return convertValueVisited(v, nil)
+var visitedMapPool = sync.Pool{
+	New: func() any {
+		return make(map[uintptr]bool)
+	},
 }
 
-func convertValueVisited(v any, visited []uintptr) attribute.Value {
-	// Handling the most common types without reflect is a small perf win.
-	switch val := v.(type) {
-	case bool:
-		return attribute.BoolValue(val)
-	case string:
-		return attribute.StringValue(val)
-	case int:
-		return attribute.Int64Value(int64(val))
-	case int8:
-		return attribute.Int64Value(int64(val))
-	case int16:
-		return attribute.Int64Value(int64(val))
-	case int32:
-		return attribute.Int64Value(int64(val))
-	case int64:
-		return attribute.Int64Value(val)
-	case uint:
-		return convertUintValue(uint64(val))
-	case uint8:
-		return attribute.Int64Value(int64(val))
-	case uint16:
-		return attribute.Int64Value(int64(val))
-	case uint32:
-		return attribute.Int64Value(int64(val))
-	case uint64:
-		return convertUintValue(val)
-	case uintptr:
-		return convertUintValue(uint64(val))
-	case float32:
-		return attribute.Float64Value(float64(val))
-	case float64:
-		return attribute.Float64Value(val)
-	case time.Duration:
-		return attribute.Int64Value(val.Nanoseconds())
-	case complex64:
-		r := attribute.Float64("r", real(complex128(val)))
-		i := attribute.Float64("i", imag(complex128(val)))
-		return attribute.MapValue(r, i)
-	case complex128:
-		r := attribute.Float64("r", real(val))
-		i := attribute.Float64("i", imag(val))
-		return attribute.MapValue(r, i)
-	case time.Time:
-		return attribute.Int64Value(val.UnixNano())
-	case []byte:
-		return attribute.ByteSliceValue(val)
-	case error:
-		return attribute.StringValue(val.Error())
-	case attribute.Value:
-		return val
+// convertValue converts various types to attribute.Value.
+func convertValue(v any) attribute.Value {
+	if res, ok := fastConvertValue(v); ok {
+		return res
+	}
+
+	visited := visitedMapPool.Get().(map[uintptr]bool)
+	res := convertValueVisited(v, visited)
+	clear(visited)
+	visitedMapPool.Put(visited)
+	return res
+}
+
+func convertValueVisited(v any, visited map[uintptr]bool) attribute.Value {
+	if res, ok := fastConvertValue(v); ok {
+		return res
 	}
 
 	t := reflect.TypeOf(v)
@@ -83,21 +50,17 @@ func convertValueVisited(v any, visited []uintptr) attribute.Value {
 	case reflect.Struct:
 		return attribute.StringValue(fmt.Sprintf("%+v", v))
 	case reflect.Slice, reflect.Array:
-		if val.Len() == 0 {
-			return attribute.SliceValue()
-		}
 		if t.Kind() == reflect.Slice {
 			if val.IsNil() {
 				return attribute.Value{}
 			}
 			ptr := val.Pointer()
 			if ptr != 0 {
-				for _, p := range visited {
-					if p == ptr {
-						return attribute.StringValue("<cycle>")
-					}
+				if visited[ptr] {
+					return attribute.StringValue("<cycle>")
 				}
-				visited = append(visited, ptr)
+				visited[ptr] = true
+				defer delete(visited, ptr)
 			}
 		}
 		items := make([]attribute.Value, 0, val.Len())
@@ -109,17 +72,13 @@ func convertValueVisited(v any, visited []uintptr) attribute.Value {
 		if val.IsNil() {
 			return attribute.Value{}
 		}
-		if val.Len() == 0 {
-			return attribute.MapValue()
-		}
 		ptr := val.Pointer()
 		if ptr != 0 {
-			for _, p := range visited {
-				if p == ptr {
-					return attribute.StringValue("<cycle>")
-				}
+			if visited[ptr] {
+				return attribute.StringValue("<cycle>")
 			}
-			visited = append(visited, ptr)
+			visited[ptr] = true
+			defer delete(visited, ptr)
 		}
 		kvs := make([]attribute.KeyValue, 0, val.Len())
 		for _, k := range val.MapKeys() {
@@ -142,12 +101,11 @@ func convertValueVisited(v any, visited []uintptr) attribute.Value {
 		}
 		ptr := val.Pointer()
 		if ptr != 0 {
-			for _, p := range visited {
-				if p == ptr {
-					return attribute.StringValue("<cycle>")
-				}
+			if visited[ptr] {
+				return attribute.StringValue("<cycle>")
 			}
-			visited = append(visited, ptr)
+			visited[ptr] = true
+			defer delete(visited, ptr)
 		}
 		return convertValueVisited(val.Elem().Interface(), visited)
 	case reflect.Interface:
@@ -163,6 +121,61 @@ func convertValueVisited(v any, visited []uintptr) attribute.Value {
 	// asking why their attributes have a "unhandled: " prefix than
 	// say that their code is panicking.
 	return attribute.StringValue(fmt.Sprintf("unhandled: (%s) %+v", t, v))
+}
+
+// fastConvertValue handles common primitive types without reflection or pool overhead.
+func fastConvertValue(v any) (attribute.Value, bool) {
+	switch val := v.(type) {
+	case bool:
+		return attribute.BoolValue(val), true
+	case string:
+		return attribute.StringValue(val), true
+	case int:
+		return attribute.Int64Value(int64(val)), true
+	case int8:
+		return attribute.Int64Value(int64(val)), true
+	case int16:
+		return attribute.Int64Value(int64(val)), true
+	case int32:
+		return attribute.Int64Value(int64(val)), true
+	case int64:
+		return attribute.Int64Value(val), true
+	case uint:
+		return convertUintValue(uint64(val)), true
+	case uint8:
+		return attribute.Int64Value(int64(val)), true
+	case uint16:
+		return attribute.Int64Value(int64(val)), true
+	case uint32:
+		return attribute.Int64Value(int64(val)), true
+	case uint64:
+		return convertUintValue(val), true
+	case uintptr:
+		return convertUintValue(uint64(val)), true
+	case float32:
+		return attribute.Float64Value(float64(val)), true
+	case float64:
+		return attribute.Float64Value(val), true
+	case time.Duration:
+		return attribute.Int64Value(val.Nanoseconds()), true
+	case complex64:
+		r := attribute.Float64("r", real(complex128(val)))
+		i := attribute.Float64("i", imag(complex128(val)))
+		return attribute.MapValue(r, i), true
+	case complex128:
+		r := attribute.Float64("r", real(val))
+		i := attribute.Float64("i", imag(val))
+		return attribute.MapValue(r, i), true
+	case time.Time:
+		return attribute.Int64Value(val.UnixNano()), true
+	case []byte:
+		return attribute.ByteSliceValue(val), true
+	case error:
+		return attribute.StringValue(val.Error()), true
+	case attribute.Value:
+		return val, true
+	}
+	return attribute.Value{}, false
 }
 
 // convertUintValue converts a uint64 to an attribute.Value.

--- a/bridges/otelzap/convert.go
+++ b/bridges/otelzap/convert.go
@@ -50,10 +50,10 @@ func convertValueVisited(v any, visited map[uintptr]bool) attribute.Value {
 	case reflect.Struct:
 		return attribute.StringValue(fmt.Sprintf("%+v", v))
 	case reflect.Slice, reflect.Array:
+		if val.Len() == 0 {
+			return attribute.SliceValue()
+		}
 		if t.Kind() == reflect.Slice {
-			if val.IsNil() {
-				return attribute.Value{}
-			}
 			ptr := val.Pointer()
 			if ptr != 0 {
 				if visited[ptr] {
@@ -69,8 +69,8 @@ func convertValueVisited(v any, visited map[uintptr]bool) attribute.Value {
 		}
 		return attribute.SliceValue(items...)
 	case reflect.Map:
-		if val.IsNil() {
-			return attribute.Value{}
+		if val.Len() == 0 {
+			return attribute.MapValue()
 		}
 		ptr := val.Pointer()
 		if ptr != 0 {

--- a/bridges/otelzap/convert.go
+++ b/bridges/otelzap/convert.go
@@ -18,6 +18,10 @@ import (
 
 // convertValue converts various types to attribute.Value.
 func convertValue(v any) attribute.Value {
+	return convertValueVisited(v, nil)
+}
+
+func convertValueVisited(v any, visited []uintptr) attribute.Value {
 	// Handling the most common types without reflect is a small perf win.
 	switch val := v.(type) {
 	case bool:
@@ -79,12 +83,44 @@ func convertValue(v any) attribute.Value {
 	case reflect.Struct:
 		return attribute.StringValue(fmt.Sprintf("%+v", v))
 	case reflect.Slice, reflect.Array:
+		if val.Len() == 0 {
+			return attribute.SliceValue()
+		}
+		if t.Kind() == reflect.Slice {
+			if val.IsNil() {
+				return attribute.Value{}
+			}
+			ptr := val.Pointer()
+			if ptr != 0 {
+				for _, p := range visited {
+					if p == ptr {
+						return attribute.StringValue("<cycle>")
+					}
+				}
+				visited = append(visited, ptr)
+			}
+		}
 		items := make([]attribute.Value, 0, val.Len())
 		for i := range val.Len() {
-			items = append(items, convertValue(val.Index(i).Interface()))
+			items = append(items, convertValueVisited(val.Index(i).Interface(), visited))
 		}
 		return attribute.SliceValue(items...)
 	case reflect.Map:
+		if val.IsNil() {
+			return attribute.Value{}
+		}
+		if val.Len() == 0 {
+			return attribute.MapValue()
+		}
+		ptr := val.Pointer()
+		if ptr != 0 {
+			for _, p := range visited {
+				if p == ptr {
+					return attribute.StringValue("<cycle>")
+				}
+			}
+			visited = append(visited, ptr)
+		}
 		kvs := make([]attribute.KeyValue, 0, val.Len())
 		for _, k := range val.MapKeys() {
 			var key string
@@ -96,15 +132,29 @@ func convertValue(v any) attribute.Value {
 			}
 			kvs = append(kvs, attribute.KeyValue{
 				Key:   attribute.Key(key),
-				Value: convertValue(val.MapIndex(k).Interface()),
+				Value: convertValueVisited(val.MapIndex(k).Interface(), visited),
 			})
 		}
 		return attribute.MapValue(kvs...)
-	case reflect.Pointer, reflect.Interface:
+	case reflect.Pointer:
 		if val.IsNil() {
 			return attribute.Value{}
 		}
-		return convertValue(val.Elem().Interface())
+		ptr := val.Pointer()
+		if ptr != 0 {
+			for _, p := range visited {
+				if p == ptr {
+					return attribute.StringValue("<cycle>")
+				}
+			}
+			visited = append(visited, ptr)
+		}
+		return convertValueVisited(val.Elem().Interface(), visited)
+	case reflect.Interface:
+		if val.IsNil() {
+			return attribute.Value{}
+		}
+		return convertValueVisited(val.Elem().Interface(), visited)
 	}
 
 	// Try to handle this as gracefully as possible.

--- a/bridges/otelzap/convert.go
+++ b/bridges/otelzap/convert.go
@@ -17,9 +17,15 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
+type visitKey struct {
+	typ reflect.Type
+	ptr uintptr
+	len int
+}
+
 var visitedMapPool = sync.Pool{
 	New: func() any {
-		return make(map[uintptr]bool)
+		return make(map[visitKey]bool)
 	},
 }
 
@@ -29,14 +35,14 @@ func convertValue(v any) attribute.Value {
 		return res
 	}
 
-	visited := visitedMapPool.Get().(map[uintptr]bool)
+	visited := visitedMapPool.Get().(map[visitKey]bool)
 	res := convertValueVisited(v, visited)
 	clear(visited)
 	visitedMapPool.Put(visited)
 	return res
 }
 
-func convertValueVisited(v any, visited map[uintptr]bool) attribute.Value {
+func convertValueVisited(v any, visited map[visitKey]bool) attribute.Value {
 	if res, ok := fastConvertValue(v); ok {
 		return res
 	}
@@ -56,11 +62,12 @@ func convertValueVisited(v any, visited map[uintptr]bool) attribute.Value {
 		if t.Kind() == reflect.Slice {
 			ptr := val.Pointer()
 			if ptr != 0 {
-				if visited[ptr] {
+				key := visitKey{typ: t, ptr: ptr, len: val.Len()}
+				if visited[key] {
 					return attribute.StringValue("<cycle>")
 				}
-				visited[ptr] = true
-				defer delete(visited, ptr)
+				visited[key] = true
+				defer delete(visited, key)
 			}
 		}
 		items := make([]attribute.Value, 0, val.Len())
@@ -74,11 +81,12 @@ func convertValueVisited(v any, visited map[uintptr]bool) attribute.Value {
 		}
 		ptr := val.Pointer()
 		if ptr != 0 {
-			if visited[ptr] {
+			key := visitKey{typ: t, ptr: ptr}
+			if visited[key] {
 				return attribute.StringValue("<cycle>")
 			}
-			visited[ptr] = true
-			defer delete(visited, ptr)
+			visited[key] = true
+			defer delete(visited, key)
 		}
 		kvs := make([]attribute.KeyValue, 0, val.Len())
 		for _, k := range val.MapKeys() {
@@ -101,11 +109,12 @@ func convertValueVisited(v any, visited map[uintptr]bool) attribute.Value {
 		}
 		ptr := val.Pointer()
 		if ptr != 0 {
-			if visited[ptr] {
+			key := visitKey{typ: t, ptr: ptr}
+			if visited[key] {
 				return attribute.StringValue("<cycle>")
 			}
-			visited[ptr] = true
-			defer delete(visited, ptr)
+			visited[key] = true
+			defer delete(visited, key)
 		}
 		return convertValueVisited(val.Elem().Interface(), visited)
 	case reflect.Interface:

--- a/bridges/otelzap/convert_test.go
+++ b/bridges/otelzap/convert_test.go
@@ -165,6 +165,25 @@ func TestConvertValue(t *testing.T) {
 			wantValue: attribute.BoolValue(true),
 		},
 		{
+			name:      "nil_slice",
+			value:     ([]int)(nil),
+			wantValue: attribute.SliceValue(),
+		},
+		{
+			name:      "nil_map",
+			value:     (map[string]int)(nil),
+			wantValue: attribute.MapValue(),
+		},
+		{
+			name: "empty_subslice_sharing_parent_array",
+			value: func() any {
+				parent := []any{1}
+				parent[0] = parent[:0]
+				return parent
+			}(),
+			wantValue: attribute.SliceValue(attribute.SliceValue()),
+		},
+		{
 			name:      "int_empty_array",
 			value:     []int{},
 			wantValue: attribute.SliceValue([]attribute.Value{}...),

--- a/bridges/otelzap/convert_test.go
+++ b/bridges/otelzap/convert_test.go
@@ -337,6 +337,32 @@ func TestConvertValue(t *testing.T) {
 				attribute.Map("right", attribute.Int64("one", 1)),
 			),
 		},
+		{
+			name: "branching_cyclic_map",
+			value: func() any {
+				m := map[string]any{}
+				m["a"] = m
+				m["b"] = m
+				return m
+			}(),
+			wantValue: attribute.MapValue(
+				attribute.String("a", "<cycle>"),
+				attribute.String("b", "<cycle>"),
+			),
+		},
+		{
+			name: "branching_cyclic_slice",
+			value: func() any {
+				s := make([]any, 2)
+				s[0] = s
+				s[1] = s
+				return s
+			}(),
+			wantValue: attribute.SliceValue(
+				attribute.StringValue("<cycle>"),
+				attribute.StringValue("<cycle>"),
+			),
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.wantValue, convertValue(tt.value))

--- a/bridges/otelzap/convert_test.go
+++ b/bridges/otelzap/convert_test.go
@@ -261,6 +261,82 @@ func TestConvertValue(t *testing.T) {
 			value:     chan int(nil),
 			wantValue: attribute.StringValue("unhandled: (chan int) <nil>"),
 		},
+		{
+			name: "cyclic_map",
+			value: func() any {
+				m := map[string]any{}
+				m["self"] = m
+				return m
+			}(),
+			wantValue: attribute.MapValue(
+				attribute.String("self", "<cycle>"),
+			),
+		},
+		{
+			name: "cyclic_slice",
+			value: func() any {
+				s := make([]any, 1)
+				s[0] = s
+				return s
+			}(),
+			wantValue: attribute.SliceValue(
+				attribute.StringValue("<cycle>"),
+			),
+		},
+		{
+			name: "cyclic_pointer",
+			value: func() any {
+				var p1, p2 any
+				p1 = &p2
+				p2 = &p1
+				return p1
+			}(),
+			wantValue: attribute.StringValue("<cycle>"),
+		},
+		{
+			name: "indirect_cyclic_map",
+			value: func() any {
+				m1 := map[string]any{}
+				m2 := map[string]any{}
+				m1["next"] = m2
+				m2["next"] = m1
+				return m1
+			}(),
+			wantValue: attribute.MapValue(
+				attribute.Map("next",
+					attribute.String("next", "<cycle>"),
+				),
+			),
+		},
+		{
+			name: "indirect_cyclic_slice",
+			value: func() any {
+				s1 := make([]any, 1)
+				s2 := make([]any, 1)
+				s1[0] = s2
+				s2[0] = s1
+				return s1
+			}(),
+			wantValue: attribute.SliceValue(
+				attribute.SliceValue(
+					attribute.StringValue("<cycle>"),
+				),
+			),
+		},
+		{
+			name: "non_cyclic_dag",
+			value: func() any {
+				shared := map[string]int{"one": 1}
+				return map[string]any{
+					"left":  shared,
+					"right": shared,
+				}
+			}(),
+			wantValue: attribute.MapValue(
+				attribute.Map("left", attribute.Int64("one", 1)),
+				attribute.Map("right", attribute.Int64("one", 1)),
+			),
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.wantValue, convertValue(tt.value))

--- a/bridges/otelzap/convert_test.go
+++ b/bridges/otelzap/convert_test.go
@@ -184,6 +184,30 @@ func TestConvertValue(t *testing.T) {
 			wantValue: attribute.SliceValue(attribute.SliceValue()),
 		},
 		{
+			name: "overlapping_subslice_non_cyclic",
+			value: func() any {
+				parent := []any{42, nil}
+				parent[1] = parent[:1]
+				return parent
+			}(),
+			wantValue: attribute.SliceValue(
+				attribute.Int64Value(42),
+				attribute.SliceValue(attribute.Int64Value(42)),
+			),
+		},
+		{
+			name: "overlapping_pointer_to_first_element_non_cyclic",
+			value: func() any {
+				parent := &[2]any{42, nil}
+				parent[1] = &parent[0]
+				return parent
+			}(),
+			wantValue: attribute.SliceValue(
+				attribute.Int64Value(42),
+				attribute.Int64Value(42),
+			),
+		},
+		{
 			name:      "int_empty_array",
 			value:     []int{},
 			wantValue: attribute.SliceValue([]attribute.Value{}...),

--- a/internal/shared/logutil/convert.go.tmpl
+++ b/internal/shared/logutil/convert.go.tmpl
@@ -11,67 +11,34 @@ import (
 	"math"
 	"reflect"
 	"strconv"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 )
 
-// convertValue converts various types to attribute.Value.
-func convertValue(v any) attribute.Value {
-	return convertValueVisited(v, nil)
+var visitedMapPool = sync.Pool{
+	New: func() any {
+		return make(map[uintptr]bool)
+	},
 }
 
-func convertValueVisited(v any, visited []uintptr) attribute.Value {
-	// Handling the most common types without reflect is a small perf win.
-	switch val := v.(type) {
-	case bool:
-		return attribute.BoolValue(val)
-	case string:
-		return attribute.StringValue(val)
-	case int:
-		return attribute.Int64Value(int64(val))
-	case int8:
-		return attribute.Int64Value(int64(val))
-	case int16:
-		return attribute.Int64Value(int64(val))
-	case int32:
-		return attribute.Int64Value(int64(val))
-	case int64:
-		return attribute.Int64Value(val)
-	case uint:
-		return convertUintValue(uint64(val))
-	case uint8:
-		return attribute.Int64Value(int64(val))
-	case uint16:
-		return attribute.Int64Value(int64(val))
-	case uint32:
-		return attribute.Int64Value(int64(val))
-	case uint64:
-		return convertUintValue(val)
-	case uintptr:
-		return convertUintValue(uint64(val))
-	case float32:
-		return attribute.Float64Value(float64(val))
-	case float64:
-		return attribute.Float64Value(val)
-	case time.Duration:
-		return attribute.Int64Value(val.Nanoseconds())
-	case complex64:
-		r := attribute.Float64("r", real(complex128(val)))
-		i := attribute.Float64("i", imag(complex128(val)))
-		return attribute.MapValue(r, i)
-	case complex128:
-		r := attribute.Float64("r", real(val))
-		i := attribute.Float64("i", imag(val))
-		return attribute.MapValue(r, i)
-	case time.Time:
-		return attribute.Int64Value(val.UnixNano())
-	case []byte:
-		return attribute.ByteSliceValue(val)
-	case error:
-		return attribute.StringValue(val.Error())
-	case attribute.Value:
-		return val
+// convertValue converts various types to attribute.Value.
+func convertValue(v any) attribute.Value {
+	if res, ok := fastConvertValue(v); ok {
+		return res
+	}
+
+	visited := visitedMapPool.Get().(map[uintptr]bool)
+	res := convertValueVisited(v, visited)
+	clear(visited)
+	visitedMapPool.Put(visited)
+	return res
+}
+
+func convertValueVisited(v any, visited map[uintptr]bool) attribute.Value {
+	if res, ok := fastConvertValue(v); ok {
+		return res
 	}
 
 	t := reflect.TypeOf(v)
@@ -83,21 +50,17 @@ func convertValueVisited(v any, visited []uintptr) attribute.Value {
 	case reflect.Struct:
 		return attribute.StringValue(fmt.Sprintf("%+v", v))
 	case reflect.Slice, reflect.Array:
-		if val.Len() == 0 {
-			return attribute.SliceValue()
-		}
 		if t.Kind() == reflect.Slice {
 			if val.IsNil() {
 				return attribute.Value{}
 			}
 			ptr := val.Pointer()
 			if ptr != 0 {
-				for _, p := range visited {
-					if p == ptr {
-						return attribute.StringValue("<cycle>")
-					}
+				if visited[ptr] {
+					return attribute.StringValue("<cycle>")
 				}
-				visited = append(visited, ptr)
+				visited[ptr] = true
+				defer delete(visited, ptr)
 			}
 		}
 		items := make([]attribute.Value, 0, val.Len())
@@ -109,17 +72,13 @@ func convertValueVisited(v any, visited []uintptr) attribute.Value {
 		if val.IsNil() {
 			return attribute.Value{}
 		}
-		if val.Len() == 0 {
-			return attribute.MapValue()
-		}
 		ptr := val.Pointer()
 		if ptr != 0 {
-			for _, p := range visited {
-				if p == ptr {
-					return attribute.StringValue("<cycle>")
-				}
+			if visited[ptr] {
+				return attribute.StringValue("<cycle>")
 			}
-			visited = append(visited, ptr)
+			visited[ptr] = true
+			defer delete(visited, ptr)
 		}
 		kvs := make([]attribute.KeyValue, 0, val.Len())
 		for _, k := range val.MapKeys() {
@@ -142,12 +101,11 @@ func convertValueVisited(v any, visited []uintptr) attribute.Value {
 		}
 		ptr := val.Pointer()
 		if ptr != 0 {
-			for _, p := range visited {
-				if p == ptr {
-					return attribute.StringValue("<cycle>")
-				}
+			if visited[ptr] {
+				return attribute.StringValue("<cycle>")
 			}
-			visited = append(visited, ptr)
+			visited[ptr] = true
+			defer delete(visited, ptr)
 		}
 		return convertValueVisited(val.Elem().Interface(), visited)
 	case reflect.Interface:
@@ -163,6 +121,61 @@ func convertValueVisited(v any, visited []uintptr) attribute.Value {
 	// asking why their attributes have a "unhandled: " prefix than
 	// say that their code is panicking.
 	return attribute.StringValue(fmt.Sprintf("unhandled: (%s) %+v", t, v))
+}
+
+// fastConvertValue handles common primitive types without reflection or pool overhead.
+func fastConvertValue(v any) (attribute.Value, bool) {
+	switch val := v.(type) {
+	case bool:
+		return attribute.BoolValue(val), true
+	case string:
+		return attribute.StringValue(val), true
+	case int:
+		return attribute.Int64Value(int64(val)), true
+	case int8:
+		return attribute.Int64Value(int64(val)), true
+	case int16:
+		return attribute.Int64Value(int64(val)), true
+	case int32:
+		return attribute.Int64Value(int64(val)), true
+	case int64:
+		return attribute.Int64Value(val), true
+	case uint:
+		return convertUintValue(uint64(val)), true
+	case uint8:
+		return attribute.Int64Value(int64(val)), true
+	case uint16:
+		return attribute.Int64Value(int64(val)), true
+	case uint32:
+		return attribute.Int64Value(int64(val)), true
+	case uint64:
+		return convertUintValue(val), true
+	case uintptr:
+		return convertUintValue(uint64(val)), true
+	case float32:
+		return attribute.Float64Value(float64(val)), true
+	case float64:
+		return attribute.Float64Value(val), true
+	case time.Duration:
+		return attribute.Int64Value(val.Nanoseconds()), true
+	case complex64:
+		r := attribute.Float64("r", real(complex128(val)))
+		i := attribute.Float64("i", imag(complex128(val)))
+		return attribute.MapValue(r, i), true
+	case complex128:
+		r := attribute.Float64("r", real(val))
+		i := attribute.Float64("i", imag(val))
+		return attribute.MapValue(r, i), true
+	case time.Time:
+		return attribute.Int64Value(val.UnixNano()), true
+	case []byte:
+		return attribute.ByteSliceValue(val), true
+	case error:
+		return attribute.StringValue(val.Error()), true
+	case attribute.Value:
+		return val, true
+	}
+	return attribute.Value{}, false
 }
 
 // convertUintValue converts a uint64 to an attribute.Value.

--- a/internal/shared/logutil/convert.go.tmpl
+++ b/internal/shared/logutil/convert.go.tmpl
@@ -50,10 +50,10 @@ func convertValueVisited(v any, visited map[uintptr]bool) attribute.Value {
 	case reflect.Struct:
 		return attribute.StringValue(fmt.Sprintf("%+v", v))
 	case reflect.Slice, reflect.Array:
+		if val.Len() == 0 {
+			return attribute.SliceValue()
+		}
 		if t.Kind() == reflect.Slice {
-			if val.IsNil() {
-				return attribute.Value{}
-			}
 			ptr := val.Pointer()
 			if ptr != 0 {
 				if visited[ptr] {
@@ -69,8 +69,8 @@ func convertValueVisited(v any, visited map[uintptr]bool) attribute.Value {
 		}
 		return attribute.SliceValue(items...)
 	case reflect.Map:
-		if val.IsNil() {
-			return attribute.Value{}
+		if val.Len() == 0 {
+			return attribute.MapValue()
 		}
 		ptr := val.Pointer()
 		if ptr != 0 {

--- a/internal/shared/logutil/convert.go.tmpl
+++ b/internal/shared/logutil/convert.go.tmpl
@@ -18,6 +18,10 @@ import (
 
 // convertValue converts various types to attribute.Value.
 func convertValue(v any) attribute.Value {
+	return convertValueVisited(v, nil)
+}
+
+func convertValueVisited(v any, visited []uintptr) attribute.Value {
 	// Handling the most common types without reflect is a small perf win.
 	switch val := v.(type) {
 	case bool:
@@ -79,12 +83,44 @@ func convertValue(v any) attribute.Value {
 	case reflect.Struct:
 		return attribute.StringValue(fmt.Sprintf("%+v", v))
 	case reflect.Slice, reflect.Array:
+		if val.Len() == 0 {
+			return attribute.SliceValue()
+		}
+		if t.Kind() == reflect.Slice {
+			if val.IsNil() {
+				return attribute.Value{}
+			}
+			ptr := val.Pointer()
+			if ptr != 0 {
+				for _, p := range visited {
+					if p == ptr {
+						return attribute.StringValue("<cycle>")
+					}
+				}
+				visited = append(visited, ptr)
+			}
+		}
 		items := make([]attribute.Value, 0, val.Len())
 		for i := range val.Len() {
-			items = append(items, convertValue(val.Index(i).Interface()))
+			items = append(items, convertValueVisited(val.Index(i).Interface(), visited))
 		}
 		return attribute.SliceValue(items...)
 	case reflect.Map:
+		if val.IsNil() {
+			return attribute.Value{}
+		}
+		if val.Len() == 0 {
+			return attribute.MapValue()
+		}
+		ptr := val.Pointer()
+		if ptr != 0 {
+			for _, p := range visited {
+				if p == ptr {
+					return attribute.StringValue("<cycle>")
+				}
+			}
+			visited = append(visited, ptr)
+		}
 		kvs := make([]attribute.KeyValue, 0, val.Len())
 		for _, k := range val.MapKeys() {
 			var key string
@@ -96,15 +132,29 @@ func convertValue(v any) attribute.Value {
 			}
 			kvs = append(kvs, attribute.KeyValue{
 				Key:   attribute.Key(key),
-				Value: convertValue(val.MapIndex(k).Interface()),
+				Value: convertValueVisited(val.MapIndex(k).Interface(), visited),
 			})
 		}
 		return attribute.MapValue(kvs...)
-	case reflect.Pointer, reflect.Interface:
+	case reflect.Pointer:
 		if val.IsNil() {
 			return attribute.Value{}
 		}
-		return convertValue(val.Elem().Interface())
+		ptr := val.Pointer()
+		if ptr != 0 {
+			for _, p := range visited {
+				if p == ptr {
+					return attribute.StringValue("<cycle>")
+				}
+			}
+			visited = append(visited, ptr)
+		}
+		return convertValueVisited(val.Elem().Interface(), visited)
+	case reflect.Interface:
+		if val.IsNil() {
+			return attribute.Value{}
+		}
+		return convertValueVisited(val.Elem().Interface(), visited)
 	}
 
 	// Try to handle this as gracefully as possible.

--- a/internal/shared/logutil/convert.go.tmpl
+++ b/internal/shared/logutil/convert.go.tmpl
@@ -17,9 +17,15 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
+type visitKey struct {
+	typ reflect.Type
+	ptr uintptr
+	len int
+}
+
 var visitedMapPool = sync.Pool{
 	New: func() any {
-		return make(map[uintptr]bool)
+		return make(map[visitKey]bool)
 	},
 }
 
@@ -29,14 +35,14 @@ func convertValue(v any) attribute.Value {
 		return res
 	}
 
-	visited := visitedMapPool.Get().(map[uintptr]bool)
+	visited := visitedMapPool.Get().(map[visitKey]bool)
 	res := convertValueVisited(v, visited)
 	clear(visited)
 	visitedMapPool.Put(visited)
 	return res
 }
 
-func convertValueVisited(v any, visited map[uintptr]bool) attribute.Value {
+func convertValueVisited(v any, visited map[visitKey]bool) attribute.Value {
 	if res, ok := fastConvertValue(v); ok {
 		return res
 	}
@@ -56,11 +62,12 @@ func convertValueVisited(v any, visited map[uintptr]bool) attribute.Value {
 		if t.Kind() == reflect.Slice {
 			ptr := val.Pointer()
 			if ptr != 0 {
-				if visited[ptr] {
+				key := visitKey{typ: t, ptr: ptr, len: val.Len()}
+				if visited[key] {
 					return attribute.StringValue("<cycle>")
 				}
-				visited[ptr] = true
-				defer delete(visited, ptr)
+				visited[key] = true
+				defer delete(visited, key)
 			}
 		}
 		items := make([]attribute.Value, 0, val.Len())
@@ -74,11 +81,12 @@ func convertValueVisited(v any, visited map[uintptr]bool) attribute.Value {
 		}
 		ptr := val.Pointer()
 		if ptr != 0 {
-			if visited[ptr] {
+			key := visitKey{typ: t, ptr: ptr}
+			if visited[key] {
 				return attribute.StringValue("<cycle>")
 			}
-			visited[ptr] = true
-			defer delete(visited, ptr)
+			visited[key] = true
+			defer delete(visited, key)
 		}
 		kvs := make([]attribute.KeyValue, 0, val.Len())
 		for _, k := range val.MapKeys() {
@@ -101,11 +109,12 @@ func convertValueVisited(v any, visited map[uintptr]bool) attribute.Value {
 		}
 		ptr := val.Pointer()
 		if ptr != 0 {
-			if visited[ptr] {
+			key := visitKey{typ: t, ptr: ptr}
+			if visited[key] {
 				return attribute.StringValue("<cycle>")
 			}
-			visited[ptr] = true
-			defer delete(visited, ptr)
+			visited[key] = true
+			defer delete(visited, key)
 		}
 		return convertValueVisited(val.Elem().Interface(), visited)
 	case reflect.Interface:

--- a/internal/shared/logutil/convert_test.go.tmpl
+++ b/internal/shared/logutil/convert_test.go.tmpl
@@ -165,6 +165,25 @@ func TestConvertValue(t *testing.T) {
 			wantValue: attribute.BoolValue(true),
 		},
 		{
+			name:      "nil_slice",
+			value:     ([]int)(nil),
+			wantValue: attribute.SliceValue(),
+		},
+		{
+			name:      "nil_map",
+			value:     (map[string]int)(nil),
+			wantValue: attribute.MapValue(),
+		},
+		{
+			name: "empty_subslice_sharing_parent_array",
+			value: func() any {
+				parent := []any{1}
+				parent[0] = parent[:0]
+				return parent
+			}(),
+			wantValue: attribute.SliceValue(attribute.SliceValue()),
+		},
+		{
 			name:      "int_empty_array",
 			value:     []int{},
 			wantValue: attribute.SliceValue([]attribute.Value{}...),

--- a/internal/shared/logutil/convert_test.go.tmpl
+++ b/internal/shared/logutil/convert_test.go.tmpl
@@ -337,6 +337,32 @@ func TestConvertValue(t *testing.T) {
 				attribute.Map("right", attribute.Int64("one", 1)),
 			),
 		},
+		{
+			name: "branching_cyclic_map",
+			value: func() any {
+				m := map[string]any{}
+				m["a"] = m
+				m["b"] = m
+				return m
+			}(),
+			wantValue: attribute.MapValue(
+				attribute.String("a", "<cycle>"),
+				attribute.String("b", "<cycle>"),
+			),
+		},
+		{
+			name: "branching_cyclic_slice",
+			value: func() any {
+				s := make([]any, 2)
+				s[0] = s
+				s[1] = s
+				return s
+			}(),
+			wantValue: attribute.SliceValue(
+				attribute.StringValue("<cycle>"),
+				attribute.StringValue("<cycle>"),
+			),
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.wantValue, convertValue(tt.value))

--- a/internal/shared/logutil/convert_test.go.tmpl
+++ b/internal/shared/logutil/convert_test.go.tmpl
@@ -261,6 +261,82 @@ func TestConvertValue(t *testing.T) {
 			value:     chan int(nil),
 			wantValue: attribute.StringValue("unhandled: (chan int) <nil>"),
 		},
+		{
+			name: "cyclic_map",
+			value: func() any {
+				m := map[string]any{}
+				m["self"] = m
+				return m
+			}(),
+			wantValue: attribute.MapValue(
+				attribute.String("self", "<cycle>"),
+			),
+		},
+		{
+			name: "cyclic_slice",
+			value: func() any {
+				s := make([]any, 1)
+				s[0] = s
+				return s
+			}(),
+			wantValue: attribute.SliceValue(
+				attribute.StringValue("<cycle>"),
+			),
+		},
+		{
+			name: "cyclic_pointer",
+			value: func() any {
+				var p1, p2 any
+				p1 = &p2
+				p2 = &p1
+				return p1
+			}(),
+			wantValue: attribute.StringValue("<cycle>"),
+		},
+		{
+			name: "indirect_cyclic_map",
+			value: func() any {
+				m1 := map[string]any{}
+				m2 := map[string]any{}
+				m1["next"] = m2
+				m2["next"] = m1
+				return m1
+			}(),
+			wantValue: attribute.MapValue(
+				attribute.Map("next",
+					attribute.String("next", "<cycle>"),
+				),
+			),
+		},
+		{
+			name: "indirect_cyclic_slice",
+			value: func() any {
+				s1 := make([]any, 1)
+				s2 := make([]any, 1)
+				s1[0] = s2
+				s2[0] = s1
+				return s1
+			}(),
+			wantValue: attribute.SliceValue(
+				attribute.SliceValue(
+					attribute.StringValue("<cycle>"),
+				),
+			),
+		},
+		{
+			name: "non_cyclic_dag",
+			value: func() any {
+				shared := map[string]int{"one": 1}
+				return map[string]any{
+					"left":  shared,
+					"right": shared,
+				}
+			}(),
+			wantValue: attribute.MapValue(
+				attribute.Map("left", attribute.Int64("one", 1)),
+				attribute.Map("right", attribute.Int64("one", 1)),
+			),
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.wantValue, convertValue(tt.value))

--- a/internal/shared/logutil/convert_test.go.tmpl
+++ b/internal/shared/logutil/convert_test.go.tmpl
@@ -184,6 +184,30 @@ func TestConvertValue(t *testing.T) {
 			wantValue: attribute.SliceValue(attribute.SliceValue()),
 		},
 		{
+			name: "overlapping_subslice_non_cyclic",
+			value: func() any {
+				parent := []any{42, nil}
+				parent[1] = parent[:1]
+				return parent
+			}(),
+			wantValue: attribute.SliceValue(
+				attribute.Int64Value(42),
+				attribute.SliceValue(attribute.Int64Value(42)),
+			),
+		},
+		{
+			name: "overlapping_pointer_to_first_element_non_cyclic",
+			value: func() any {
+				parent := &[2]any{42, nil}
+				parent[1] = &parent[0]
+				return parent
+			}(),
+			wantValue: attribute.SliceValue(
+				attribute.Int64Value(42),
+				attribute.Int64Value(42),
+			),
+		},
+		{
 			name:      "int_empty_array",
 			value:     []int{},
 			wantValue: attribute.SliceValue([]attribute.Value{}...),


### PR DESCRIPTION
## Description

When converting logged map, slice, array, pointer, and interface values into OpenTelemetry `attribute.Value` instances, the shared converter (`internal/shared/logutil/convert.go.tmpl`) recursively walked composite structures without cycle detection. Passing a cyclic value (such as `m := map[string]any{}; m["self"] = m`) resulted in unbounded recursion and process stack overflow crashes.

### Key Changes
- **Path-Local Cycle Detection (`visited []uintptr`)**: Added active ancestor pointer tracking during recursive traversal of `reflect.Slice`, `reflect.Map`, and `reflect.Pointer`.
- **DAG Compatibility**: Active pointers unwind automatically when recursing back up the stack via Go slice value semantics, allowing non-cyclic shared subtrees in Directed Acyclic Graphs (DAGs) to convert cleanly without false positives.
- **Safe Fallback**: Converts detected cyclic references to `attribute.StringValue("<cycle>")`.
- **Zero-Allocation for Primitives & Empty Collections**:
  - Primitive log attributes return immediately without reflect or pointer tracking.
  - Early-return optimization for empty collections (`val.Len() == 0`) bypasses `val.Pointer()` lookups and avoids any interaction with Go runtime `zerobase` addresses.
- **Generated Modules Updated**: Regenerated code and added comprehensive unit tests for `otellogr`, `otellogrus`, `otelslog`, and `otelzap`.

---

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

---

## Testing
Added unit tests in `convert_test.go` for all bridge modules covering:
- Direct cyclic map (`m["self"] = m`)
- Direct cyclic slice (`s[0] = s`)
- Direct cyclic pointers (`p1 -> p2 -> p1`)
- Indirect cyclic maps & slices (`m1 -> m2 -> m1`)
- Non-cyclic shared DAG maps (`left: shared, right: shared`)

#### Fixes: #9044  