### PR TITLE
fix(ci): resolve root-level CODEOWNERS paths in owner-ping workflow

### DIFF
--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -97,10 +97,10 @@ jobs:
               ns = `sampler: ${sanitize(m[1])}`;
             } else if (/^autoexporter$/i.test(component.trim())) {
               area = 'area: exporter';
-              ns = 'exporter: autoexport';
+              ns = 'exporter: exporters/autoexport';
             } else if (/^zpages$/i.test(component.trim())) {
               area = 'area: zpages';
-              ns = 'zpages';
+              ns = 'zpages: zpages';
             } else if (/^config$/i.test(component.trim())) {
               area = 'area: file-config';
               ns = '';

--- a/tools/ping_codeowners_issues.sh
+++ b/tools/ping_codeowners_issues.sh
@@ -18,7 +18,7 @@ CUR_DIRECTORY=$(dirname "$0")
 # Extract the component name (the part after ': ') and resolve the full path
 # from CODEOWNERS, since get-codeowners.sh matches by path prefix.
 COMPONENT_NAME=$(echo "${COMPONENT}" | sed 's/^[^:]*:[[:space:]]*//')
-COMPONENT_PATH=$(grep -F "/${COMPONENT_NAME}/" "${CUR_DIRECTORY}/../CODEOWNERS" | awk '{ print $1 }' | sed 's|/$||' | head -1 || true)
+COMPONENT_PATH=$(grep -E "(^|/)${COMPONENT_NAME}(/|[[:space:]])" "${CUR_DIRECTORY}/../CODEOWNERS" | awk '{ print $1 }' | sed 's|/$||' | head -1 || true)
 
 if [[ -z "${COMPONENT_PATH}" ]]; then
     exit 0


### PR DESCRIPTION
Fixes: #9050

The issue owner-ping workflow could miss owners for AutoExporter and zPages because their generated labels did not map cleanly to the corresponding CODEOWNERS paths.

This change:

Renames the generated labels to:
exporter: exporters/autoexport
zpages: zpages
Updates the CODEOWNERS path matcher to support repository-root paths and directory boundaries.