### PR TITLE
fix(otelconf): use map[string]any for AdditionalProperties remain field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- Change the `AdditionalProperties` field on generated config structs from `interface{}` to `map[string]any` in `go.opentelemetry.io/contrib/otelconf` and `go.opentelemetry.io/contrib/otelconf/x`, so structs tagged `mapstructure:",remain"` can be decoded with `github.com/go-viper/mapstructure/v2` instead of panicking.
+
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->
 

--- a/otelconf/config_test.go
+++ b/otelconf/config_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	lognoop "go.opentelemetry.io/otel/log/noop"
@@ -2082,4 +2083,15 @@ func TestUnmarshalResourceJson(t *testing.T) {
 			assert.Equal(t, tt.wantResource, r)
 		})
 	}
+}
+
+func TestMapstructureDecodeAdditionalProperties(t *testing.T) {
+	raw := map[string]any{
+		"opencensus": map[string]any{},
+		"extra_key":  "value",
+	}
+
+	var cfg MetricProducer
+	require.NoError(t, mapstructure.Decode(raw, &cfg))
+	assert.Equal(t, map[string]any{"extra_key": "value"}, cfg.AdditionalProperties)
 }

--- a/otelconf/generated_config.go
+++ b/otelconf/generated_config.go
@@ -535,7 +535,7 @@ type LogRecordExporter struct {
 	//
 	OTLPHttp *OTLPHttpExporter `json:"otlp_http,omitempty,omitzero" yaml:"otlp_http,omitempty" mapstructure:"otlp_http,omitempty"`
 
-	AdditionalProperties interface{} `mapstructure:",remain"`
+	AdditionalProperties map[string]any `mapstructure:",remain"`
 }
 
 type LogRecordLimits struct {
@@ -577,7 +577,7 @@ type LogRecordProcessor struct {
 	//
 	Simple *SimpleLogRecordProcessor `json:"simple,omitempty,omitzero" yaml:"simple,omitempty" mapstructure:"simple,omitempty"`
 
-	AdditionalProperties interface{} `mapstructure:",remain"`
+	AdditionalProperties map[string]any `mapstructure:",remain"`
 }
 
 type LoggerProvider struct {
@@ -624,7 +624,7 @@ type MetricProducer struct {
 	//
 	Opencensus OpenCensusMetricProducer `json:"opencensus,omitempty,omitzero" yaml:"opencensus,omitempty" mapstructure:"opencensus,omitempty"`
 
-	AdditionalProperties interface{} `mapstructure:",remain"`
+	AdditionalProperties map[string]any `mapstructure:",remain"`
 }
 
 type MetricReader struct {
@@ -1075,7 +1075,7 @@ type OpenTelemetryConfiguration struct {
 	//
 	TracerProvider *TracerProvider `json:"tracer_provider,omitempty,omitzero" yaml:"tracer_provider,omitempty" mapstructure:"tracer_provider,omitempty"`
 
-	AdditionalProperties interface{} `mapstructure:",remain"`
+	AdditionalProperties map[string]any `mapstructure:",remain"`
 }
 
 // Configure if the SDK is disabled or not.
@@ -1188,7 +1188,7 @@ type Propagator struct {
 type PropagatorCompositeList *string
 
 type PullMetricExporter struct {
-	AdditionalProperties interface{} `mapstructure:",remain"`
+	AdditionalProperties map[string]any `mapstructure:",remain"`
 }
 
 type PullMetricReader struct {
@@ -1224,7 +1224,7 @@ type PushMetricExporter struct {
 	//
 	OTLPHttp *OTLPHttpMetricExporter `json:"otlp_http,omitempty,omitzero" yaml:"otlp_http,omitempty" mapstructure:"otlp_http,omitempty"`
 
-	AdditionalProperties interface{} `mapstructure:",remain"`
+	AdditionalProperties map[string]any `mapstructure:",remain"`
 }
 
 type Resource struct {
@@ -1284,7 +1284,7 @@ type Sampler struct {
 	//
 	TraceIDRatioBased *TraceIDRatioBasedSampler `json:"trace_id_ratio_based,omitempty,omitzero" yaml:"trace_id_ratio_based,omitempty" mapstructure:"trace_id_ratio_based,omitempty"`
 
-	AdditionalProperties interface{} `mapstructure:",remain"`
+	AdditionalProperties map[string]any `mapstructure:",remain"`
 }
 
 type SeverityNumber string
@@ -1344,7 +1344,7 @@ type SpanExporter struct {
 	//
 	OTLPHttp *OTLPHttpExporter `json:"otlp_http,omitempty,omitzero" yaml:"otlp_http,omitempty" mapstructure:"otlp_http,omitempty"`
 
-	AdditionalProperties interface{} `mapstructure:",remain"`
+	AdditionalProperties map[string]any `mapstructure:",remain"`
 }
 
 type SpanKind string
@@ -1438,7 +1438,7 @@ type SpanProcessor struct {
 	//
 	Simple *SimpleSpanProcessor `json:"simple,omitempty,omitzero" yaml:"simple,omitempty" mapstructure:"simple,omitempty"`
 
-	AdditionalProperties interface{} `mapstructure:",remain"`
+	AdditionalProperties map[string]any `mapstructure:",remain"`
 }
 
 type SumAggregation map[string]interface{}
@@ -1474,7 +1474,7 @@ type TextMapPropagator struct {
 	//
 	Tracecontext TraceContextPropagator `json:"tracecontext,omitempty,omitzero" yaml:"tracecontext,omitempty" mapstructure:"tracecontext,omitempty"`
 
-	AdditionalProperties interface{} `mapstructure:",remain"`
+	AdditionalProperties map[string]any `mapstructure:",remain"`
 }
 
 type TraceContextPropagator map[string]interface{}

--- a/otelconf/go.mod
+++ b/otelconf/go.mod
@@ -3,6 +3,7 @@ module go.opentelemetry.io/contrib/otelconf
 go 1.25.0
 
 require (
+	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/prometheus/client_golang v1.24.1
 	github.com/prometheus/otlptranslator v1.0.0
 	github.com/stretchr/testify v1.12.1

--- a/otelconf/go.sum
+++ b/otelconf/go.sum
@@ -79,6 +79,8 @@ github.com/go-openapi/swag/typeutils v0.28.0 h1:nRBKSBXjDgf01VDPB3fWeD9nQuhCOVeI
 github.com/go-openapi/swag/typeutils v0.28.0/go.mod h1:Srm0xFNRZ1Y+vCxJclo5qzx8aj+1pAKda/YfFPrG0dQ=
 github.com/go-openapi/swag/yamlutils v0.28.0 h1:TV3JXH6DS46KUroDtMLAYHGkdWf5VDq3wVWFirmzROY=
 github.com/go-openapi/swag/yamlutils v0.28.0/go.mod h1:x0q/yndZHEgk9Rx3DyDqzFUmHy55KTvIZldvF2dTJXs=
+github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPEgAXnvj1Ro=
+github.com/go-viper/mapstructure/v2 v2.5.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/gnostic-models v0.7.1 h1:SisTfuFKJSKM5CPZkffwi6coztzzeYUhc3v4yxLWH8c=

--- a/otelconf/jsonschema_patch.sed
+++ b/otelconf/jsonschema_patch.sed
@@ -2,6 +2,12 @@
 # map[string]interface{}, for more specific types, they must
 # be replaced here
 s+type Headers.*+type Headers map[string]string+g
+
+# go-jsonschema generates the ",remain" additionalProperties field as
+# interface{}, but the mapstructure decoder requires remain fields to be a
+# map, or decoding panics. Use map[string]any so structs with additional
+# properties can be decoded with mapstructure.
+s+AdditionalProperties interface{} `mapstructure:",remain"`+AdditionalProperties map[string]any `mapstructure:",remain"`+g
 /^type ExperimentalResourceDetector struct {/a\
 \	// Enable the AWS EC2 resource detector.\
 \	// If omitted, ignore.\

--- a/otelconf/x/generated_config.go
+++ b/otelconf/x/generated_config.go
@@ -509,7 +509,7 @@ type ExperimentalComposableSampler struct {
 	//
 	RuleBased *ExperimentalComposableRuleBasedSampler `json:"rule_based,omitempty,omitzero" yaml:"rule_based,omitempty" mapstructure:"rule_based,omitempty"`
 
-	AdditionalProperties interface{} `mapstructure:",remain"`
+	AdditionalProperties map[string]any `mapstructure:",remain"`
 }
 
 type ExperimentalContainerResourceDetector map[string]interface{}
@@ -1022,7 +1022,7 @@ type ExperimentalResourceDetector struct {
 	//
 	Service ExperimentalServiceResourceDetector `json:"service,omitempty,omitzero" yaml:"service,omitempty" mapstructure:"service,omitempty"`
 
-	AdditionalProperties interface{} `mapstructure:",remain"`
+	AdditionalProperties map[string]any `mapstructure:",remain"`
 }
 
 type ExperimentalAWSEC2ResourceDetector map[string]interface{}
@@ -1259,7 +1259,7 @@ type LogRecordExporter struct {
 	//
 	OTLPHttp *OTLPHttpExporter `json:"otlp_http,omitempty,omitzero" yaml:"otlp_http,omitempty" mapstructure:"otlp_http,omitempty"`
 
-	AdditionalProperties interface{} `mapstructure:",remain"`
+	AdditionalProperties map[string]any `mapstructure:",remain"`
 }
 
 type LogRecordLimits struct {
@@ -1301,7 +1301,7 @@ type LogRecordProcessor struct {
 	//
 	Simple *SimpleLogRecordProcessor `json:"simple,omitempty,omitzero" yaml:"simple,omitempty" mapstructure:"simple,omitempty"`
 
-	AdditionalProperties interface{} `mapstructure:",remain"`
+	AdditionalProperties map[string]any `mapstructure:",remain"`
 }
 
 type LoggerProvider struct {
@@ -1360,7 +1360,7 @@ type MetricProducer struct {
 	//
 	Opencensus OpenCensusMetricProducer `json:"opencensus,omitempty,omitzero" yaml:"opencensus,omitempty" mapstructure:"opencensus,omitempty"`
 
-	AdditionalProperties interface{} `mapstructure:",remain"`
+	AdditionalProperties map[string]any `mapstructure:",remain"`
 }
 
 type MetricReader struct {
@@ -1816,7 +1816,7 @@ type OpenTelemetryConfiguration struct {
 	//
 	TracerProvider *TracerProvider `json:"tracer_provider,omitempty,omitzero" yaml:"tracer_provider,omitempty" mapstructure:"tracer_provider,omitempty"`
 
-	AdditionalProperties interface{} `mapstructure:",remain"`
+	AdditionalProperties map[string]any `mapstructure:",remain"`
 }
 
 // Configure if the SDK is disabled or not.
@@ -1934,7 +1934,7 @@ type PullMetricExporter struct {
 	//
 	PrometheusDevelopment *ExperimentalPrometheusMetricExporter `json:"prometheus/development,omitempty,omitzero" yaml:"prometheus/development,omitempty" mapstructure:"prometheus/development,omitempty"`
 
-	AdditionalProperties interface{} `mapstructure:",remain"`
+	AdditionalProperties map[string]any `mapstructure:",remain"`
 }
 
 type PullMetricReader struct {
@@ -1975,7 +1975,7 @@ type PushMetricExporter struct {
 	//
 	OTLPHttp *OTLPHttpMetricExporter `json:"otlp_http,omitempty,omitzero" yaml:"otlp_http,omitempty" mapstructure:"otlp_http,omitempty"`
 
-	AdditionalProperties interface{} `mapstructure:",remain"`
+	AdditionalProperties map[string]any `mapstructure:",remain"`
 }
 
 type Resource struct {
@@ -2055,7 +2055,7 @@ type Sampler struct {
 	//
 	TraceIDRatioBased *TraceIDRatioBasedSampler `json:"trace_id_ratio_based,omitempty,omitzero" yaml:"trace_id_ratio_based,omitempty" mapstructure:"trace_id_ratio_based,omitempty"`
 
-	AdditionalProperties interface{} `mapstructure:",remain"`
+	AdditionalProperties map[string]any `mapstructure:",remain"`
 }
 
 type SeverityNumber string
@@ -2120,7 +2120,7 @@ type SpanExporter struct {
 	//
 	OTLPHttp *OTLPHttpExporter `json:"otlp_http,omitempty,omitzero" yaml:"otlp_http,omitempty" mapstructure:"otlp_http,omitempty"`
 
-	AdditionalProperties interface{} `mapstructure:",remain"`
+	AdditionalProperties map[string]any `mapstructure:",remain"`
 }
 
 type SpanKind string
@@ -2214,7 +2214,7 @@ type SpanProcessor struct {
 	//
 	Simple *SimpleSpanProcessor `json:"simple,omitempty,omitzero" yaml:"simple,omitempty" mapstructure:"simple,omitempty"`
 
-	AdditionalProperties interface{} `mapstructure:",remain"`
+	AdditionalProperties map[string]any `mapstructure:",remain"`
 }
 
 type SumAggregation map[string]interface{}
@@ -2250,7 +2250,7 @@ type TextMapPropagator struct {
 	//
 	Tracecontext TraceContextPropagator `json:"tracecontext,omitempty,omitzero" yaml:"tracecontext,omitempty" mapstructure:"tracecontext,omitempty"`
 
-	AdditionalProperties interface{} `mapstructure:",remain"`
+	AdditionalProperties map[string]any `mapstructure:",remain"`
 }
 
 type TraceContextPropagator map[string]interface{}


### PR DESCRIPTION
Motivation:
Generated config structs in otelconf and otelconf/x (e.g. MetricProducer,
LogRecordProcessor, SpanExporter, OpenTelemetryConfiguration) declare
AdditionalProperties as `interface{}` with the `mapstructure:",remain"`
tag. The go-viper/mapstructure/v2 decoder requires fields tagged
",remain" to be of map kind, and panics with "reflect: Key of non-map
type interface {}" when decoding into these structs, breaking any
application that loads this configuration via mapstructure (directly or
through a config loader built on it).

Approach:
Change the AdditionalProperties field type from `interface{}` to
`map[string]any` in the two checked-in generated files
(otelconf/generated_config.go and otelconf/x/generated_config.go), and
add the equivalent sed rule to otelconf/jsonschema_patch.sed so a future
`make genjsonschema` regeneration preserves the fix. The frozen
historical snapshots under otelconf/v0.2.0 and otelconf/v0.3.0 are left
untouched. The only production code that reads/writes this field
(unmarshalMetricProducer in config_common.go / x/config_common.go)
already assigns a map[string]any value, so the narrower field type
requires no other code changes.

Validation:
- Added TestMapstructureDecodeAdditionalProperties in
  otelconf/config_test.go, which decodes a raw map containing an unknown
  key into a MetricProducer via mapstructure.Decode. Confirmed this test
  panics with "reflect: Key of non-map type interface {}" against the
  prior `interface{}` field type, and passes after this change.
- `go build ./...` and `go test ./...` pass in both the otelconf and
  otelconf/x modules.
- `golangci-lint run ./...` reports 0 issues in both modules; `gofmt -l`
  is clean on all changed files.
- Ran the actual `make genjsonschema` generation pipeline end-to-end
  (fetching the real opentelemetry-configuration schema and building
  go-jsonschema from tools/go.mod) in a scratch copy of the repo; the
  regenerated output is byte-for-byte identical to the hand-applied
  change in generated_config.go and x/generated_config.go, confirming
  the sed patch reproduces this fix on a fresh generation.
- `go mod tidy` in otelconf produces no further diff beyond the new
  github.com/go-viper/mapstructure/v2 test dependency.

Report: https://github.com/open-telemetry/opentelemetry-go-contrib/issues/8842
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
Assisted-by: claude-sonnet-5 (via Claude Code)

Fixes #8842