### PR TITLE
otelconf: register Prometheus reader with a MeterProvider in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Report `ot-baggage-*` extraction errors from `go.opentelemetry.io/contrib/propagators/ot` to `otel.Handle` instead of silently discarding them, while still attaching the successfully parsed baggage members to the context. (#9395)
 - Set `error.type` on the `rpc.client.call.duration` and `rpc.server.call.duration` metrics in `go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc` when the RPC fails with a non-OK status, per the RPC semantic conventions. (#9429)
 - Reject OTLP exporter headers with an empty `name` in `go.opentelemetry.io/contrib/otelconf`, `go.opentelemetry.io/contrib/otelconf/x`, and `go.opentelemetry.io/contrib/otelconf/v0.3.0`, instead of forwarding invalid header names to OTLP exporters. (#9102)
-- Register the Prometheus reader with a `sdkmetric.MeterProvider` in the `go.opentelemetry.io/contrib/otelconf` and `go.opentelemetry.io/contrib/otelconf/v0.3.0` test suites, removing a noisy "reader is not registered" error logged to stderr during test runs. (#9475)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Report `ot-baggage-*` extraction errors from `go.opentelemetry.io/contrib/propagators/ot` to `otel.Handle` instead of silently discarding them, while still attaching the successfully parsed baggage members to the context. (#9395)
 - Set `error.type` on the `rpc.client.call.duration` and `rpc.server.call.duration` metrics in `go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc` when the RPC fails with a non-OK status, per the RPC semantic conventions. (#9429)
 - Reject OTLP exporter headers with an empty `name` in `go.opentelemetry.io/contrib/otelconf`, `go.opentelemetry.io/contrib/otelconf/x`, and `go.opentelemetry.io/contrib/otelconf/v0.3.0`, instead of forwarding invalid header names to OTLP exporters. (#9102)
+- Register the Prometheus reader with a `sdkmetric.MeterProvider` in the `go.opentelemetry.io/contrib/otelconf` and `go.opentelemetry.io/contrib/otelconf/v0.3.0` test suites, removing a noisy "reader is not registered" error logged to stderr during test runs. (#9475)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/otelconf/v0.2.0/metric_test.go
+++ b/otelconf/v0.2.0/metric_test.go
@@ -1201,11 +1201,15 @@ func TestPrometheusIPv6(t *testing.T) {
 			}
 
 			rs, err := prometheusReader(t.Context(), &cfg)
+			require.NoError(t, err)
+
+			// Register the reader with a MeterProvider so that scraping
+			// /metrics below does not log a "reader is not registered" error.
+			mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(rs))
 			t.Cleanup(func() {
 				//nolint:usetesting // required to avoid getting a canceled context at cleanup.
-				require.NoError(t, rs.Shutdown(context.Background()))
+				require.NoError(t, mp.Shutdown(context.Background()))
 			})
-			require.NoError(t, err)
 
 			hServ := rs.(readerWithServer).server
 			assert.True(t, strings.HasPrefix(hServ.Addr, "[::1]:"))
@@ -1293,9 +1297,12 @@ func TestPrometheusReaderConfigurationOptions(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, reader)
 
+	// Register the reader with a MeterProvider so that scraping /metrics
+	// below does not log a "reader is not registered" error.
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	t.Cleanup(func() {
 		//nolint:usetesting // required to avoid getting a canceled context at cleanup.
-		require.NoError(t, reader.Shutdown(context.Background()))
+		require.NoError(t, mp.Shutdown(context.Background()))
 	})
 
 	rws, ok := reader.(readerWithServer)

--- a/otelconf/v0.3.0/metric_test.go
+++ b/otelconf/v0.3.0/metric_test.go
@@ -1436,8 +1436,6 @@ func TestPrometheusIPv6(t *testing.T) {
 			rs, err := prometheusReader(t.Context(), &cfg)
 			require.NoError(t, err)
 
-			// Register the reader with a MeterProvider so that scraping
-			// /metrics below does not log a "reader is not registered" error.
 			mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(rs))
 			t.Cleanup(func() {
 				//nolint:usetesting // required to avoid getting a canceled context at cleanup.
@@ -1576,8 +1574,6 @@ func TestPrometheusReaderConfigurationOptions(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, reader)
 
-	// Register the reader with a MeterProvider so that scraping /metrics
-	// below does not log a "reader is not registered" error.
 	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	t.Cleanup(func() {
 		//nolint:usetesting // required to avoid getting a canceled context at cleanup.

--- a/otelconf/v0.3.0/metric_test.go
+++ b/otelconf/v0.3.0/metric_test.go
@@ -1434,11 +1434,15 @@ func TestPrometheusIPv6(t *testing.T) {
 			}
 
 			rs, err := prometheusReader(t.Context(), &cfg)
+			require.NoError(t, err)
+
+			// Register the reader with a MeterProvider so that scraping
+			// /metrics below does not log a "reader is not registered" error.
+			mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(rs))
 			t.Cleanup(func() {
 				//nolint:usetesting // required to avoid getting a canceled context at cleanup.
-				require.NoError(t, rs.Shutdown(context.Background()))
+				require.NoError(t, mp.Shutdown(context.Background()))
 			})
-			require.NoError(t, err)
 
 			hServ := rs.(readerWithServer).server
 			assert.True(t, strings.HasPrefix(hServ.Addr, "[::1]:"))
@@ -1572,9 +1576,12 @@ func TestPrometheusReaderConfigurationOptions(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, reader)
 
+	// Register the reader with a MeterProvider so that scraping /metrics
+	// below does not log a "reader is not registered" error.
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	t.Cleanup(func() {
 		//nolint:usetesting // required to avoid getting a canceled context at cleanup.
-		require.NoError(t, reader.Shutdown(context.Background()))
+		require.NoError(t, mp.Shutdown(context.Background()))
 	})
 
 	rws, ok := reader.(readerWithServer)

--- a/otelconf/x/metric_test.go
+++ b/otelconf/x/metric_test.go
@@ -1617,8 +1617,6 @@ func TestPrometheusIPv6(t *testing.T) {
 			rs, err := prometheusReader(t.Context(), &cfg)
 			require.NoError(t, err)
 
-			// Register the reader with a MeterProvider so that scraping
-			// /metrics below does not log a "reader is not registered" error.
 			mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(rs))
 			t.Cleanup(func() {
 				//nolint:usetesting // required to avoid getting a canceled context at cleanup.

--- a/otelconf/x/metric_test.go
+++ b/otelconf/x/metric_test.go
@@ -1615,11 +1615,15 @@ func TestPrometheusIPv6(t *testing.T) {
 			}
 
 			rs, err := prometheusReader(t.Context(), &cfg)
+			require.NoError(t, err)
+
+			// Register the reader with a MeterProvider so that scraping
+			// /metrics below does not log a "reader is not registered" error.
+			mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(rs))
 			t.Cleanup(func() {
 				//nolint:usetesting // required to avoid getting a canceled context at cleanup.
-				require.NoError(t, rs.Shutdown(context.Background()))
+				require.NoError(t, mp.Shutdown(context.Background()))
 			})
-			require.NoError(t, err)
 
 			hServ := rs.(readerWithServer).server
 			assert.True(t, strings.HasPrefix(hServ.Addr, "[::1]:"))


### PR DESCRIPTION
These Prometheus tests were passing, but they were also printing a misleading `reader is not registered` error whenever `/metrics` was scraped.

The tests were creating the Prometheus reader directly without registering it with a `MeterProvider`. I changed them to create a `MeterProvider` with the reader before scraping, which is also how this is expected to be used normally.

This is test-only and doesn't change production behavior.

I ran the tests for both otelconf versions with race detection, along with build, vet and lint, and confirmed the warning is gone.

AI assistance: I used AI tools while investigating this and preparing the change; I have reviewed and tested it myself.

Fixes #7641