### PR TITLE
Support Go 1.27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   # backwards compatibility with the previous two minor releases and we
   # explicitly test our code for these versions so keeping this at prior
   # versions does not add value.
-  DEFAULT_GO_VERSION: "~1.26.0"
+  DEFAULT_GO_VERSION: "~1.27.0"
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -139,7 +139,7 @@ jobs:
   compatibility-test:
     strategy:
       matrix:
-        go-version: ["1.26.0", "1.25.0"]
+        go-version: ["1.27.0", "1.26.0", "1.25.0"]
         platform:
           - os: ubuntu-latest
             arch: "386"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The next release will require at least [Go 1.26].
 ### Added
 
 - Add support for the `aws.ec2` resource detector in `go.opentelemetry.io/contrib/otelconf/x`. (#9139)
-- Support testing of [Go 1.27].
+- Support testing of [Go 1.27]. (#9524)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+This release is the last to support [Go 1.25].
+The next release will require at least [Go 1.26].
+
 ### Added
 
 - Add support for the `aws.ec2` resource detector in `go.opentelemetry.io/contrib/otelconf/x`. (#9139)
+- Support testing of [Go 1.27].
 
 ### Fixed
 
@@ -1933,6 +1937,7 @@ First official tagged release of `contrib` repository.
 
 <!-- Released section ended -->
 
+[Go 1.27]: https://go.dev/doc/go1.27
 [Go 1.26]: https://go.dev/doc/go1.26
 [Go 1.25]: https://go.dev/doc/go1.25
 [Go 1.24]: https://go.dev/doc/go1.24

--- a/README.md
+++ b/README.md
@@ -52,16 +52,22 @@ This project is tested on the following systems.
 
 | OS       | Go Version | Architecture |
 | -------- | ---------- | ------------ |
+| Ubuntu   | 1.27       | amd64        |
 | Ubuntu   | 1.26       | amd64        |
 | Ubuntu   | 1.25       | amd64        |
+| Ubuntu   | 1.27       | 386          |
 | Ubuntu   | 1.26       | 386          |
 | Ubuntu   | 1.25       | 386          |
+| macOS    | 1.27       | amd64        |
 | macOS    | 1.26       | amd64        |
 | macOS    | 1.25       | amd64        |
+| macOS    | 1.27       | arm64        |
 | macOS    | 1.26       | arm64        |
 | macOS    | 1.25       | arm64        |
+| Windows  | 1.27       | amd64        |
 | Windows  | 1.26       | amd64        |
 | Windows  | 1.25       | amd64        |
+| Windows  | 1.27       | 386          |
 | Windows  | 1.26       | 386          |
 | Windows  | 1.25       | 386          |
 

--- a/otelconf/v0.3.0/config_test.go
+++ b/otelconf/v0.3.0/config_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -551,7 +552,7 @@ func TestSerializeJSON(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
-		wantErr  error
+		wantErr  []error
 		wantType any
 	}{
 		{
@@ -566,22 +567,25 @@ func TestSerializeJSON(t *testing.T) {
 		{
 			name:    "invalid config",
 			input:   "invalid_bool.json",
-			wantErr: errors.New(`json: cannot unmarshal string into Go struct field Plain.disabled of type bool`),
+			wantErr: []error{errors.New(`json: cannot unmarshal string into Go struct field Plain.disabled of type bool`)},
 		},
 		{
 			name:    "invalid nil name",
 			input:   "invalid_nil_name.json",
-			wantErr: errors.New(`json: cannot unmarshal field name in NameStringValuePair required`),
+			wantErr: []error{errors.New(`json: cannot unmarshal field name in NameStringValuePair required`)},
 		},
 		{
 			name:    "invalid nil value",
 			input:   "invalid_nil_value.json",
-			wantErr: errors.New(`json: cannot unmarshal field value in NameStringValuePair required`),
+			wantErr: []error{errors.New(`json: cannot unmarshal field value in NameStringValuePair required`)},
 		},
 		{
-			name:    "valid v0.2 config",
-			input:   "v0.2.json",
-			wantErr: errors.New(`json: cannot unmarshal object into Go struct field LogRecordProcessor.logger_provider.processors.batch`),
+			name:  "valid v0.2 config",
+			input: "v0.2.json",
+			wantErr: []error{
+				errors.New(`json: cannot unmarshal object into Go struct field LogRecordProcessor.logger_provider.processors.batch`),
+				errors.New(`json: cannot unmarshal object into Go struct field Plain.headers of type []otelconf.NameStringValuePair`),
+			},
 		},
 		{
 			name:     "valid v0.3 config",
@@ -600,7 +604,14 @@ func TestSerializeJSON(t *testing.T) {
 
 			if tt.wantErr != nil {
 				require.Error(t, err)
-				require.ErrorContains(t, err, tt.wantErr.Error())
+				require.Condition(t, func() bool {
+					for _, wantErr := range tt.wantErr {
+						if strings.Contains(err.Error(), wantErr.Error()) {
+							return true
+						}
+					}
+					return false
+				}, "error %q does not contain any expected message: %v", err, tt.wantErr)
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, tt.wantType, got)


### PR DESCRIPTION
Updates CI to use Go 1.27, adds Go 1.27 to compatibility testing and the supported-environments table, and announces that this release is the last to support Go 1.25.

The next release will require at least Go 1.26.

This also makes the v0.3.0 JSON compatibility test accept the two errors Go 1.25–1.27 may report first.

See also https://github.com/open-telemetry/opentelemetry-go/pull/8811