### PR TITLE
Reduce the semconv v1.37.0 import scope

### DIFF
--- a/instrumentation/google.golang.org/grpc/otelgrpc/internal/parse.go
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/internal/parse.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"go.opentelemetry.io/otel/attribute"
-	oldsemconv "go.opentelemetry.io/otel/semconv/v1.37.0" //nolint:depguard // Use of v1.37.0 is required for backward compatibility stability opt-in.
 	semconv "go.opentelemetry.io/otel/semconv/v1.43.0"
 )
 
@@ -45,9 +44,10 @@ func ParseFullMethodOld(fullMethod string) (string, []attribute.KeyValue) {
 	}
 	service := parts[0]
 	method := parts[1]
+	// Attributes defined in semconv v1.37.0
 	return name, []attribute.KeyValue{
-		oldsemconv.RPCSystemKey.String("grpc"),
-		oldsemconv.RPCServiceKey.String(service),
-		oldsemconv.RPCMethodKey.String(method),
+		attribute.Key("rpc.system").String("grpc"),
+		attribute.Key("rpc.service").String(service),
+		attribute.Key("rpc.method").String(method),
 	}
 }


### PR DESCRIPTION
In ParseFullMethodOld, the only use of semconv/v1.37.0 is to retrieve three attribute definitions. Since they are referenced for backward compatibility only, and won't change in the future, they can be defined in situ, which eliminates the only use of the full semconv/v1.37.0 package. semconv/v1.37.0/rpcconv is still required for otelgrpc but is much smaller.

This reduces the impact of importing otelgrpc in downstream projects using newer semconv versions.