### PR TITLE
fix(bridges/prometheus): keep explicitly supplied epoch sample timestamps

### DIFF
--- a/bridges/prometheus/producer.go
+++ b/bridges/prometheus/producer.go
@@ -132,7 +132,9 @@ func convertGauge(metrics []*dto.Metric, now time.Time) metricdata.Gauge[float64
 			Time:       now,
 			Value:      m.GetGauge().GetValue(),
 		}
-		if m.GetTimestampMs() != 0 {
+		// The getter conflates an absent timestamp with an explicit Unix
+		// epoch (0), so presence must be checked on the field itself (#9539).
+		if m.TimestampMs != nil {
 			dp.Time = time.UnixMilli(m.GetTimestampMs())
 		}
 		otelGauge.DataPoints[i] = dp
@@ -150,7 +152,9 @@ func convertUntyped(metrics []*dto.Metric, now time.Time) metricdata.Gauge[float
 			Time:       now,
 			Value:      m.GetUntyped().GetValue(),
 		}
-		if m.GetTimestampMs() != 0 {
+		// The getter conflates an absent timestamp with an explicit Unix
+		// epoch (0), so presence must be checked on the field itself (#9539).
+		if m.TimestampMs != nil {
 			dp.Time = time.UnixMilli(m.GetTimestampMs())
 		}
 		otelGauge.DataPoints[i] = dp
@@ -178,7 +182,9 @@ func convertCounter(metrics []*dto.Metric, now time.Time) metricdata.Sum[float64
 		if createdTs.IsValid() {
 			dp.StartTime = createdTs.AsTime()
 		}
-		if m.GetTimestampMs() != 0 {
+		// The getter conflates an absent timestamp with an explicit Unix
+		// epoch (0), so presence must be checked on the field itself (#9539).
+		if m.TimestampMs != nil {
 			dp.Time = time.UnixMilli(m.GetTimestampMs())
 		}
 		otelCounter.DataPoints[i] = dp
@@ -215,8 +221,10 @@ func convertExponentialHistogram(metrics []*dto.Metric, now time.Time) metricdat
 		if createdTs.IsValid() {
 			dp.StartTime = createdTs.AsTime()
 		}
-		if t := m.GetTimestampMs(); t != 0 {
-			dp.Time = time.UnixMilli(t)
+		// The getter conflates an absent timestamp with an explicit Unix
+		// epoch (0), so presence must be checked on the field itself (#9539).
+		if m.TimestampMs != nil {
+			dp.Time = time.UnixMilli(m.GetTimestampMs())
 		}
 		otelExpHistogram.DataPoints[i] = dp
 	}
@@ -288,7 +296,9 @@ func convertHistogram(metrics []*dto.Metric, now time.Time) metricdata.Histogram
 		if createdTs.IsValid() {
 			dp.StartTime = createdTs.AsTime()
 		}
-		if m.GetTimestampMs() != 0 {
+		// The getter conflates an absent timestamp with an explicit Unix
+		// epoch (0), so presence must be checked on the field itself (#9539).
+		if m.TimestampMs != nil {
 			dp.Time = time.UnixMilli(m.GetTimestampMs())
 		}
 		otelHistogram.DataPoints[i] = dp
@@ -353,8 +363,10 @@ func convertSummary(metrics []*dto.Metric, now time.Time) metricdata.Summary {
 		if createdTs.IsValid() {
 			dp.StartTime = createdTs.AsTime()
 		}
-		if t := m.GetTimestampMs(); t != 0 {
-			dp.Time = time.UnixMilli(t)
+		// The getter conflates an absent timestamp with an explicit Unix
+		// epoch (0), so presence must be checked on the field itself (#9539).
+		if m.TimestampMs != nil {
+			dp.Time = time.UnixMilli(m.GetTimestampMs())
 		}
 		otelSummary.DataPoints[i] = dp
 	}

--- a/bridges/prometheus/producer_test.go
+++ b/bridges/prometheus/producer_test.go
@@ -679,3 +679,70 @@ type gathererFunc func() ([]*dto.MetricFamily, error)
 func (f gathererFunc) Gather() ([]*dto.MetricFamily, error) {
 	return f()
 }
+
+func TestConvertersExplicitEpochTimestamp(t *testing.T) {
+	// Prometheus samples may explicitly carry a Unix epoch timestamp (0).
+	// The proto getter returns 0 both for an absent field and for this
+	// explicit value, so presence used to be detected with != 0 and epoch
+	// timestamps were replaced with the production time (#9539).
+	epoch := int64(0)
+	now := time.Unix(1720000000, 0) // deliberately not the epoch
+
+	metrics := []*dto.Metric{
+		{TimestampMs: &epoch, Gauge: &dto.Gauge{}},
+		{TimestampMs: &epoch, Untyped: &dto.Untyped{}},
+		{TimestampMs: &epoch, Counter: &dto.Counter{}},
+		{TimestampMs: &epoch, Summary: &dto.Summary{}},
+		{TimestampMs: &epoch, Histogram: &dto.Histogram{}},
+	}
+
+	expectEpoch := func(t *testing.T, name string, got time.Time) {
+		t.Helper()
+		if !got.Equal(time.UnixMilli(epoch)) {
+			t.Errorf("%s: expected explicit epoch timestamp %v, got %v", name, time.UnixMilli(epoch), got)
+		}
+	}
+
+	t.Run("gauge", func(t *testing.T) {
+		out := convertGauge(metrics[0:1], now)
+		expectEpoch(t, "gauge", out.DataPoints[0].Time)
+	})
+	t.Run("untyped", func(t *testing.T) {
+		out := convertUntyped(metrics[1:2], now)
+		expectEpoch(t, "untyped", out.DataPoints[0].Time)
+	})
+	t.Run("counter", func(t *testing.T) {
+		out := convertCounter(metrics[2:3], now)
+		expectEpoch(t, "counter", out.DataPoints[0].Time)
+	})
+	t.Run("summary", func(t *testing.T) {
+		out := convertSummary(metrics[3:4], now)
+		expectEpoch(t, "summary", out.DataPoints[0].Time)
+	})
+	t.Run("exponential histogram", func(t *testing.T) {
+		out := convertExponentialHistogram(metrics[4:5], now)
+		expectEpoch(t, "exponential histogram", out.DataPoints[0].Time)
+	})
+	t.Run("histogram", func(t *testing.T) {
+		out := convertHistogram(metrics[4:5], now)
+		expectEpoch(t, "histogram", out.DataPoints[0].Time)
+	})
+}
+
+func TestConvertersAbsentTimestampUsesProductionTime(t *testing.T) {
+	now := time.Unix(1720000000, 0)
+
+	metrics := []*dto.Metric{
+		{Gauge: &dto.Gauge{}},
+		{Counter: &dto.Counter{}},
+	}
+
+	gauge := convertGauge(metrics[0:1], now)
+	if !gauge.DataPoints[0].Time.Equal(now) {
+		t.Errorf("gauge: expected production time %v, got %v", now, gauge.DataPoints[0].Time)
+	}
+	counter := convertCounter(metrics[1:2], now)
+	if !counter.DataPoints[0].Time.Equal(now) {
+		t.Errorf("counter: expected production time %v, got %v", now, counter.DataPoints[0].Time)
+	}
+}


### PR DESCRIPTION
Fixes #9539.

## Summary

Every Prometheus-to-OTLP converter in `bridges/prometheus` decided whether a sample carries an explicit timestamp with `m.GetTimestampMs() != 0`. The generated getter returns `0` **both** when the field is absent and when it is explicitly set to Unix epoch, so an explicitly supplied epoch timestamp was treated as absent and silently replaced with the time of `Produce` — contrary to the [Prometheus compatibility specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/compatibility/prometheus_and_openmetrics.md#timestamps), which requires a present sample timestamp to become the OTLP data point timestamp.

All six converters now check the field itself (`m.TimestampMs != nil`):

- `convertGauge`, `convertUntyped`, `convertCounter` (simple form)
- `convertExponentialHistogram`, `convertSummary` (the `if t := ...; t != 0` form)
- plus `convertHistogram`, which used the same idiom

Absent timestamps still fall back to the production time, unchanged.

## Testing

Added `TestConvertersExplicitEpochTimestamp` — builds `dto.Metric` values with `TimestampMs` explicitly set to `0` and asserts every converter keeps `time.UnixMilli(0)` instead of the (deliberately non-epoch) production time — and `TestConvertersAbsentTimestampUsesProductionTime`, pinning the absent-field behavior.

- With the fix: `go test . -run TestConverters` → 8/8 pass, full module suite `go test .` → ok, `gofmt` clean.
- Differential on unpatched `producer.go`: the epoch test fails on all converters.
