### PR TITLE
Drop support for Go 1.25

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -119,7 +119,7 @@ body:
     attributes:
       label: Go Version
       description: What Golang version were you running?
-      placeholder: '1.25'
+      placeholder: '1.26'
     validations:
       required: true
   - type: input
@@ -139,4 +139,3 @@ body:
         useful context, avoiding comments like `+1` or `me too`, to help us
         triage it. Learn more
         [here](https://opentelemetry.io/community/end-user/issue-participation/).</sub>
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
   compatibility-test:
     strategy:
       matrix:
-        go-version: ["1.27.0", "1.26.0", "1.25.0"]
+        go-version: ["1.27.0", "1.26.0"]
         platform:
           - os: ubuntu-latest
             arch: "386"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 This release is the last to support [Go 1.25].
 The next release will require at least [Go 1.26].
 
+### Removed
+
+- Drop support for [Go 1.25]. (#9584)
+
 ### Added
 
 - Add support for the `aws.ec2` resource detector in `go.opentelemetry.io/contrib/otelconf/x`. (#9139)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Removed
+
+- Drop support for [Go 1.25]. (#9584)
+
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->
 
@@ -15,10 +19,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 This release is the last to support [Go 1.25].
 The next release will require at least [Go 1.26].
-
-### Removed
-
-- Drop support for [Go 1.25]. (#9584)
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -54,22 +54,16 @@ This project is tested on the following systems.
 | -------- | ---------- | ------------ |
 | Ubuntu   | 1.27       | amd64        |
 | Ubuntu   | 1.26       | amd64        |
-| Ubuntu   | 1.25       | amd64        |
 | Ubuntu   | 1.27       | 386          |
 | Ubuntu   | 1.26       | 386          |
-| Ubuntu   | 1.25       | 386          |
 | macOS    | 1.27       | amd64        |
 | macOS    | 1.26       | amd64        |
-| macOS    | 1.25       | amd64        |
 | macOS    | 1.27       | arm64        |
 | macOS    | 1.26       | arm64        |
-| macOS    | 1.25       | arm64        |
 | Windows  | 1.27       | amd64        |
 | Windows  | 1.26       | amd64        |
-| Windows  | 1.25       | amd64        |
 | Windows  | 1.27       | 386          |
 | Windows  | 1.26       | 386          |
-| Windows  | 1.25       | 386          |
 
 While this project should work for other systems, no compatibility guarantees
 are made for those systems currently.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Docs](https://godoc.org/go.opentelemetry.io/contrib?status.svg)](https://pkg.go.dev/go.opentelemetry.io/contrib)
 [![Go Report Card](https://goreportcard.com/badge/go.opentelemetry.io/contrib)](https://goreportcard.com/report/go.opentelemetry.io/contrib)
 [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/opentelemetry-go-contrib.svg)](https://issues.oss-fuzz.com/issues?q=project:opentelemetry-go-contrib)
-[![Slack](https://img.shields.io/badge/slack-@cncf/otel--go-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C01NPAXACKT)
+[![Slack](https://img.shields.io/badge/slack-@cncf/otel--go-brightgreen.svg?logo=slack)](https://slack.cncf.io/)
 
 Collection of 3rd-party packages for [OpenTelemetry-Go](https://github.com/open-telemetry/opentelemetry-go).
 
@@ -27,7 +27,7 @@ Refer to the module for its version or our [versioning manifest](./versions.yaml
 
 Project versioning information and stability guarantees can be found in the [versioning documentation](https://github.com/open-telemetry/opentelemetry-go/blob/a724cf884287e04785eaa91513d26a6ef9699288/VERSIONING.md).
 
-Progress and status specific to this repository is tracked in our local [project boards](https://github.com/open-telemetry/opentelemetry-go-contrib/projects?query=is%3Aopen) and [milestones](https://github.com/open-telemetry/opentelemetry-go-contrib/milestones).
+Progress and status specific to this repository is tracked in our [project board](https://github.com/orgs/open-telemetry/projects/186) and [milestones](https://github.com/open-telemetry/opentelemetry-go-contrib/milestones).
 
 ### Compatibility
 

--- a/bridges/otellogr/go.mod
+++ b/bridges/otellogr/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/bridges/otellogr
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/go-logr/logr v1.4.4

--- a/bridges/otellogrus/go.mod
+++ b/bridges/otellogrus/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/bridges/otellogrus
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/sirupsen/logrus v1.10.2

--- a/bridges/otelslog/go.mod
+++ b/bridges/otelslog/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/bridges/otelslog
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.1

--- a/bridges/otelzap/go.mod
+++ b/bridges/otelzap/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/bridges/otelzap
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.1

--- a/bridges/prometheus/go.mod
+++ b/bridges/prometheus/go.mod
@@ -9,7 +9,6 @@ require (
 	go.opentelemetry.io/otel v1.46.0
 	go.opentelemetry.io/otel/sdk v1.46.0
 	go.opentelemetry.io/otel/sdk/metric v1.46.0
-	google.golang.org/protobuf v1.36.12
 )
 
 require (
@@ -26,4 +25,5 @@ require (
 	go.opentelemetry.io/otel/trace v1.46.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/sys v0.47.0 // indirect
+	google.golang.org/protobuf v1.36.12 // indirect
 )

--- a/bridges/prometheus/go.mod
+++ b/bridges/prometheus/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/bridges/prometheus
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/prometheus/client_golang v1.24.1

--- a/bridges/prometheus/producer_test.go
+++ b/bridges/prometheus/producer_test.go
@@ -16,7 +16,6 @@ import (
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
-	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -487,26 +486,26 @@ func TestProducePartialSuccess(t *testing.T) {
 	p := NewMetricProducer(WithGatherer(gathererFunc(func() ([]*dto.MetricFamily, error) {
 		return []*dto.MetricFamily{
 			{
-				Name: proto.String("test_gauge_metric"),
-				Help: proto.String("A gauge metric for testing"),
+				Name: new("test_gauge_metric"),
+				Help: new("A gauge metric for testing"),
 				Type: dto.MetricType_GAUGE.Enum(),
 				Metric: []*dto.Metric{
 					{
 						Gauge: &dto.Gauge{
-							Value: proto.Float64(123.4),
+							Value: new(123.4),
 						},
 						Label: []*dto.LabelPair{
 							{
-								Name:  proto.String("foo"),
-								Value: proto.String("bar"),
+								Name:  new("foo"),
+								Value: new("bar"),
 							},
 						},
 					},
 				},
 			},
 			{
-				Name: proto.String("test_gauge_histogram_metric"),
-				Help: proto.String("A gauge histogram metric for testing"),
+				Name: new("test_gauge_histogram_metric"),
+				Help: new("A gauge histogram metric for testing"),
 				Type: dto.MetricType_GAUGE_HISTOGRAM.Enum(),
 				Metric: []*dto.Metric{
 					{},

--- a/detectors/autodetect/go.mod
+++ b/detectors/autodetect/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/detectors/autodetect
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.1

--- a/detectors/aws/ec2/v2/go.mod
+++ b/detectors/aws/ec2/v2/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/detectors/aws/ec2/v2
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.43.8

--- a/detectors/aws/ecs/go.mod
+++ b/detectors/aws/ecs/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/detectors/aws/ecs
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20221221133751-67e37ae746cd

--- a/detectors/aws/eks/go.mod
+++ b/detectors/aws/eks/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/detectors/aws/eks
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.1

--- a/detectors/aws/elasticbeanstalk/go.mod
+++ b/detectors/aws/elasticbeanstalk/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/detectors/aws/elasticbeanstalk
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.1

--- a/detectors/aws/lambda/go.mod
+++ b/detectors/aws/lambda/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/detectors/aws/lambda
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.1

--- a/detectors/azure/azureappservice/go.mod
+++ b/detectors/azure/azureappservice/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/detectors/azure/azureappservice
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.1

--- a/detectors/azure/azurecontainerapps/go.mod
+++ b/detectors/azure/azurecontainerapps/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/detectors/azure/azurecontainerapps
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.1

--- a/detectors/azure/azurefunctions/go.mod
+++ b/detectors/azure/azurefunctions/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/detectors/azure/azurefunctions
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.1

--- a/detectors/azure/azurevm/go.mod
+++ b/detectors/azure/azurevm/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/detectors/azure/azurevm
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.1

--- a/detectors/docker/detector_test.go
+++ b/detectors/docker/detector_test.go
@@ -38,8 +38,6 @@ func (m *mockProvider) Close() error {
 	return nil
 }
 
-func ptr[T any](v T) *T { return &v }
-
 func newMockDetector(m *mockProvider, opts ...Option) *ResourceDetector {
 	d := NewResourceDetector(opts...)
 	d.createProvider = func(...client.Opt) (provider, error) { return m, nil }
@@ -63,7 +61,7 @@ func TestSuccess(t *testing.T) {
 		info: hostInfo{Name: "docker-host", OSType: "linux"},
 		containerInfo: containerInfo{
 			Name:      "my-container",
-			ImageName: ptr("golang"),
+			ImageName: new("golang"),
 			ImageID:   "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 			Tags:      []string{"1.25"},
 		},
@@ -99,7 +97,7 @@ func TestInfoError(t *testing.T) {
 		infoErr: errors.New("daemon unavailable"),
 		containerInfo: containerInfo{
 			Name:      "my-container",
-			ImageName: ptr("golang"),
+			ImageName: new("golang"),
 			ImageID:   "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 			Tags:      []string{"1.25"},
 		},
@@ -199,7 +197,7 @@ func TestWithAttributeFilter(t *testing.T) {
 			info: hostInfo{Name: "docker-host", OSType: "linux"},
 			containerInfo: containerInfo{
 				Name:      "my-container",
-				ImageName: ptr("golang"),
+				ImageName: new("golang"),
 				ImageID:   "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 				Tags:      []string{"1.25"},
 			},

--- a/detectors/docker/go.mod
+++ b/detectors/docker/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/detectors/docker
 
-go 1.25.0
+go 1.26.0
 
 require github.com/moby/moby/client v0.4.1
 

--- a/detectors/gcp/go.mod
+++ b/detectors/gcp/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/detectors/gcp
 
-go 1.25.0
+go 1.26.0
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0

--- a/detectors/hetzner/go.mod
+++ b/detectors/hetzner/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/detectors/hetzner
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/hetznercloud/hcloud-go/v2 v2.47.0

--- a/detectors/ibmcloud/vpc/go.mod
+++ b/detectors/ibmcloud/vpc/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/detectors/ibmcloud/vpc
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.1

--- a/detectors/k8sapi/go.mod
+++ b/detectors/k8sapi/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/detectors/k8sapi
 
-go 1.25.0
+go 1.26.0
 
 require (
 	go.opentelemetry.io/otel v1.46.0

--- a/detectors/vultr/go.mod
+++ b/detectors/vultr/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/detectors/vultr
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.1

--- a/examples/dice/instrumented/go.mod
+++ b/examples/dice/instrumented/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/examples/dice/instrumented
 
-go 1.25.0
+go 1.26.0
 
 require (
 	go.opentelemetry.io/contrib/bridges/otelslog v0.20.1

--- a/examples/dice/uninstrumented/go.mod
+++ b/examples/dice/uninstrumented/go.mod
@@ -1,3 +1,3 @@
 module go.opentelemetry.io/contrib/examples/dice/uninstrumented
 
-go 1.25.0
+go 1.26.0

--- a/examples/namedtracer/go.mod
+++ b/examples/namedtracer/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/examples/namedtracer
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/go-logr/stdr v1.2.2

--- a/examples/opencensus/go.mod
+++ b/examples/opencensus/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/examples/opencensus
 
-go 1.25.0
+go 1.26.0
 
 require (
 	go.opencensus.io v0.24.0

--- a/examples/otel-collector/go.mod
+++ b/examples/otel-collector/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/examples/otel-collector
 
-go 1.25.0
+go 1.26.0
 
 require (
 	go.opentelemetry.io/otel v1.46.0

--- a/examples/passthrough/go.mod
+++ b/examples/passthrough/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/examples/passthrough
 
-go 1.25.0
+go 1.26.0
 
 require (
 	go.opentelemetry.io/otel v1.46.0

--- a/examples/prometheus-compatibility/go.mod
+++ b/examples/prometheus-compatibility/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/examples/prometheus-compatibility
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/prometheus/client_golang v1.24.1

--- a/examples/prometheus/go.mod
+++ b/examples/prometheus/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/examples/prometheus
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/prometheus/client_golang v1.24.1

--- a/exporters/autoexport/go.mod
+++ b/exporters/autoexport/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/exporters/autoexport
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/prometheus/client_golang v1.24.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.12.1
 

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/example/go.mod
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/example/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda/example
 
-go 1.25.0
+go 1.26.0
 
 replace (
 	go.opentelemetry.io/contrib/detectors/aws/lambda => ../../../../../../detectors/aws/lambda

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/go.mod
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda
 
-go 1.25.0
+go 1.26.0
 
 replace (
 	go.opentelemetry.io/contrib/detectors/aws/lambda => ../../../../../detectors/aws/lambda

--- a/instrumentation/github.com/aws/aws-lambda-go/otellambda/xrayconfig/go.mod
+++ b/instrumentation/github.com/aws/aws-lambda-go/otellambda/xrayconfig/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda/xrayconfig
 
-go 1.25.0
+go 1.26.0
 
 replace (
 	go.opentelemetry.io/contrib/detectors/aws/lambda => ../../../../../../detectors/aws/lambda

--- a/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/example/go.mod
+++ b/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/example/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/example
 
-go 1.25.0
+go 1.26.0
 
 replace go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws => ../
 

--- a/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/go.mod
+++ b/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.43.8

--- a/instrumentation/github.com/emicklei/go-restful/otelrestful/go.mod
+++ b/instrumentation/github.com/emicklei/go-restful/otelrestful/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful
 
-go 1.25.0
+go 1.26.0
 
 replace go.opentelemetry.io/contrib/propagators/b3 => ../../../../../propagators/b3
 

--- a/instrumentation/github.com/gin-gonic/gin/otelgin/go.mod
+++ b/instrumentation/github.com/gin-gonic/gin/otelgin/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/gin-gonic/gin v1.12.0

--- a/instrumentation/github.com/gorilla/mux/otelmux/go.mod
+++ b/instrumentation/github.com/gorilla/mux/otelmux/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/felixge/httpsnoop v1.1.0

--- a/instrumentation/github.com/labstack/echo/otelecho/example/go.mod
+++ b/instrumentation/github.com/labstack/echo/otelecho/example/go.mod
@@ -1,7 +1,7 @@
 // Deprecated: Use github.com/labstack/echo-opentelemetry instead.
 module go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho/example
 
-go 1.25.0
+go 1.26.0
 
 replace (
 	go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho => ../

--- a/instrumentation/github.com/labstack/echo/otelecho/go.mod
+++ b/instrumentation/github.com/labstack/echo/otelecho/go.mod
@@ -1,7 +1,7 @@
 // Deprecated: Use github.com/labstack/echo-opentelemetry instead.
 module go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho
 
-go 1.25.0
+go 1.26.0
 
 replace go.opentelemetry.io/contrib/propagators/b3 => ../../../../../propagators/b3
 

--- a/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/go.mod
+++ b/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.1

--- a/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/test/go.mod
+++ b/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/test/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo/test
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.1

--- a/instrumentation/go.mongodb.org/mongo-driver/v2/mongo/otelmongo/go.mod
+++ b/instrumentation/go.mongodb.org/mongo-driver/v2/mongo/otelmongo/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver/v2/mongo/otelmongo
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.1

--- a/instrumentation/google.golang.org/grpc/otelgrpc/example/go.mod
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/example/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc/example
 
-go 1.25.0
+go 1.26.0
 
 replace go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc => ../
 

--- a/instrumentation/google.golang.org/grpc/otelgrpc/go.mod
+++ b/instrumentation/google.golang.org/grpc/otelgrpc/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.1

--- a/instrumentation/host/example/go.mod
+++ b/instrumentation/host/example/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/host/example
 
-go 1.25.0
+go 1.26.0
 
 replace go.opentelemetry.io/contrib/instrumentation/host => ../
 

--- a/instrumentation/host/go.mod
+++ b/instrumentation/host/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/host
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/shirou/gopsutil/v4 v4.26.7

--- a/instrumentation/net/http/httptrace/otelhttptrace/example/go.mod
+++ b/instrumentation/net/http/httptrace/otelhttptrace/example/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace/example
 
-go 1.25.0
+go 1.26.0
 
 replace (
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace => ../

--- a/instrumentation/net/http/httptrace/otelhttptrace/go.mod
+++ b/instrumentation/net/http/httptrace/otelhttptrace/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/instrumentation/net/http/otelhttp/example/go.mod
+++ b/instrumentation/net/http/otelhttp/example/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/example
 
-go 1.25.0
+go 1.26.0
 
 replace go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp => ../
 

--- a/instrumentation/net/http/otelhttp/go.mod
+++ b/instrumentation/net/http/otelhttp/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/felixge/httpsnoop v1.1.0

--- a/instrumentation/runtime/go.mod
+++ b/instrumentation/runtime/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/instrumentation/runtime
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.1

--- a/otelconf/config_common.go
+++ b/otelconf/config_common.go
@@ -273,10 +273,6 @@ func validateSpanLimits(plain *SpanLimits) error {
 	return nil
 }
 
-func ptr[T any](v T) *T {
-	return &v
-}
-
 // validateOTLPHTTPEncoding validates the encoding configuration.
 // The Go SDK only supports protobuf encoding for OTLP HTTP exporters.
 func validateOTLPHTTPEncoding(encoding *OTLPHttpEncoding) error {

--- a/otelconf/config_json.go
+++ b/otelconf/config_json.go
@@ -396,7 +396,7 @@ func (j *OpenTelemetryConfiguration) UnmarshalJSON(b []byte) error {
 	} else {
 		// Configure if the SDK is disabled or not.
 		// If omitted or null, false is used.
-		sh.Plain.Disabled = ptr(false)
+		sh.Plain.Disabled = new(false)
 	}
 
 	if sh.LogLevel != nil {
@@ -406,7 +406,7 @@ func (j *OpenTelemetryConfiguration) UnmarshalJSON(b []byte) error {
 	} else {
 		// Configure the log level of the internal logger used by the SDK.
 		// If omitted, info is used.
-		sh.Plain.LogLevel = ptr(SeverityNumberInfo)
+		sh.Plain.LogLevel = new(SeverityNumberInfo)
 	}
 
 	*j = OpenTelemetryConfiguration(sh.Plain)

--- a/otelconf/config_test.go
+++ b/otelconf/config_test.go
@@ -388,7 +388,7 @@ func TestNewSDK(t *testing.T) {
 			cfg: []ConfigurationOption{
 				WithContext(t.Context()),
 				WithOpenTelemetryConfiguration(OpenTelemetryConfiguration{
-					Disabled:       ptr(true),
+					Disabled:       new(true),
 					TracerProvider: &TracerProvider{},
 					MeterProvider:  &MeterProvider{},
 					LoggerProvider: &LoggerProvider{},
@@ -442,43 +442,43 @@ func newV10OpenTelemetryConfig(material testtls.Material) *OpenTelemetryConfigur
 	material.ClientCertPath = filepath.ToSlash(material.ClientCertPath)
 	material.ClientKeyPath = filepath.ToSlash(material.ClientKeyPath)
 	return &OpenTelemetryConfiguration{
-		Disabled:   ptr(false),
+		Disabled:   new(false),
 		FileFormat: "1.0-rc.2",
 		AttributeLimits: &AttributeLimits{
-			AttributeCountLimit:       ptr(128),
-			AttributeValueLengthLimit: ptr(4096),
+			AttributeCountLimit:       new(128),
+			AttributeValueLengthLimit: new(4096),
 		},
 
-		LogLevel: ptr(SeverityNumberInfo),
+		LogLevel: new(SeverityNumberInfo),
 		LoggerProvider: &LoggerProvider{
 			Limits: &LogRecordLimits{
-				AttributeCountLimit:       ptr(128),
-				AttributeValueLengthLimit: ptr(4096),
+				AttributeCountLimit:       new(128),
+				AttributeValueLengthLimit: new(4096),
 			},
 			Processors: []LogRecordProcessor{
 				{
 					Batch: &BatchLogRecordProcessor{
-						ExportTimeout: ptr(30000),
+						ExportTimeout: new(30000),
 						Exporter: LogRecordExporter{
 							OTLPHttp: &OTLPHttpExporter{
 								Tls: &HttpTls{
-									CaFile:   ptr(material.CACertPath),
-									CertFile: ptr(material.ClientCertPath),
-									KeyFile:  ptr(material.ClientKeyPath),
+									CaFile:   new(material.CACertPath),
+									CertFile: new(material.ClientCertPath),
+									KeyFile:  new(material.ClientKeyPath),
 								},
-								Compression: ptr("gzip"),
-								Encoding:    ptr(OTLPHttpEncodingProtobuf),
-								Endpoint:    ptr("http://localhost:4318/v1/logs"),
+								Compression: new("gzip"),
+								Encoding:    new(OTLPHttpEncodingProtobuf),
+								Endpoint:    new("http://localhost:4318/v1/logs"),
 								Headers: []NameStringValuePair{
-									{Name: "api-key", Value: ptr("1234")},
+									{Name: "api-key", Value: new("1234")},
 								},
-								HeadersList: ptr("api-key=1234"),
-								Timeout:     ptr(10000),
+								HeadersList: new("api-key=1234"),
+								Timeout:     new(10000),
 							},
 						},
-						MaxExportBatchSize: ptr(512),
-						MaxQueueSize:       ptr(2048),
-						ScheduleDelay:      ptr(5000),
+						MaxExportBatchSize: new(512),
+						MaxQueueSize:       new(2048),
+						ScheduleDelay:      new(5000),
 					},
 				},
 				{
@@ -486,18 +486,18 @@ func newV10OpenTelemetryConfig(material testtls.Material) *OpenTelemetryConfigur
 						Exporter: LogRecordExporter{
 							OTLPGrpc: &OTLPGrpcExporter{
 								Tls: &GrpcTls{
-									CaFile:   ptr(material.CACertPath),
-									CertFile: ptr(material.ClientCertPath),
-									KeyFile:  ptr(material.ClientKeyPath),
-									Insecure: ptr(false),
+									CaFile:   new(material.CACertPath),
+									CertFile: new(material.ClientCertPath),
+									KeyFile:  new(material.ClientKeyPath),
+									Insecure: new(false),
 								},
-								Compression: ptr("gzip"),
-								Endpoint:    ptr("http://localhost:4317"),
+								Compression: new("gzip"),
+								Endpoint:    new("http://localhost:4317"),
 								Headers: []NameStringValuePair{
-									{Name: "api-key", Value: ptr("1234")},
+									{Name: "api-key", Value: new("1234")},
 								},
-								HeadersList: ptr("api-key=1234"),
-								Timeout:     ptr(10000),
+								HeadersList: new("api-key=1234"),
+								Timeout:     new(10000),
 							},
 						},
 					},
@@ -522,7 +522,7 @@ func newV10OpenTelemetryConfig(material testtls.Material) *OpenTelemetryConfigur
 			},
 		},
 		MeterProvider: &MeterProvider{
-			ExemplarFilter: ptr(ExemplarFilter("trace_based")),
+			ExemplarFilter: new(ExemplarFilter("trace_based")),
 			Readers: []MetricReader{
 				{
 					Pull: &PullMetricReader{
@@ -532,14 +532,14 @@ func newV10OpenTelemetryConfig(material testtls.Material) *OpenTelemetryConfigur
 							},
 						},
 						CardinalityLimits: &CardinalityLimits{
-							Default:                 ptr(2000),
-							Counter:                 ptr(2000),
-							Gauge:                   ptr(2000),
-							Histogram:               ptr(2000),
-							ObservableCounter:       ptr(2000),
-							ObservableGauge:         ptr(2000),
-							ObservableUpDownCounter: ptr(2000),
-							UpDownCounter:           ptr(2000),
+							Default:                 new(2000),
+							Counter:                 new(2000),
+							Gauge:                   new(2000),
+							Histogram:               new(2000),
+							ObservableCounter:       new(2000),
+							ObservableGauge:         new(2000),
+							ObservableUpDownCounter: new(2000),
+							UpDownCounter:           new(2000),
 						},
 						Exporter: PullMetricExporter{},
 					},
@@ -554,36 +554,36 @@ func newV10OpenTelemetryConfig(material testtls.Material) *OpenTelemetryConfigur
 							},
 						},
 						CardinalityLimits: &CardinalityLimits{
-							Default:                 ptr(2000),
-							Counter:                 ptr(2000),
-							Gauge:                   ptr(2000),
-							Histogram:               ptr(2000),
-							ObservableCounter:       ptr(2000),
-							ObservableGauge:         ptr(2000),
-							ObservableUpDownCounter: ptr(2000),
-							UpDownCounter:           ptr(2000),
+							Default:                 new(2000),
+							Counter:                 new(2000),
+							Gauge:                   new(2000),
+							Histogram:               new(2000),
+							ObservableCounter:       new(2000),
+							ObservableGauge:         new(2000),
+							ObservableUpDownCounter: new(2000),
+							UpDownCounter:           new(2000),
 						},
 						Exporter: PushMetricExporter{
 							OTLPHttp: &OTLPHttpMetricExporter{
 								Tls: &HttpTls{
-									CaFile:   ptr(material.CACertPath),
-									CertFile: ptr(material.ClientCertPath),
-									KeyFile:  ptr(material.ClientKeyPath),
+									CaFile:   new(material.CACertPath),
+									CertFile: new(material.ClientCertPath),
+									KeyFile:  new(material.ClientKeyPath),
 								},
-								Compression:                 ptr("gzip"),
-								DefaultHistogramAggregation: ptr(ExporterDefaultHistogramAggregationBase2ExponentialBucketHistogram),
-								Endpoint:                    ptr("http://localhost:4318/v1/metrics"),
-								Encoding:                    ptr(OTLPHttpEncodingProtobuf),
+								Compression:                 new("gzip"),
+								DefaultHistogramAggregation: new(ExporterDefaultHistogramAggregationBase2ExponentialBucketHistogram),
+								Endpoint:                    new("http://localhost:4318/v1/metrics"),
+								Encoding:                    new(OTLPHttpEncodingProtobuf),
 								Headers: []NameStringValuePair{
-									{Name: "api-key", Value: ptr("1234")},
+									{Name: "api-key", Value: new("1234")},
 								},
-								HeadersList:           ptr("api-key=1234"),
-								TemporalityPreference: ptr(ExporterTemporalityPreferenceDelta),
-								Timeout:               ptr(10000),
+								HeadersList:           new("api-key=1234"),
+								TemporalityPreference: new(ExporterTemporalityPreferenceDelta),
+								Timeout:               new(10000),
 							},
 						},
-						Interval: ptr(60000),
-						Timeout:  ptr(30000),
+						Interval: new(60000),
+						Timeout:  new(30000),
 					},
 				},
 				{
@@ -591,20 +591,20 @@ func newV10OpenTelemetryConfig(material testtls.Material) *OpenTelemetryConfigur
 						Exporter: PushMetricExporter{
 							OTLPGrpc: &OTLPGrpcMetricExporter{
 								Tls: &GrpcTls{
-									CaFile:   ptr(material.CACertPath),
-									CertFile: ptr(material.ClientCertPath),
-									KeyFile:  ptr(material.ClientKeyPath),
-									Insecure: ptr(false),
+									CaFile:   new(material.CACertPath),
+									CertFile: new(material.ClientCertPath),
+									KeyFile:  new(material.ClientKeyPath),
+									Insecure: new(false),
 								},
-								Compression:                 ptr("gzip"),
-								DefaultHistogramAggregation: ptr(ExporterDefaultHistogramAggregationBase2ExponentialBucketHistogram),
-								Endpoint:                    ptr("http://localhost:4317"),
+								Compression:                 new("gzip"),
+								DefaultHistogramAggregation: new(ExporterDefaultHistogramAggregationBase2ExponentialBucketHistogram),
+								Endpoint:                    new("http://localhost:4317"),
 								Headers: []NameStringValuePair{
-									{Name: "api-key", Value: ptr("1234")},
+									{Name: "api-key", Value: new("1234")},
 								},
-								HeadersList:           ptr("api-key=1234"),
-								TemporalityPreference: ptr(ExporterTemporalityPreferenceDelta),
-								Timeout:               ptr(10000),
+								HeadersList:           new("api-key=1234"),
+								TemporalityPreference: new(ExporterTemporalityPreferenceDelta),
+								Timeout:               new(10000),
 							},
 						},
 					},
@@ -630,27 +630,27 @@ func newV10OpenTelemetryConfig(material testtls.Material) *OpenTelemetryConfigur
 			Views: []View{
 				{
 					Selector: ViewSelector{
-						InstrumentName: ptr("my-instrument"),
-						InstrumentType: ptr(InstrumentTypeHistogram),
-						MeterName:      ptr("my-meter"),
-						MeterSchemaUrl: ptr("https://opentelemetry.io/schemas/1.16.0"),
-						MeterVersion:   ptr("1.0.0"),
-						Unit:           ptr("ms"),
+						InstrumentName: new("my-instrument"),
+						InstrumentType: new(InstrumentTypeHistogram),
+						MeterName:      new("my-meter"),
+						MeterSchemaUrl: new("https://opentelemetry.io/schemas/1.16.0"),
+						MeterVersion:   new("1.0.0"),
+						Unit:           new("ms"),
 					},
 					Stream: ViewStream{
 						Aggregation: &Aggregation{
 							ExplicitBucketHistogram: &ExplicitBucketHistogramAggregation{
 								Boundaries:   []float64{0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000},
-								RecordMinMax: ptr(true),
+								RecordMinMax: new(true),
 							},
 						},
-						AggregationCardinalityLimit: ptr(2000),
+						AggregationCardinalityLimit: new(2000),
 						AttributeKeys: &IncludeExclude{
 							Included: []string{"key1", "key2"},
 							Excluded: []string{"key3"},
 						},
-						Description: ptr("new_description"),
-						Name:        ptr("new_instrument_name"),
+						Description: new("new_description"),
+						Name:        new("new_instrument_name"),
 					},
 				},
 			},
@@ -676,55 +676,55 @@ func newV10OpenTelemetryConfig(material testtls.Material) *OpenTelemetryConfigur
 					Ottrace: OpenTracingPropagator{},
 				},
 			},
-			CompositeList: ptr("tracecontext,baggage,b3,b3multi,jaeger,ottrace,xray"),
+			CompositeList: new("tracecontext,baggage,b3,b3multi,jaeger,ottrace,xray"),
 		},
 		Resource: &Resource{
 			Attributes: []AttributeNameValue{
 				{Name: "service.name", Value: "unknown_service"},
-				{Name: "string_key", Type: ptr(AttributeTypeString), Value: "value"},
-				{Name: "bool_key", Type: ptr(AttributeTypeBool), Value: true},
-				{Name: "int_key", Type: ptr(AttributeTypeInt), Value: 1},
-				{Name: "double_key", Type: ptr(AttributeTypeDouble), Value: 1.1},
-				{Name: "string_array_key", Type: ptr(AttributeTypeStringArray), Value: []any{"value1", "value2"}},
-				{Name: "bool_array_key", Type: ptr(AttributeTypeBoolArray), Value: []any{true, false}},
-				{Name: "int_array_key", Type: ptr(AttributeTypeIntArray), Value: []any{1, 2}},
-				{Name: "double_array_key", Type: ptr(AttributeTypeDoubleArray), Value: []any{1.1, 2.2}},
+				{Name: "string_key", Type: new(AttributeTypeString), Value: "value"},
+				{Name: "bool_key", Type: new(AttributeTypeBool), Value: true},
+				{Name: "int_key", Type: new(AttributeTypeInt), Value: 1},
+				{Name: "double_key", Type: new(AttributeTypeDouble), Value: 1.1},
+				{Name: "string_array_key", Type: new(AttributeTypeStringArray), Value: []any{"value1", "value2"}},
+				{Name: "bool_array_key", Type: new(AttributeTypeBoolArray), Value: []any{true, false}},
+				{Name: "int_array_key", Type: new(AttributeTypeIntArray), Value: []any{1, 2}},
+				{Name: "double_array_key", Type: new(AttributeTypeDoubleArray), Value: []any{1.1, 2.2}},
 			},
-			AttributesList: ptr("service.namespace=my-namespace,service.version=1.0.0"),
+			AttributesList: new("service.namespace=my-namespace,service.version=1.0.0"),
 		},
 		TracerProvider: &TracerProvider{
 			Limits: &SpanLimits{
-				AttributeCountLimit:       ptr(128),
-				AttributeValueLengthLimit: ptr(4096),
-				EventCountLimit:           ptr(128),
-				EventAttributeCountLimit:  ptr(128),
-				LinkCountLimit:            ptr(128),
-				LinkAttributeCountLimit:   ptr(128),
+				AttributeCountLimit:       new(128),
+				AttributeValueLengthLimit: new(4096),
+				EventCountLimit:           new(128),
+				EventAttributeCountLimit:  new(128),
+				LinkCountLimit:            new(128),
+				LinkAttributeCountLimit:   new(128),
 			},
 			Processors: []SpanProcessor{
 				{
 					Batch: &BatchSpanProcessor{
-						ExportTimeout: ptr(30000),
+						ExportTimeout: new(30000),
 						Exporter: SpanExporter{
 							OTLPHttp: &OTLPHttpExporter{
 								Tls: &HttpTls{
-									CaFile:   ptr(material.CACertPath),
-									CertFile: ptr(material.ClientCertPath),
-									KeyFile:  ptr(material.ClientKeyPath),
+									CaFile:   new(material.CACertPath),
+									CertFile: new(material.ClientCertPath),
+									KeyFile:  new(material.ClientKeyPath),
 								},
-								Compression: ptr("gzip"),
-								Encoding:    ptr(OTLPHttpEncodingProtobuf),
-								Endpoint:    ptr("http://localhost:4318/v1/traces"),
+								Compression: new("gzip"),
+								Encoding:    new(OTLPHttpEncodingProtobuf),
+								Endpoint:    new("http://localhost:4318/v1/traces"),
 								Headers: []NameStringValuePair{
-									{Name: "api-key", Value: ptr("1234")},
+									{Name: "api-key", Value: new("1234")},
 								},
-								HeadersList: ptr("api-key=1234"),
-								Timeout:     ptr(10000),
+								HeadersList: new("api-key=1234"),
+								Timeout:     new(10000),
 							},
 						},
-						MaxExportBatchSize: ptr(512),
-						MaxQueueSize:       ptr(2048),
-						ScheduleDelay:      ptr(5000),
+						MaxExportBatchSize: new(512),
+						MaxQueueSize:       new(2048),
+						ScheduleDelay:      new(5000),
 					},
 				},
 				{
@@ -732,18 +732,18 @@ func newV10OpenTelemetryConfig(material testtls.Material) *OpenTelemetryConfigur
 						Exporter: SpanExporter{
 							OTLPGrpc: &OTLPGrpcExporter{
 								Tls: &GrpcTls{
-									CaFile:   ptr(material.CACertPath),
-									CertFile: ptr(material.ClientCertPath),
-									KeyFile:  ptr(material.ClientKeyPath),
-									Insecure: ptr(false),
+									CaFile:   new(material.CACertPath),
+									CertFile: new(material.ClientCertPath),
+									KeyFile:  new(material.ClientKeyPath),
+									Insecure: new(false),
 								},
-								Compression: ptr("gzip"),
-								Endpoint:    ptr("http://localhost:4317"),
+								Compression: new("gzip"),
+								Endpoint:    new("http://localhost:4317"),
 								Headers: []NameStringValuePair{
-									{Name: "api-key", Value: ptr("1234")},
+									{Name: "api-key", Value: new("1234")},
 								},
-								HeadersList: ptr("api-key=1234"),
-								Timeout:     ptr(10000),
+								HeadersList: new("api-key=1234"),
+								Timeout:     new(10000),
 							},
 						},
 					},
@@ -782,7 +782,7 @@ func newV10OpenTelemetryConfig(material testtls.Material) *OpenTelemetryConfigur
 					},
 					Root: &Sampler{
 						TraceIDRatioBased: &TraceIDRatioBasedSampler{
-							Ratio: ptr(0.0001),
+							Ratio: new(0.0001),
 						},
 					},
 				},
@@ -792,60 +792,60 @@ func newV10OpenTelemetryConfig(material testtls.Material) *OpenTelemetryConfigur
 }
 
 var v100OpenTelemetryConfigEnvParsing = OpenTelemetryConfiguration{
-	Disabled:   ptr(false),
+	Disabled:   new(false),
 	FileFormat: "1.0",
-	LogLevel:   ptr(SeverityNumberInfo),
+	LogLevel:   new(SeverityNumberInfo),
 	AttributeLimits: &AttributeLimits{
-		AttributeCountLimit:       ptr(128),
-		AttributeValueLengthLimit: ptr(4096),
+		AttributeCountLimit:       new(128),
+		AttributeValueLengthLimit: new(4096),
 	},
 	Resource: &Resource{
 		Attributes: []AttributeNameValue{
 			{Name: "service.name", Value: "unknown_service"},
-			{Name: "string_key", Type: ptr(AttributeTypeString), Value: "value"},
-			{Name: "bool_key", Type: ptr(AttributeTypeBool), Value: true},
-			{Name: "int_key", Type: ptr(AttributeTypeInt), Value: 1},
-			{Name: "double_key", Type: ptr(AttributeTypeDouble), Value: 1.1},
-			{Name: "string_array_key", Type: ptr(AttributeTypeStringArray), Value: []any{"value1", "value2"}},
-			{Name: "bool_array_key", Type: ptr(AttributeTypeBoolArray), Value: []any{true, false}},
-			{Name: "int_array_key", Type: ptr(AttributeTypeIntArray), Value: []any{1, 2}},
-			{Name: "double_array_key", Type: ptr(AttributeTypeDoubleArray), Value: []any{1.1, 2.2}},
-			{Name: "string_value", Type: ptr(AttributeTypeString), Value: "value"},
-			{Name: "bool_value", Type: ptr(AttributeTypeBool), Value: true},
-			{Name: "int_value", Type: ptr(AttributeTypeInt), Value: 1},
-			{Name: "float_value", Type: ptr(AttributeTypeDouble), Value: 1.1},
-			{Name: "hex_value", Type: ptr(AttributeTypeInt), Value: int(48879)},
-			{Name: "quoted_string_value", Type: ptr(AttributeTypeString), Value: "value"},
-			{Name: "quoted_bool_value", Type: ptr(AttributeTypeString), Value: "true"},
-			{Name: "quoted_int_value", Type: ptr(AttributeTypeString), Value: "1"},
-			{Name: "quoted_float_value", Type: ptr(AttributeTypeString), Value: "1.1"},
-			{Name: "quoted_hex_value", Type: ptr(AttributeTypeString), Value: "0xbeef"},
-			{Name: "alternative_env_syntax", Type: ptr(AttributeTypeString), Value: "value"},
-			{Name: "invalid_map_value", Type: ptr(AttributeTypeString), Value: "value\nkey:value"},
-			{Name: "multiple_references_inject", Type: ptr(AttributeTypeString), Value: "foo value 1.1"},
-			{Name: "undefined_key", Type: ptr(AttributeTypeString), Value: nil},
-			{Name: "undefined_key_fallback", Type: ptr(AttributeTypeString), Value: "fallback"},
-			{Name: "env_var_in_key", Type: ptr(AttributeTypeString), Value: "value"},
-			{Name: "replace_me", Type: ptr(AttributeTypeString), Value: "${DO_NOT_REPLACE_ME}"},
-			{Name: "undefined_defaults_to_var", Type: ptr(AttributeTypeString), Value: "${STRING_VALUE}"},
-			{Name: "escaped_does_not_substitute", Type: ptr(AttributeTypeString), Value: "${STRING_VALUE}"},
-			{Name: "escaped_does_not_substitute_fallback", Type: ptr(AttributeTypeString), Value: "${STRING_VALUE:-fallback}"},
-			{Name: "escaped_and_substituted_fallback", Type: ptr(AttributeTypeString), Value: "${STRING_VALUE:-value}"},
-			{Name: "escaped_and_substituted", Type: ptr(AttributeTypeString), Value: "$value"},
-			{Name: "multiple_escaped_and_not_substituted", Type: ptr(AttributeTypeString), Value: "$${STRING_VALUE}"},
-			{Name: "undefined_key_with_escape_sequence_in_fallback", Type: ptr(AttributeTypeString), Value: "${UNDEFINED_KEY}"},
-			{Name: "value_with_escape", Type: ptr(AttributeTypeString), Value: "value$$"},
-			{Name: "escape_sequence", Type: ptr(AttributeTypeString), Value: "a $ b"},
-			{Name: "no_escape_sequence", Type: ptr(AttributeTypeString), Value: "a $ b"},
+			{Name: "string_key", Type: new(AttributeTypeString), Value: "value"},
+			{Name: "bool_key", Type: new(AttributeTypeBool), Value: true},
+			{Name: "int_key", Type: new(AttributeTypeInt), Value: 1},
+			{Name: "double_key", Type: new(AttributeTypeDouble), Value: 1.1},
+			{Name: "string_array_key", Type: new(AttributeTypeStringArray), Value: []any{"value1", "value2"}},
+			{Name: "bool_array_key", Type: new(AttributeTypeBoolArray), Value: []any{true, false}},
+			{Name: "int_array_key", Type: new(AttributeTypeIntArray), Value: []any{1, 2}},
+			{Name: "double_array_key", Type: new(AttributeTypeDoubleArray), Value: []any{1.1, 2.2}},
+			{Name: "string_value", Type: new(AttributeTypeString), Value: "value"},
+			{Name: "bool_value", Type: new(AttributeTypeBool), Value: true},
+			{Name: "int_value", Type: new(AttributeTypeInt), Value: 1},
+			{Name: "float_value", Type: new(AttributeTypeDouble), Value: 1.1},
+			{Name: "hex_value", Type: new(AttributeTypeInt), Value: int(48879)},
+			{Name: "quoted_string_value", Type: new(AttributeTypeString), Value: "value"},
+			{Name: "quoted_bool_value", Type: new(AttributeTypeString), Value: "true"},
+			{Name: "quoted_int_value", Type: new(AttributeTypeString), Value: "1"},
+			{Name: "quoted_float_value", Type: new(AttributeTypeString), Value: "1.1"},
+			{Name: "quoted_hex_value", Type: new(AttributeTypeString), Value: "0xbeef"},
+			{Name: "alternative_env_syntax", Type: new(AttributeTypeString), Value: "value"},
+			{Name: "invalid_map_value", Type: new(AttributeTypeString), Value: "value\nkey:value"},
+			{Name: "multiple_references_inject", Type: new(AttributeTypeString), Value: "foo value 1.1"},
+			{Name: "undefined_key", Type: new(AttributeTypeString), Value: nil},
+			{Name: "undefined_key_fallback", Type: new(AttributeTypeString), Value: "fallback"},
+			{Name: "env_var_in_key", Type: new(AttributeTypeString), Value: "value"},
+			{Name: "replace_me", Type: new(AttributeTypeString), Value: "${DO_NOT_REPLACE_ME}"},
+			{Name: "undefined_defaults_to_var", Type: new(AttributeTypeString), Value: "${STRING_VALUE}"},
+			{Name: "escaped_does_not_substitute", Type: new(AttributeTypeString), Value: "${STRING_VALUE}"},
+			{Name: "escaped_does_not_substitute_fallback", Type: new(AttributeTypeString), Value: "${STRING_VALUE:-fallback}"},
+			{Name: "escaped_and_substituted_fallback", Type: new(AttributeTypeString), Value: "${STRING_VALUE:-value}"},
+			{Name: "escaped_and_substituted", Type: new(AttributeTypeString), Value: "$value"},
+			{Name: "multiple_escaped_and_not_substituted", Type: new(AttributeTypeString), Value: "$${STRING_VALUE}"},
+			{Name: "undefined_key_with_escape_sequence_in_fallback", Type: new(AttributeTypeString), Value: "${UNDEFINED_KEY}"},
+			{Name: "value_with_escape", Type: new(AttributeTypeString), Value: "value$$"},
+			{Name: "escape_sequence", Type: new(AttributeTypeString), Value: "a $ b"},
+			{Name: "no_escape_sequence", Type: new(AttributeTypeString), Value: "a $ b"},
 		},
-		AttributesList: ptr("service.namespace=my-namespace,service.version=1.0.0"),
+		AttributesList: new("service.namespace=my-namespace,service.version=1.0.0"),
 		// Detectors: &Detectors{
 		// 	Attributes: &DetectorsAttributes{
 		// 		Excluded: []string{"process.command_args"},
 		// 		Included: []string{"process.*"},
 		// 	},
 		// },
-		SchemaUrl: ptr("https://opentelemetry.io/schemas/1.16.0"),
+		SchemaUrl: new("https://opentelemetry.io/schemas/1.16.0"),
 	},
 }
 
@@ -932,9 +932,9 @@ func TestUnmarshalOpenTelemetryConfiguration(t *testing.T) {
 			jsonConfig: []byte(`{"file_format": "1.0"}`),
 			yamlConfig: []byte("file_format: 1.0"),
 			wantType: OpenTelemetryConfiguration{
-				Disabled:   ptr(false),
+				Disabled:   new(false),
 				FileFormat: "1.0",
-				LogLevel:   ptr(SeverityNumberInfo),
+				LogLevel:   new(SeverityNumberInfo),
 			},
 		},
 		{
@@ -1371,7 +1371,7 @@ func TestCreateHeadersConfig(t *testing.T) {
 		{
 			name:        "headerslist only",
 			headers:     []NameStringValuePair{},
-			headersList: ptr("a=b,c=d"),
+			headersList: new("a=b,c=d"),
 			wantHeaders: map[string]string{
 				"a": "b",
 				"c": "d",
@@ -1382,11 +1382,11 @@ func TestCreateHeadersConfig(t *testing.T) {
 			headers: []NameStringValuePair{
 				{
 					Name:  "a",
-					Value: ptr("b"),
+					Value: new("b"),
 				},
 				{
 					Name:  "c",
-					Value: ptr("d"),
+					Value: new("d"),
 				},
 			},
 			headersList: nil,
@@ -1400,10 +1400,10 @@ func TestCreateHeadersConfig(t *testing.T) {
 			headers: []NameStringValuePair{
 				{
 					Name:  "a",
-					Value: ptr("b"),
+					Value: new("b"),
 				},
 			},
-			headersList: ptr("c=d"),
+			headersList: new("c=d"),
 			wantHeaders: map[string]string{
 				"a": "b",
 				"c": "d",
@@ -1414,14 +1414,14 @@ func TestCreateHeadersConfig(t *testing.T) {
 			headers: []NameStringValuePair{
 				{
 					Name:  "a",
-					Value: ptr("b"),
+					Value: new("b"),
 				},
 				{
 					Name:  "c",
-					Value: ptr("override"),
+					Value: new("override"),
 				},
 			},
-			headersList: ptr("c=d"),
+			headersList: new("c=d"),
 			wantHeaders: map[string]string{
 				"a": "b",
 				"c": "override",
@@ -1429,7 +1429,7 @@ func TestCreateHeadersConfig(t *testing.T) {
 		},
 		{
 			name:        "invalid headerslist",
-			headersList: ptr("==="),
+			headersList: new("==="),
 			wantErr:     newErrInvalid("invalid headers_list"),
 		},
 		{
@@ -1437,7 +1437,7 @@ func TestCreateHeadersConfig(t *testing.T) {
 			headers: []NameStringValuePair{
 				{
 					Name:  "",
-					Value: ptr("token"),
+					Value: new("token"),
 				},
 			},
 			wantErr: newErrInvalid("invalid header: empty name"),
@@ -1541,7 +1541,7 @@ func TestUnmarshalOTLPHttpExporter(t *testing.T) {
 			name:         "valid with exporter",
 			jsonConfig:   []byte(`{"endpoint":"localhost:4318"}`),
 			yamlConfig:   []byte("endpoint: localhost:4318\n"),
-			wantExporter: OTLPHttpExporter{Endpoint: ptr("localhost:4318")},
+			wantExporter: OTLPHttpExporter{Endpoint: new("localhost:4318")},
 		},
 		{
 			name:       "missing required endpoint field",
@@ -1553,7 +1553,7 @@ func TestUnmarshalOTLPHttpExporter(t *testing.T) {
 			name:         "valid with zero timeout",
 			jsonConfig:   []byte(`{"endpoint":"localhost:4318", "timeout":0}`),
 			yamlConfig:   []byte("endpoint: localhost:4318\ntimeout: 0"),
-			wantExporter: OTLPHttpExporter{Endpoint: ptr("localhost:4318"), Timeout: ptr(0)},
+			wantExporter: OTLPHttpExporter{Endpoint: new("localhost:4318"), Timeout: new(0)},
 		},
 		{
 			name:       "invalid data",
@@ -1594,7 +1594,7 @@ func TestUnmarshalOTLPGrpcExporter(t *testing.T) {
 			name:         "valid with exporter",
 			jsonConfig:   []byte(`{"endpoint":"localhost:4318"}`),
 			yamlConfig:   []byte("endpoint: localhost:4318\n"),
-			wantExporter: OTLPGrpcExporter{Endpoint: ptr("localhost:4318")},
+			wantExporter: OTLPGrpcExporter{Endpoint: new("localhost:4318")},
 		},
 		{
 			name:       "missing required endpoint field",
@@ -1606,7 +1606,7 @@ func TestUnmarshalOTLPGrpcExporter(t *testing.T) {
 			name:         "valid with zero timeout",
 			jsonConfig:   []byte(`{"endpoint":"localhost:4318", "timeout":0}`),
 			yamlConfig:   []byte("endpoint: localhost:4318\ntimeout: 0"),
-			wantExporter: OTLPGrpcExporter{Endpoint: ptr("localhost:4318"), Timeout: ptr(0)},
+			wantExporter: OTLPGrpcExporter{Endpoint: new("localhost:4318"), Timeout: new(0)},
 		},
 		{
 			name:       "invalid data",
@@ -1647,7 +1647,7 @@ func TestUnmarshalOTLPHttpMetricExporter(t *testing.T) {
 			name:         "valid with exporter",
 			jsonConfig:   []byte(`{"endpoint":"localhost:4318"}`),
 			yamlConfig:   []byte("endpoint: localhost:4318\n"),
-			wantExporter: OTLPHttpMetricExporter{Endpoint: ptr("localhost:4318")},
+			wantExporter: OTLPHttpMetricExporter{Endpoint: new("localhost:4318")},
 		},
 		{
 			name:       "missing required endpoint field",
@@ -1659,7 +1659,7 @@ func TestUnmarshalOTLPHttpMetricExporter(t *testing.T) {
 			name:         "valid with zero timeout",
 			jsonConfig:   []byte(`{"endpoint":"localhost:4318", "timeout":0}`),
 			yamlConfig:   []byte("endpoint: localhost:4318\ntimeout: 0"),
-			wantExporter: OTLPHttpMetricExporter{Endpoint: ptr("localhost:4318"), Timeout: ptr(0)},
+			wantExporter: OTLPHttpMetricExporter{Endpoint: new("localhost:4318"), Timeout: new(0)},
 		},
 		{
 			name:       "invalid data",
@@ -1700,7 +1700,7 @@ func TestUnmarshalOTLPGrpcMetricExporter(t *testing.T) {
 			name:         "valid with exporter",
 			jsonConfig:   []byte(`{"endpoint":"localhost:4318"}`),
 			yamlConfig:   []byte("endpoint: localhost:4318\n"),
-			wantExporter: OTLPGrpcMetricExporter{Endpoint: ptr("localhost:4318")},
+			wantExporter: OTLPGrpcMetricExporter{Endpoint: new("localhost:4318")},
 		},
 		{
 			name:       "missing required endpoint field",
@@ -1712,7 +1712,7 @@ func TestUnmarshalOTLPGrpcMetricExporter(t *testing.T) {
 			name:         "valid with zero timeout",
 			jsonConfig:   []byte(`{"endpoint":"localhost:4318", "timeout":0}`),
 			yamlConfig:   []byte("endpoint: localhost:4318\ntimeout: 0"),
-			wantExporter: OTLPGrpcMetricExporter{Endpoint: ptr("localhost:4318"), Timeout: ptr(0)},
+			wantExporter: OTLPGrpcMetricExporter{Endpoint: new("localhost:4318"), Timeout: new(0)},
 		},
 		{
 			name:       "invalid data",
@@ -1774,7 +1774,7 @@ func TestUnmarshalAttributeNameValueType(t *testing.T) {
 			wantAttributeNameValue: AttributeNameValue{
 				Name:  "test",
 				Value: "test-val",
-				Type:  ptr(AttributeTypeString),
+				Type:  new(AttributeTypeString),
 			},
 		},
 		{
@@ -1784,7 +1784,7 @@ func TestUnmarshalAttributeNameValueType(t *testing.T) {
 			wantAttributeNameValue: AttributeNameValue{
 				Name:  "test",
 				Value: []any{"test-val", "test-val-2"},
-				Type:  ptr(AttributeTypeStringArray),
+				Type:  new(AttributeTypeStringArray),
 			},
 		},
 		{
@@ -1794,7 +1794,7 @@ func TestUnmarshalAttributeNameValueType(t *testing.T) {
 			wantAttributeNameValue: AttributeNameValue{
 				Name:  "test",
 				Value: true,
-				Type:  ptr(AttributeTypeBool),
+				Type:  new(AttributeTypeBool),
 			},
 		},
 		{
@@ -1804,7 +1804,7 @@ func TestUnmarshalAttributeNameValueType(t *testing.T) {
 			wantAttributeNameValue: AttributeNameValue{
 				Name:  "test",
 				Value: []any{"test-val", "test-val-2"},
-				Type:  ptr(AttributeTypeStringArray),
+				Type:  new(AttributeTypeStringArray),
 			},
 		},
 		{
@@ -1814,7 +1814,7 @@ func TestUnmarshalAttributeNameValueType(t *testing.T) {
 			wantAttributeNameValue: AttributeNameValue{
 				Name:  "test",
 				Value: int(1),
-				Type:  ptr(AttributeTypeInt),
+				Type:  new(AttributeTypeInt),
 			},
 		},
 		{
@@ -1824,7 +1824,7 @@ func TestUnmarshalAttributeNameValueType(t *testing.T) {
 			wantAttributeNameValue: AttributeNameValue{
 				Name:  "test",
 				Value: []any{1, 2},
-				Type:  ptr(AttributeTypeIntArray),
+				Type:  new(AttributeTypeIntArray),
 			},
 		},
 		{
@@ -1834,7 +1834,7 @@ func TestUnmarshalAttributeNameValueType(t *testing.T) {
 			wantAttributeNameValue: AttributeNameValue{
 				Name:  "test",
 				Value: float64(1),
-				Type:  ptr(AttributeTypeDouble),
+				Type:  new(AttributeTypeDouble),
 			},
 		},
 		{
@@ -1844,7 +1844,7 @@ func TestUnmarshalAttributeNameValueType(t *testing.T) {
 			wantAttributeNameValue: AttributeNameValue{
 				Name:  "test",
 				Value: []any{float64(1), float64(2)},
-				Type:  ptr(AttributeTypeDoubleArray),
+				Type:  new(AttributeTypeDoubleArray),
 			},
 		},
 		{
@@ -1906,7 +1906,7 @@ func TestUnmarshalNameStringValuePairType(t *testing.T) {
 			yamlConfig: []byte("name: test\nvalue: test-val\ntype: string\n"),
 			wantNameStringValuePair: NameStringValuePair{
 				Name:  "test",
-				Value: ptr("test-val"),
+				Value: new("test-val"),
 			},
 		},
 		{

--- a/otelconf/config_yaml.go
+++ b/otelconf/config_yaml.go
@@ -77,7 +77,7 @@ func (j *OpenTelemetryConfiguration) UnmarshalYAML(node *yaml.Node) error {
 	} else {
 		// Configure the log level of the internal logger used by the SDK.
 		// If omitted, info is used.
-		sh.Plain.Disabled = ptr(false)
+		sh.Plain.Disabled = new(false)
 	}
 	if sh.LoggerProvider != nil {
 		sh.Plain.LoggerProvider = sh.LoggerProvider
@@ -100,7 +100,7 @@ func (j *OpenTelemetryConfiguration) UnmarshalYAML(node *yaml.Node) error {
 	} else {
 		// Configure the log level of the internal logger used by the SDK.
 		// If omitted, info is used.
-		sh.Plain.LogLevel = ptr(SeverityNumberInfo)
+		sh.Plain.LogLevel = new(SeverityNumberInfo)
 	}
 
 	*j = OpenTelemetryConfiguration(sh.Plain)

--- a/otelconf/go.mod
+++ b/otelconf/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/otelconf
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/prometheus/client_golang v1.24.1

--- a/otelconf/internal/tls/config_test.go
+++ b/otelconf/internal/tls/config_test.go
@@ -32,7 +32,7 @@ func TestCreateConfig(t *testing.T) {
 		},
 		{
 			name:       "only-cacert-provided",
-			caCertFile: ptr(material.CACertPath),
+			caCertFile: new(material.CACertPath),
 			want: func(result *tls.Config, t *testing.T) {
 				require.Nil(t, result.Certificates)
 				require.NotNil(t, result.RootCAs)
@@ -40,23 +40,23 @@ func TestCreateConfig(t *testing.T) {
 		},
 		{
 			name:            "nonexistent-cacert-file",
-			caCertFile:      ptr("nowhere.crt"),
+			caCertFile:      new("nowhere.crt"),
 			wantErrContains: "open nowhere.crt:",
 		},
 		{
 			name:            "nonexistent-clientcert-file",
-			clientCertFile:  ptr("nowhere.crt"),
-			clientKeyFile:   ptr("nowhere.crt"),
+			clientCertFile:  new("nowhere.crt"),
+			clientKeyFile:   new("nowhere.crt"),
 			wantErrContains: "could not use client certificate: open nowhere.crt:",
 		},
 		{
 			name:            "clientkey-without-clientcert",
-			clientKeyFile:   ptr("nowhere.key"),
+			clientKeyFile:   new("nowhere.key"),
 			wantErrContains: "client key was provided but no client certificate was provided",
 		},
 		{
 			name:            "bad-cacert-file",
-			caCertFile:      ptr(material.BadCertPath),
+			caCertFile:      new(material.BadCertPath),
 			wantErrContains: "could not create certificate authority chain from certificate",
 		},
 	}
@@ -73,8 +73,4 @@ func TestCreateConfig(t *testing.T) {
 			}
 		})
 	}
-}
-
-func ptr[T any](v T) *T {
-	return &v
 }

--- a/otelconf/log_test.go
+++ b/otelconf/log_test.go
@@ -68,8 +68,8 @@ func TestLoggerProvider(t *testing.T) {
 				opentelemetryConfig: OpenTelemetryConfiguration{
 					LoggerProvider: &LoggerProvider{
 						Limits: &LogRecordLimits{
-							AttributeCountLimit:       ptr(50),
-							AttributeValueLengthLimit: ptr(100),
+							AttributeCountLimit:       new(50),
+							AttributeValueLengthLimit: new(100),
 						},
 					},
 				},
@@ -132,7 +132,7 @@ func TestLogProcessor(t *testing.T) {
 
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(0),
+					MaxExportBatchSize: new(0),
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{},
 					},
@@ -144,7 +144,7 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch processor invalid export timeout otlphttp exporter",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					ExportTimeout: ptr(-2),
+					ExportTimeout: new(-2),
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{},
 					},
@@ -157,7 +157,7 @@ func TestLogProcessor(t *testing.T) {
 
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxQueueSize: ptr(-3),
+					MaxQueueSize: new(-3),
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{},
 					},
@@ -169,7 +169,7 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch processor invalid schedule delay console exporter",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					ScheduleDelay: ptr(-4),
+					ScheduleDelay: new(-4),
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{},
 					},
@@ -190,10 +190,10 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/console",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						Console: ConsoleExporter{},
 					},
@@ -205,16 +205,16 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-exporter-no-endpoint",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -226,17 +226,17 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-exporter",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr("http://localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("http://localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -248,17 +248,17 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-exporter-socket-endpoint",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr("unix:collector.sock"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("unix:collector.sock"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -272,11 +272,11 @@ func TestLogProcessor(t *testing.T) {
 				Batch: &BatchLogRecordProcessor{
 					Exporter: LogRecordExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &GrpcTls{
-								CaFile: ptr(material.CACertPath),
+								CaFile: new(material.CACertPath),
 							},
 						},
 					},
@@ -290,11 +290,11 @@ func TestLogProcessor(t *testing.T) {
 				Batch: &BatchLogRecordProcessor{
 					Exporter: LogRecordExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &GrpcTls{
-								CaFile: ptr(material.BadCertPath),
+								CaFile: new(material.BadCertPath),
 							},
 						},
 					},
@@ -308,10 +308,10 @@ func TestLogProcessor(t *testing.T) {
 				Batch: &BatchLogRecordProcessor{
 					Exporter: LogRecordExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
-							HeadersList: ptr("==="),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
+							HeadersList: new("==="),
 						},
 					},
 				},
@@ -324,12 +324,12 @@ func TestLogProcessor(t *testing.T) {
 				Batch: &BatchLogRecordProcessor{
 					Exporter: LogRecordExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &GrpcTls{
-								KeyFile:  ptr(material.BadCertPath),
-								CertFile: ptr(material.BadCertPath),
+								KeyFile:  new(material.BadCertPath),
+								CertFile: new(material.BadCertPath),
 							},
 						},
 					},
@@ -341,17 +341,17 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-exporter-no-scheme",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -363,17 +363,17 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-invalid-endpoint",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr(" "),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new(" "),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -385,17 +385,17 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-invalid-compression",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("invalid"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("invalid"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -407,17 +407,17 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-http-exporter",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("http://localhost:4318"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("http://localhost:4318"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -431,11 +431,11 @@ func TestLogProcessor(t *testing.T) {
 				Batch: &BatchLogRecordProcessor{
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &HttpTls{
-								CaFile: ptr(material.CACertPath),
+								CaFile: new(material.CACertPath),
 							},
 						},
 					},
@@ -449,11 +449,11 @@ func TestLogProcessor(t *testing.T) {
 				Batch: &BatchLogRecordProcessor{
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &HttpTls{
-								CaFile: ptr(material.BadCertPath),
+								CaFile: new(material.BadCertPath),
 							},
 						},
 					},
@@ -467,12 +467,12 @@ func TestLogProcessor(t *testing.T) {
 				Batch: &BatchLogRecordProcessor{
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &HttpTls{
-								KeyFile:  ptr(material.BadCertPath),
-								CertFile: ptr(material.BadCertPath),
+								KeyFile:  new(material.BadCertPath),
+								CertFile: new(material.BadCertPath),
 							},
 						},
 					},
@@ -486,10 +486,10 @@ func TestLogProcessor(t *testing.T) {
 				Batch: &BatchLogRecordProcessor{
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
-							HeadersList: ptr("==="),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
+							HeadersList: new("==="),
 						},
 					},
 				},
@@ -500,17 +500,17 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-http-exporter-with-path",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("http://localhost:4318/path/123"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("http://localhost:4318/path/123"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -522,16 +522,16 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-http-exporter-no-endpoint",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -543,17 +543,17 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-http-exporter-no-scheme",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -565,17 +565,17 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-http-invalid-endpoint",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr(" "),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new(" "),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -587,17 +587,17 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-http-none-compression",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -609,17 +609,17 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-http-invalid-compression",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("invalid"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("invalid"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -631,14 +631,14 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-http-invalid-encoding",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint: ptr("http://localhost:4318"),
-							Encoding: ptr(OTLPHttpEncoding("json")),
+							Endpoint: new("http://localhost:4318"),
+							Encoding: new(OTLPHttpEncoding("json")),
 						},
 					},
 				},
@@ -692,11 +692,11 @@ func TestLogProcessor(t *testing.T) {
 				Simple: &SimpleLogRecordProcessor{
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -734,7 +734,7 @@ func TestLoggerProviderOptions(t *testing.T) {
 				Simple: &SimpleLogRecordProcessor{
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint: ptr(srv.URL),
+							Endpoint: new(srv.URL),
 						},
 					},
 				},
@@ -784,22 +784,22 @@ func TestLogProcessorLimits(t *testing.T) {
 		{
 			name: "attribute-count-limit-only",
 			limits: LogRecordLimits{
-				AttributeCountLimit: ptr(50),
+				AttributeCountLimit: new(50),
 			},
 			wantAdditionalOpts: 1,
 		},
 		{
 			name: "attribute-value-length-limit-only",
 			limits: LogRecordLimits{
-				AttributeValueLengthLimit: ptr(100),
+				AttributeValueLengthLimit: new(100),
 			},
 			wantAdditionalOpts: 1,
 		},
 		{
 			name: "both-limits",
 			limits: LogRecordLimits{
-				AttributeCountLimit:       ptr(50),
-				AttributeValueLengthLimit: ptr(100),
+				AttributeCountLimit:       new(50),
+				AttributeValueLengthLimit: new(100),
 			},
 			wantAdditionalOpts: 2,
 		},
@@ -831,13 +831,13 @@ func Test_otlpGRPCLogExporter(t *testing.T) {
 			args: args{
 				ctx: t.Context(),
 				otlpConfig: &OTLPGrpcExporter{
-					Compression: ptr("gzip"),
-					Timeout:     ptr(50000),
+					Compression: new("gzip"),
+					Timeout:     new(50000),
 					Tls: &GrpcTls{
-						Insecure: ptr(true),
+						Insecure: new(true),
 					},
 					Headers: []NameStringValuePair{
-						{Name: "test", Value: ptr("test1")},
+						{Name: "test", Value: new("test1")},
 					},
 				},
 			},
@@ -850,13 +850,13 @@ func Test_otlpGRPCLogExporter(t *testing.T) {
 			args: args{
 				ctx: t.Context(),
 				otlpConfig: &OTLPGrpcExporter{
-					Compression: ptr("gzip"),
-					Timeout:     ptr(50000),
+					Compression: new("gzip"),
+					Timeout:     new(50000),
 					Tls: &GrpcTls{
-						CaFile: ptr(material.CACertPath),
+						CaFile: new(material.CACertPath),
 					},
 					Headers: []NameStringValuePair{
-						{Name: "test", Value: ptr("test1")},
+						{Name: "test", Value: new("test1")},
 					},
 				},
 			},
@@ -875,15 +875,15 @@ func Test_otlpGRPCLogExporter(t *testing.T) {
 			args: args{
 				ctx: t.Context(),
 				otlpConfig: &OTLPGrpcExporter{
-					Compression: ptr("gzip"),
-					Timeout:     ptr(50000),
+					Compression: new("gzip"),
+					Timeout:     new(50000),
 					Tls: &GrpcTls{
-						CaFile:   ptr(material.CACertPath),
-						KeyFile:  ptr(material.ClientKeyPath),
-						CertFile: ptr(material.ClientCertPath),
+						CaFile:   new(material.CACertPath),
+						KeyFile:  new(material.ClientKeyPath),
+						CertFile: new(material.ClientCertPath),
 					},
 					Headers: []NameStringValuePair{
-						{Name: "test", Value: ptr("test1")},
+						{Name: "test", Value: new("test1")},
 					},
 				},
 			},
@@ -918,7 +918,7 @@ func Test_otlpGRPCLogExporter(t *testing.T) {
 			if tt.args.otlpConfig.Tls != nil && tt.args.otlpConfig.Tls.Insecure != nil && *tt.args.otlpConfig.Tls.Insecure {
 				scheme = "http"
 			}
-			tt.args.otlpConfig.Endpoint = ptr(scheme + "://" + n.Addr().String())
+			tt.args.otlpConfig.Endpoint = new(scheme + "://" + n.Addr().String())
 
 			serverOpts, err := tt.grpcServerOpts()
 			require.NoError(t, err)

--- a/otelconf/metric_test.go
+++ b/otelconf/metric_test.go
@@ -114,7 +114,7 @@ func TestMeterProviderOptions(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPHttp: &OTLPHttpMetricExporter{
-							Endpoint: ptr(srv.URL),
+							Endpoint: new(srv.URL),
 						},
 					},
 				},
@@ -186,11 +186,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPGrpc: &OTLPGrpcMetricExporter{
-							Endpoint:    ptr("http://localhost:4318"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("http://localhost:4318"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -204,11 +204,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPGrpc: &OTLPGrpcMetricExporter{
-							Endpoint:    ptr("http://localhost:4318/path/123"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("http://localhost:4318/path/123"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -222,11 +222,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPGrpc: &OTLPGrpcMetricExporter{
-							Endpoint:    ptr("https://localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("https://localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &GrpcTls{
-								CaFile: ptr(material.CACertPath),
+								CaFile: new(material.CACertPath),
 							},
 						},
 					},
@@ -240,11 +240,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPGrpc: &OTLPGrpcMetricExporter{
-							Endpoint:    ptr("https://localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("https://localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &GrpcTls{
-								CaFile: ptr(material.BadCertPath),
+								CaFile: new(material.BadCertPath),
 							},
 						},
 					},
@@ -258,12 +258,12 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPGrpc: &OTLPGrpcMetricExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &GrpcTls{
-								KeyFile:  ptr(material.BadCertPath),
-								CertFile: ptr(material.BadCertPath),
+								KeyFile:  new(material.BadCertPath),
+								CertFile: new(material.BadCertPath),
 							},
 						},
 					},
@@ -277,10 +277,10 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPGrpc: &OTLPGrpcMetricExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
-							HeadersList: ptr("==="),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
+							HeadersList: new("==="),
 						},
 					},
 				},
@@ -293,10 +293,10 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPGrpc: &OTLPGrpcMetricExporter{
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -310,11 +310,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPGrpc: &OTLPGrpcMetricExporter{
-							Endpoint:    ptr("unix:collector.sock"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("unix:collector.sock"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -328,11 +328,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPGrpc: &OTLPGrpcMetricExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -346,11 +346,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPGrpc: &OTLPGrpcMetricExporter{
-							Endpoint:    ptr(" "),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new(" "),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -364,11 +364,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPGrpc: &OTLPGrpcMetricExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -382,13 +382,13 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPGrpc: &OTLPGrpcMetricExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
-							TemporalityPreference: ptr(ExporterTemporalityPreferenceDelta),
+							TemporalityPreference: new(ExporterTemporalityPreferenceDelta),
 						},
 					},
 				},
@@ -401,13 +401,13 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPGrpc: &OTLPGrpcMetricExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
-							TemporalityPreference: ptr(ExporterTemporalityPreferenceCumulative),
+							TemporalityPreference: new(ExporterTemporalityPreferenceCumulative),
 						},
 					},
 				},
@@ -420,13 +420,13 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPGrpc: &OTLPGrpcMetricExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
-							TemporalityPreference: ptr(ExporterTemporalityPreferenceLowMemory),
+							TemporalityPreference: new(ExporterTemporalityPreferenceLowMemory),
 						},
 					},
 				},
@@ -439,13 +439,13 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPGrpc: &OTLPGrpcMetricExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
-							TemporalityPreference: (*ExporterTemporalityPreference)(ptr("invalid")),
+							TemporalityPreference: (*ExporterTemporalityPreference)(new("invalid")),
 						},
 					},
 				},
@@ -458,11 +458,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPGrpc: &OTLPGrpcMetricExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("invalid"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("invalid"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -476,11 +476,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPHttp: &OTLPHttpMetricExporter{
-							Endpoint:    ptr("http://localhost:4318"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("http://localhost:4318"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -494,11 +494,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPHttp: &OTLPHttpMetricExporter{
-							Endpoint:    ptr("https://localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("https://localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &HttpTls{
-								CaFile: ptr(material.CACertPath),
+								CaFile: new(material.CACertPath),
 							},
 						},
 					},
@@ -512,11 +512,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPHttp: &OTLPHttpMetricExporter{
-							Endpoint:    ptr("https://localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("https://localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &HttpTls{
-								CaFile: ptr(material.BadCertPath),
+								CaFile: new(material.BadCertPath),
 							},
 						},
 					},
@@ -530,12 +530,12 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPHttp: &OTLPHttpMetricExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &HttpTls{
-								KeyFile:  ptr(material.BadCertPath),
-								CertFile: ptr(material.BadCertPath),
+								KeyFile:  new(material.BadCertPath),
+								CertFile: new(material.BadCertPath),
 							},
 						},
 					},
@@ -549,10 +549,10 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPHttp: &OTLPHttpMetricExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
-							HeadersList: ptr("==="),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
+							HeadersList: new("==="),
 						},
 					},
 				},
@@ -565,11 +565,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPHttp: &OTLPHttpMetricExporter{
-							Endpoint:    ptr("http://localhost:4318/path/123"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("http://localhost:4318/path/123"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -583,10 +583,10 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPHttp: &OTLPHttpMetricExporter{
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -600,11 +600,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPHttp: &OTLPHttpMetricExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -618,11 +618,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPHttp: &OTLPHttpMetricExporter{
-							Endpoint:    ptr(" "),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new(" "),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -636,11 +636,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPHttp: &OTLPHttpMetricExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -654,13 +654,13 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPHttp: &OTLPHttpMetricExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
-							TemporalityPreference: ptr(ExporterTemporalityPreferenceCumulative),
+							TemporalityPreference: new(ExporterTemporalityPreferenceCumulative),
 						},
 					},
 				},
@@ -673,13 +673,13 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPHttp: &OTLPHttpMetricExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
-							TemporalityPreference: ptr(ExporterTemporalityPreferenceLowMemory),
+							TemporalityPreference: new(ExporterTemporalityPreferenceLowMemory),
 						},
 					},
 				},
@@ -692,13 +692,13 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPHttp: &OTLPHttpMetricExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
-							TemporalityPreference: ptr(ExporterTemporalityPreferenceDelta),
+							TemporalityPreference: new(ExporterTemporalityPreferenceDelta),
 						},
 					},
 				},
@@ -711,13 +711,13 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPHttp: &OTLPHttpMetricExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
-							TemporalityPreference: (*ExporterTemporalityPreference)(ptr("invalid")),
+							TemporalityPreference: (*ExporterTemporalityPreference)(new("invalid")),
 						},
 					},
 				},
@@ -730,11 +730,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPHttp: &OTLPHttpMetricExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("invalid"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("invalid"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -748,8 +748,8 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPHttp: &OTLPHttpMetricExporter{
-							Endpoint: ptr("http://localhost:4318"),
-							Encoding: ptr(OTLPHttpEncoding("json")),
+							Endpoint: new("http://localhost:4318"),
+							Encoding: new(OTLPHttpEncoding("json")),
 						},
 					},
 				},
@@ -770,13 +770,13 @@ func TestReader(t *testing.T) {
 			reader: MetricReader{
 				Periodic: &PeriodicMetricReader{
 					CardinalityLimits: &CardinalityLimits{
-						Counter:                 ptr(100),
-						UpDownCounter:           ptr(200),
-						Histogram:               ptr(300),
-						ObservableCounter:       ptr(400),
-						ObservableUpDownCounter: ptr(500),
-						ObservableGauge:         ptr(600),
-						Gauge:                   ptr(700),
+						Counter:                 new(100),
+						UpDownCounter:           new(200),
+						Histogram:               new(300),
+						ObservableCounter:       new(400),
+						ObservableUpDownCounter: new(500),
+						ObservableGauge:         new(600),
+						Gauge:                   new(700),
 					},
 					Exporter: PushMetricExporter{
 						Console: &ConsoleMetricExporter{},
@@ -811,7 +811,7 @@ func TestReader(t *testing.T) {
 			reader: MetricReader{
 				Periodic: &PeriodicMetricReader{
 					CardinalityLimits: &CardinalityLimits{
-						Default: ptr(50),
+						Default: new(50),
 					},
 					Exporter: PushMetricExporter{
 						Console: &ConsoleMetricExporter{},
@@ -840,8 +840,8 @@ func TestReader(t *testing.T) {
 			name: "periodic/console-exporter-with-extra-options",
 			reader: MetricReader{
 				Periodic: &PeriodicMetricReader{
-					Interval: ptr(30_000),
-					Timeout:  ptr(5_000),
+					Interval: new(30_000),
+					Timeout:  new(5_000),
 					Exporter: PushMetricExporter{
 						Console: &ConsoleMetricExporter{},
 					},
@@ -893,13 +893,13 @@ func TestCardinalityLimitSelector(t *testing.T) {
 
 	t.Run("per-kind limits", func(t *testing.T) {
 		cl := &CardinalityLimits{
-			Counter:                 ptr(100),
-			UpDownCounter:           ptr(200),
-			Histogram:               ptr(300),
-			ObservableCounter:       ptr(400),
-			ObservableUpDownCounter: ptr(500),
-			ObservableGauge:         ptr(600),
-			Gauge:                   ptr(700),
+			Counter:                 new(100),
+			UpDownCounter:           new(200),
+			Histogram:               new(300),
+			ObservableCounter:       new(400),
+			ObservableUpDownCounter: new(500),
+			ObservableGauge:         new(600),
+			Gauge:                   new(700),
 		}
 		sel := cardinalityLimitSelector(cl)
 		expected := map[sdkmetric.InstrumentKind]int{
@@ -920,7 +920,7 @@ func TestCardinalityLimitSelector(t *testing.T) {
 
 	t.Run("default limit used when kind not set", func(t *testing.T) {
 		cl := &CardinalityLimits{
-			Default: ptr(50),
+			Default: new(50),
 		}
 		sel := cardinalityLimitSelector(cl)
 		for _, ik := range allKinds {
@@ -932,8 +932,8 @@ func TestCardinalityLimitSelector(t *testing.T) {
 
 	t.Run("per-kind overrides default", func(t *testing.T) {
 		cl := &CardinalityLimits{
-			Default: ptr(50),
-			Counter: ptr(100),
+			Default: new(50),
+			Counter: new(100),
 		}
 		sel := cardinalityLimitSelector(cl)
 		limit, fallback := sel(sdkmetric.InstrumentKindCounter)
@@ -968,7 +968,7 @@ func TestMetricReaderCardinalityLimitsWired(t *testing.T) {
 	reader, err := metricReader(ctx, MetricReader{
 		Periodic: &PeriodicMetricReader{
 			CardinalityLimits: &CardinalityLimits{
-				Counter: ptr(1),
+				Counter: new(1),
 			},
 			Exporter: PushMetricExporter{
 				Console: &ConsoleMetricExporter{},
@@ -1014,7 +1014,7 @@ func TestView(t *testing.T) {
 			name: "selector/invalid_type",
 			view: View{
 				Selector: ViewSelector{
-					InstrumentType: (*InstrumentType)(ptr("invalid_type")),
+					InstrumentType: (*InstrumentType)(new("invalid_type")),
 				},
 			},
 			wantErr: "view_selector: instrument_type: invalid value",
@@ -1030,12 +1030,12 @@ func TestView(t *testing.T) {
 			name: "all selectors match",
 			view: View{
 				Selector: ViewSelector{
-					InstrumentName: ptr("test_name"),
-					InstrumentType: ptr(InstrumentTypeCounter),
-					Unit:           ptr("test_unit"),
-					MeterName:      ptr("test_meter_name"),
-					MeterVersion:   ptr("test_meter_version"),
-					MeterSchemaUrl: ptr("test_schema_url"),
+					InstrumentName: new("test_name"),
+					InstrumentType: new(InstrumentTypeCounter),
+					Unit:           new("test_unit"),
+					MeterName:      new("test_meter_name"),
+					MeterVersion:   new("test_meter_version"),
+					MeterSchemaUrl: new("test_schema_url"),
 				},
 			},
 			matchInstrument: &sdkmetric.Instrument{
@@ -1055,12 +1055,12 @@ func TestView(t *testing.T) {
 			name: "all selectors no match name",
 			view: View{
 				Selector: ViewSelector{
-					InstrumentName: ptr("test_name"),
-					InstrumentType: ptr(InstrumentTypeCounter),
-					Unit:           ptr("test_unit"),
-					MeterName:      ptr("test_meter_name"),
-					MeterVersion:   ptr("test_meter_version"),
-					MeterSchemaUrl: ptr("test_schema_url"),
+					InstrumentName: new("test_name"),
+					InstrumentType: new(InstrumentTypeCounter),
+					Unit:           new("test_unit"),
+					MeterName:      new("test_meter_name"),
+					MeterVersion:   new("test_meter_version"),
+					MeterSchemaUrl: new("test_schema_url"),
 				},
 			},
 			matchInstrument: &sdkmetric.Instrument{
@@ -1080,12 +1080,12 @@ func TestView(t *testing.T) {
 			name: "all selectors no match unit",
 			view: View{
 				Selector: ViewSelector{
-					InstrumentName: ptr("test_name"),
-					InstrumentType: ptr(InstrumentTypeCounter),
-					Unit:           ptr("test_unit"),
-					MeterName:      ptr("test_meter_name"),
-					MeterVersion:   ptr("test_meter_version"),
-					MeterSchemaUrl: ptr("test_schema_url"),
+					InstrumentName: new("test_name"),
+					InstrumentType: new(InstrumentTypeCounter),
+					Unit:           new("test_unit"),
+					MeterName:      new("test_meter_name"),
+					MeterVersion:   new("test_meter_version"),
+					MeterSchemaUrl: new("test_schema_url"),
 				},
 			},
 			matchInstrument: &sdkmetric.Instrument{
@@ -1105,12 +1105,12 @@ func TestView(t *testing.T) {
 			name: "all selectors no match kind",
 			view: View{
 				Selector: ViewSelector{
-					InstrumentName: ptr("test_name"),
-					InstrumentType: (*InstrumentType)(ptr("histogram")),
-					Unit:           ptr("test_unit"),
-					MeterName:      ptr("test_meter_name"),
-					MeterVersion:   ptr("test_meter_version"),
-					MeterSchemaUrl: ptr("test_schema_url"),
+					InstrumentName: new("test_name"),
+					InstrumentType: (*InstrumentType)(new("histogram")),
+					Unit:           new("test_unit"),
+					MeterName:      new("test_meter_name"),
+					MeterVersion:   new("test_meter_version"),
+					MeterSchemaUrl: new("test_schema_url"),
 				},
 			},
 			matchInstrument: &sdkmetric.Instrument{
@@ -1130,12 +1130,12 @@ func TestView(t *testing.T) {
 			name: "all selectors no match meter name",
 			view: View{
 				Selector: ViewSelector{
-					InstrumentName: ptr("test_name"),
-					InstrumentType: ptr(InstrumentTypeCounter),
-					Unit:           ptr("test_unit"),
-					MeterName:      ptr("test_meter_name"),
-					MeterVersion:   ptr("test_meter_version"),
-					MeterSchemaUrl: ptr("test_schema_url"),
+					InstrumentName: new("test_name"),
+					InstrumentType: new(InstrumentTypeCounter),
+					Unit:           new("test_unit"),
+					MeterName:      new("test_meter_name"),
+					MeterVersion:   new("test_meter_version"),
+					MeterSchemaUrl: new("test_schema_url"),
 				},
 			},
 			matchInstrument: &sdkmetric.Instrument{
@@ -1155,12 +1155,12 @@ func TestView(t *testing.T) {
 			name: "all selectors no match meter version",
 			view: View{
 				Selector: ViewSelector{
-					InstrumentName: ptr("test_name"),
-					InstrumentType: ptr(InstrumentTypeCounter),
-					Unit:           ptr("test_unit"),
-					MeterName:      ptr("test_meter_name"),
-					MeterVersion:   ptr("test_meter_version"),
-					MeterSchemaUrl: ptr("test_schema_url"),
+					InstrumentName: new("test_name"),
+					InstrumentType: new(InstrumentTypeCounter),
+					Unit:           new("test_unit"),
+					MeterName:      new("test_meter_name"),
+					MeterVersion:   new("test_meter_version"),
+					MeterSchemaUrl: new("test_schema_url"),
 				},
 			},
 			matchInstrument: &sdkmetric.Instrument{
@@ -1180,12 +1180,12 @@ func TestView(t *testing.T) {
 			name: "all selectors no match meter schema url",
 			view: View{
 				Selector: ViewSelector{
-					InstrumentName: ptr("test_name"),
-					InstrumentType: ptr(InstrumentTypeCounter),
-					Unit:           ptr("test_unit"),
-					MeterName:      ptr("test_meter_name"),
-					MeterVersion:   ptr("test_meter_version"),
-					MeterSchemaUrl: ptr("test_schema_url"),
+					InstrumentName: new("test_name"),
+					InstrumentType: new(InstrumentTypeCounter),
+					Unit:           new("test_unit"),
+					MeterName:      new("test_meter_name"),
+					MeterVersion:   new("test_meter_version"),
+					MeterSchemaUrl: new("test_schema_url"),
 				},
 			},
 			matchInstrument: &sdkmetric.Instrument{
@@ -1205,13 +1205,13 @@ func TestView(t *testing.T) {
 			name: "with stream",
 			view: View{
 				Selector: ViewSelector{
-					InstrumentName: ptr("test_name"),
-					Unit:           ptr("test_unit"),
+					InstrumentName: new("test_name"),
+					Unit:           new("test_unit"),
 				},
 				Stream: ViewStream{
-					Name:          ptr("new_name"),
-					Description:   ptr("new_description"),
-					AttributeKeys: ptr(IncludeExclude{Included: []string{"foo", "bar"}}),
+					Name:          new("new_name"),
+					Description:   new("new_description"),
+					AttributeKeys: new(IncludeExclude{Included: []string{"foo", "bar"}}),
 					Aggregation:   &Aggregation{Sum: make(SumAggregation)},
 				},
 			},
@@ -1260,37 +1260,37 @@ func TestInstrumentType(t *testing.T) {
 		},
 		{
 			name:     "counter",
-			instType: ptr(InstrumentTypeCounter),
+			instType: new(InstrumentTypeCounter),
 			wantKind: sdkmetric.InstrumentKindCounter,
 		},
 		{
 			name:     "up_down_counter",
-			instType: ptr(InstrumentTypeUpDownCounter),
+			instType: new(InstrumentTypeUpDownCounter),
 			wantKind: sdkmetric.InstrumentKindUpDownCounter,
 		},
 		{
 			name:     "histogram",
-			instType: ptr(InstrumentTypeHistogram),
+			instType: new(InstrumentTypeHistogram),
 			wantKind: sdkmetric.InstrumentKindHistogram,
 		},
 		{
 			name:     "observable_counter",
-			instType: ptr(InstrumentTypeObservableCounter),
+			instType: new(InstrumentTypeObservableCounter),
 			wantKind: sdkmetric.InstrumentKindObservableCounter,
 		},
 		{
 			name:     "observable_up_down_counter",
-			instType: ptr(InstrumentTypeObservableUpDownCounter),
+			instType: new(InstrumentTypeObservableUpDownCounter),
 			wantKind: sdkmetric.InstrumentKindObservableUpDownCounter,
 		},
 		{
 			name:     "observable_gauge",
-			instType: ptr(InstrumentTypeObservableGauge),
+			instType: new(InstrumentTypeObservableGauge),
 			wantKind: sdkmetric.InstrumentKindObservableGauge,
 		},
 		{
 			name:     "invalid",
-			instType: (*InstrumentType)(ptr("invalid")),
+			instType: (*InstrumentType)(new("invalid")),
 			wantErr:  errors.New("instrument_type: invalid value"),
 		},
 	}
@@ -1338,9 +1338,9 @@ func TestAggregation(t *testing.T) {
 			name: "Base2ExponentialBucketHistogram",
 			aggregation: &Aggregation{
 				Base2ExponentialBucketHistogram: &Base2ExponentialBucketHistogramAggregation{
-					MaxSize:      ptr(2),
-					MaxScale:     ptr(3),
-					RecordMinMax: ptr(true),
+					MaxSize:      new(2),
+					MaxScale:     new(3),
+					RecordMinMax: new(true),
 				},
 			},
 			wantAggregation: sdkmetric.AggregationBase2ExponentialHistogram{
@@ -1378,7 +1378,7 @@ func TestAggregation(t *testing.T) {
 			aggregation: &Aggregation{
 				ExplicitBucketHistogram: &ExplicitBucketHistogramAggregation{
 					Boundaries:   []float64{1, 2, 3},
-					RecordMinMax: ptr(true),
+					RecordMinMax: new(true),
 				},
 			},
 			wantAggregation: sdkmetric.AggregationExplicitBucketHistogram{
@@ -1424,7 +1424,7 @@ func TestNewIncludeExcludeFilter(t *testing.T) {
 		},
 		{
 			name: "filter-with-include",
-			attributeKeys: ptr(IncludeExclude{
+			attributeKeys: new(IncludeExclude{
 				Included: []string{"foo"},
 			}),
 			wantPass: []string{"foo"},
@@ -1432,7 +1432,7 @@ func TestNewIncludeExcludeFilter(t *testing.T) {
 		},
 		{
 			name: "filter-with-exclude",
-			attributeKeys: ptr(IncludeExclude{
+			attributeKeys: new(IncludeExclude{
 				Excluded: []string{"foo"},
 			}),
 			wantPass: []string{"bar"},
@@ -1440,7 +1440,7 @@ func TestNewIncludeExcludeFilter(t *testing.T) {
 		},
 		{
 			name: "filter-with-include-and-exclude",
-			attributeKeys: ptr(IncludeExclude{
+			attributeKeys: new(IncludeExclude{
 				Included: []string{"bar"},
 				Excluded: []string{"foo"},
 			}),
@@ -1463,7 +1463,7 @@ func TestNewIncludeExcludeFilter(t *testing.T) {
 }
 
 func TestNewIncludeExcludeFilterError(t *testing.T) {
-	_, err := newIncludeExcludeFilter(ptr(IncludeExclude{
+	_, err := newIncludeExcludeFilter(new(IncludeExclude{
 		Included: []string{"foo"},
 		Excluded: []string{"foo"},
 	}))
@@ -1486,13 +1486,13 @@ func Test_otlpGRPCMetricExporter(t *testing.T) {
 			args: args{
 				ctx: t.Context(),
 				otlpConfig: &OTLPGrpcMetricExporter{
-					Compression: ptr("gzip"),
-					Timeout:     ptr(50000),
+					Compression: new("gzip"),
+					Timeout:     new(50000),
 					Tls: &GrpcTls{
-						Insecure: ptr(true),
+						Insecure: new(true),
 					},
 					Headers: []NameStringValuePair{
-						{Name: "test", Value: ptr("test1")},
+						{Name: "test", Value: new("test1")},
 					},
 				},
 			},
@@ -1505,13 +1505,13 @@ func Test_otlpGRPCMetricExporter(t *testing.T) {
 			args: args{
 				ctx: t.Context(),
 				otlpConfig: &OTLPGrpcMetricExporter{
-					Compression: ptr("gzip"),
-					Timeout:     ptr(50000),
+					Compression: new("gzip"),
+					Timeout:     new(50000),
 					Tls: &GrpcTls{
-						CaFile: ptr(material.CACertPath),
+						CaFile: new(material.CACertPath),
 					},
 					Headers: []NameStringValuePair{
-						{Name: "test", Value: ptr("test1")},
+						{Name: "test", Value: new("test1")},
 					},
 				},
 			},
@@ -1530,15 +1530,15 @@ func Test_otlpGRPCMetricExporter(t *testing.T) {
 			args: args{
 				ctx: t.Context(),
 				otlpConfig: &OTLPGrpcMetricExporter{
-					Compression: ptr("gzip"),
-					Timeout:     ptr(50000),
+					Compression: new("gzip"),
+					Timeout:     new(50000),
 					Tls: &GrpcTls{
-						CaFile:   ptr(material.CACertPath),
-						KeyFile:  ptr(material.ClientKeyPath),
-						CertFile: ptr(material.ClientCertPath),
+						CaFile:   new(material.CACertPath),
+						KeyFile:  new(material.ClientKeyPath),
+						CertFile: new(material.ClientCertPath),
 					},
 					Headers: []NameStringValuePair{
-						{Name: "test", Value: ptr("test1")},
+						{Name: "test", Value: new("test1")},
 					},
 				},
 			},
@@ -1573,7 +1573,7 @@ func Test_otlpGRPCMetricExporter(t *testing.T) {
 			if tt.args.otlpConfig.Tls != nil && tt.args.otlpConfig.Tls.Insecure != nil && *tt.args.otlpConfig.Tls.Insecure {
 				scheme = "http"
 			}
-			tt.args.otlpConfig.Endpoint = ptr(scheme + "://" + n.Addr().String())
+			tt.args.otlpConfig.Endpoint = new(scheme + "://" + n.Addr().String())
 
 			serverOpts, err := tt.grpcServerOpts()
 			require.NoError(t, err)

--- a/otelconf/propagator_test.go
+++ b/otelconf/propagator_test.go
@@ -127,7 +127,7 @@ func TestPropagator(t *testing.T) {
 		{
 			name: "multiple propagators via composite_list",
 			cfg: &Propagator{
-				CompositeList: ptr("tracecontext,baggage,b3"),
+				CompositeList: new("tracecontext,baggage,b3"),
 			},
 			want:    []string{"tracestate", "baggage", "b3", "traceparent"},
 			wantErr: false,
@@ -135,7 +135,7 @@ func TestPropagator(t *testing.T) {
 		{
 			name: "valid xray",
 			cfg: &Propagator{
-				CompositeList: ptr("xray"),
+				CompositeList: new("xray"),
 			},
 			want:    []string{"X-Amzn-Trace-Id"},
 			wantErr: false,
@@ -143,7 +143,7 @@ func TestPropagator(t *testing.T) {
 		{
 			name: "empty propagator name",
 			cfg: &Propagator{
-				CompositeList: ptr(""),
+				CompositeList: new(""),
 			},
 			want:    []string{},
 			wantErr: true,
@@ -152,7 +152,7 @@ func TestPropagator(t *testing.T) {
 		{
 			name: "unsupported propagator",
 			cfg: &Propagator{
-				CompositeList: ptr("random-garbage,baggage,b3"),
+				CompositeList: new("random-garbage,baggage,b3"),
 			},
 			want:    []string{},
 			wantErr: true,

--- a/otelconf/resource_test.go
+++ b/otelconf/resource_test.go
@@ -34,7 +34,7 @@ func TestNewResource(t *testing.T) {
 		{
 			name: "resource-with-schema",
 			config: &Resource{
-				SchemaUrl: ptr(semconv.SchemaURL),
+				SchemaUrl: new(semconv.SchemaURL),
 			},
 			wantSchemaURL: semconv.SchemaURL,
 		},
@@ -54,7 +54,7 @@ func TestNewResource(t *testing.T) {
 				Attributes: []AttributeNameValue{
 					{Name: string(semconv.ServiceNameKey), Value: "service-a"},
 				},
-				SchemaUrl: ptr(semconv.SchemaURL),
+				SchemaUrl: new(semconv.SchemaURL),
 			},
 			wantSchemaURL: semconv.SchemaURL,
 			wantAttrs:     []attribute.KeyValue{semconv.ServiceName("service-a")},
@@ -66,7 +66,7 @@ func TestNewResource(t *testing.T) {
 					{Name: string(semconv.ServiceNameKey), Value: "service-a"},
 					{Name: "attr-bool", Value: true},
 				},
-				SchemaUrl: ptr(semconv.SchemaURL),
+				SchemaUrl: new(semconv.SchemaURL),
 			},
 			wantSchemaURL: semconv.SchemaURL,
 			wantAttrs: []attribute.KeyValue{

--- a/otelconf/trace_test.go
+++ b/otelconf/trace_test.go
@@ -114,8 +114,8 @@ func TestTracerProvider(t *testing.T) {
 				opentelemetryConfig: OpenTelemetryConfiguration{
 					TracerProvider: &TracerProvider{
 						Limits: &SpanLimits{
-							AttributeCountLimit:       ptr(50),
-							AttributeValueLengthLimit: ptr(100),
+							AttributeCountLimit:       new(50),
+							AttributeValueLengthLimit: new(100),
 						},
 					},
 				},
@@ -150,7 +150,7 @@ func TestTracerProviderOptions(t *testing.T) {
 				Simple: &SimpleSpanProcessor{
 					Exporter: SpanExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint: ptr(srv.URL),
+							Endpoint: new(srv.URL),
 						},
 					},
 				},
@@ -201,22 +201,22 @@ func TestSpanProcessorLimits(t *testing.T) {
 		{
 			name: "attribute-count-limit-only",
 			limits: SpanLimits{
-				AttributeCountLimit: ptr(50),
+				AttributeCountLimit: new(50),
 			},
 			wantAdditionalOpts: 1,
 		},
 		{
 			name: "attribute-value-length-limit-only",
 			limits: SpanLimits{
-				AttributeValueLengthLimit: ptr(100),
+				AttributeValueLengthLimit: new(100),
 			},
 			wantAdditionalOpts: 1,
 		},
 		{
 			name: "both-limits",
 			limits: SpanLimits{
-				AttributeCountLimit:       ptr(50),
-				AttributeValueLengthLimit: ptr(100),
+				AttributeCountLimit:       new(50),
+				AttributeValueLengthLimit: new(100),
 			},
 			wantAdditionalOpts: 1,
 		},
@@ -277,7 +277,7 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch processor invalid batch size console exporter",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(-1),
+					MaxExportBatchSize: new(-1),
 					Exporter: SpanExporter{
 						Console: ConsoleExporter{},
 					},
@@ -289,7 +289,7 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch processor invalid export timeout console exporter",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					ExportTimeout: ptr(-2),
+					ExportTimeout: new(-2),
 					Exporter: SpanExporter{
 						Console: ConsoleExporter{},
 					},
@@ -301,7 +301,7 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch processor invalid queue size console exporter",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxQueueSize: ptr(-3),
+					MaxQueueSize: new(-3),
 					Exporter: SpanExporter{
 						Console: ConsoleExporter{},
 					},
@@ -313,7 +313,7 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch processor invalid schedule delay console exporter",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					ScheduleDelay: ptr(-4),
+					ScheduleDelay: new(-4),
 					Exporter: SpanExporter{
 						Console: ConsoleExporter{},
 					},
@@ -337,10 +337,10 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch processor console exporter",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						Console: ConsoleExporter{},
 					},
@@ -352,16 +352,16 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-exporter-no-endpoint",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -373,17 +373,17 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-exporter",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr("http://localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("http://localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -395,17 +395,17 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-exporter-socket-endpoint",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr("unix:collector.sock"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("unix:collector.sock"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -419,11 +419,11 @@ func TestSpanProcessor(t *testing.T) {
 				Batch: &BatchSpanProcessor{
 					Exporter: SpanExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &GrpcTls{
-								CaFile: ptr(material.CACertPath),
+								CaFile: new(material.CACertPath),
 							},
 						},
 					},
@@ -437,11 +437,11 @@ func TestSpanProcessor(t *testing.T) {
 				Batch: &BatchSpanProcessor{
 					Exporter: SpanExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &GrpcTls{
-								CaFile: ptr(material.BadCertPath),
+								CaFile: new(material.BadCertPath),
 							},
 						},
 					},
@@ -455,12 +455,12 @@ func TestSpanProcessor(t *testing.T) {
 				Batch: &BatchSpanProcessor{
 					Exporter: SpanExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &GrpcTls{
-								KeyFile:  ptr(material.BadCertPath),
-								CertFile: ptr(material.BadCertPath),
+								KeyFile:  new(material.BadCertPath),
+								CertFile: new(material.BadCertPath),
 							},
 						},
 					},
@@ -474,10 +474,10 @@ func TestSpanProcessor(t *testing.T) {
 				Batch: &BatchSpanProcessor{
 					Exporter: SpanExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
-							HeadersList: ptr("==="),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
+							HeadersList: new("==="),
 						},
 					},
 				},
@@ -488,17 +488,17 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-exporter-no-scheme",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -510,17 +510,17 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-invalid-endpoint",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr(" "),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new(" "),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -532,17 +532,17 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-invalid-compression",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("invalid"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("invalid"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -554,17 +554,17 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-http-exporter",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("http://localhost:4318"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("http://localhost:4318"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -578,11 +578,11 @@ func TestSpanProcessor(t *testing.T) {
 				Batch: &BatchSpanProcessor{
 					Exporter: SpanExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &HttpTls{
-								CaFile: ptr(material.CACertPath),
+								CaFile: new(material.CACertPath),
 							},
 						},
 					},
@@ -596,11 +596,11 @@ func TestSpanProcessor(t *testing.T) {
 				Batch: &BatchSpanProcessor{
 					Exporter: SpanExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &HttpTls{
-								CaFile: ptr(material.BadCertPath),
+								CaFile: new(material.BadCertPath),
 							},
 						},
 					},
@@ -614,12 +614,12 @@ func TestSpanProcessor(t *testing.T) {
 				Batch: &BatchSpanProcessor{
 					Exporter: SpanExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &HttpTls{
-								KeyFile:  ptr(material.BadCertPath),
-								CertFile: ptr(material.BadCertPath),
+								KeyFile:  new(material.BadCertPath),
+								CertFile: new(material.BadCertPath),
 							},
 						},
 					},
@@ -633,10 +633,10 @@ func TestSpanProcessor(t *testing.T) {
 				Batch: &BatchSpanProcessor{
 					Exporter: SpanExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
-							HeadersList: ptr("==="),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
+							HeadersList: new("==="),
 						},
 					},
 				},
@@ -647,17 +647,17 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-http-exporter-with-path",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("http://localhost:4318/path/123"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("http://localhost:4318/path/123"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -669,16 +669,16 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-http-exporter-no-endpoint",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -690,17 +690,17 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-http-exporter-no-scheme",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -712,17 +712,17 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-http-invalid-endpoint",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr(" "),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new(" "),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -734,17 +734,17 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-http-none-compression",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -756,17 +756,17 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-http-invalid-compression",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("invalid"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("invalid"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -778,14 +778,14 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-http-invalid-encoding",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint: ptr("http://localhost:4318"),
-							Encoding: ptr(OTLPHttpEncoding("json")),
+							Endpoint: new("http://localhost:4318"),
+							Encoding: new(OTLPHttpEncoding("json")),
 						},
 					},
 				},
@@ -893,7 +893,7 @@ func TestSampler(t *testing.T) {
 			name: "sampler configuration trace ID ratio",
 			sampler: &Sampler{
 				TraceIDRatioBased: &TraceIDRatioBasedSampler{
-					Ratio: ptr(0.54),
+					Ratio: new(0.54),
 				},
 			},
 			wantSampler: sdktrace.TraceIDRatioBased(0.54),
@@ -924,7 +924,7 @@ func TestSampler(t *testing.T) {
 					},
 					RemoteParentSampled: &Sampler{
 						TraceIDRatioBased: &TraceIDRatioBasedSampler{
-							Ratio: ptr(0.009),
+							Ratio: new(0.009),
 						},
 					},
 					LocalParentNotSampled: &Sampler{
@@ -932,7 +932,7 @@ func TestSampler(t *testing.T) {
 					},
 					LocalParentSampled: &Sampler{
 						TraceIDRatioBased: &TraceIDRatioBasedSampler{
-							Ratio: ptr(0.05),
+							Ratio: new(0.05),
 						},
 					},
 				},
@@ -995,13 +995,13 @@ func Test_otlpGRPCTraceExporter(t *testing.T) {
 			args: args{
 				ctx: t.Context(),
 				otlpConfig: &OTLPGrpcExporter{
-					Compression: ptr("gzip"),
-					Timeout:     ptr(50000),
+					Compression: new("gzip"),
+					Timeout:     new(50000),
 					Tls: &GrpcTls{
-						Insecure: ptr(true),
+						Insecure: new(true),
 					},
 					Headers: []NameStringValuePair{
-						{Name: "test", Value: ptr("test1")},
+						{Name: "test", Value: new("test1")},
 					},
 				},
 			},
@@ -1014,13 +1014,13 @@ func Test_otlpGRPCTraceExporter(t *testing.T) {
 			args: args{
 				ctx: t.Context(),
 				otlpConfig: &OTLPGrpcExporter{
-					Compression: ptr("gzip"),
-					Timeout:     ptr(50000),
+					Compression: new("gzip"),
+					Timeout:     new(50000),
 					Tls: &GrpcTls{
-						CaFile: ptr(material.CACertPath),
+						CaFile: new(material.CACertPath),
 					},
 					Headers: []NameStringValuePair{
-						{Name: "test", Value: ptr("test1")},
+						{Name: "test", Value: new("test1")},
 					},
 				},
 			},
@@ -1039,15 +1039,15 @@ func Test_otlpGRPCTraceExporter(t *testing.T) {
 			args: args{
 				ctx: t.Context(),
 				otlpConfig: &OTLPGrpcExporter{
-					Compression: ptr("gzip"),
-					Timeout:     ptr(50000),
+					Compression: new("gzip"),
+					Timeout:     new(50000),
 					Tls: &GrpcTls{
-						CaFile:   ptr(material.CACertPath),
-						KeyFile:  ptr(material.ClientKeyPath),
-						CertFile: ptr(material.ClientCertPath),
+						CaFile:   new(material.CACertPath),
+						KeyFile:  new(material.ClientKeyPath),
+						CertFile: new(material.ClientCertPath),
 					},
 					Headers: []NameStringValuePair{
-						{Name: "test", Value: ptr("test1")},
+						{Name: "test", Value: new("test1")},
 					},
 				},
 			},
@@ -1082,7 +1082,7 @@ func Test_otlpGRPCTraceExporter(t *testing.T) {
 			if tt.args.otlpConfig.Tls != nil && tt.args.otlpConfig.Tls.Insecure != nil && *tt.args.otlpConfig.Tls.Insecure {
 				scheme = "http"
 			}
-			tt.args.otlpConfig.Endpoint = ptr(scheme + "://" + n.Addr().String())
+			tt.args.otlpConfig.Endpoint = new(scheme + "://" + n.Addr().String())
 
 			serverOpts, err := tt.grpcServerOpts()
 			require.NoError(t, err)

--- a/otelconf/v0.2.0/config_test.go
+++ b/otelconf/v0.2.0/config_test.go
@@ -55,7 +55,7 @@ func TestNewSDK(t *testing.T) {
 			cfg: []ConfigurationOption{
 				WithContext(t.Context()),
 				WithOpenTelemetryConfiguration(OpenTelemetryConfiguration{
-					Disabled:       ptr(true),
+					Disabled:       new(true),
 					TracerProvider: &TracerProvider{},
 					MeterProvider:  &MeterProvider{},
 					LoggerProvider: &LoggerProvider{},
@@ -77,39 +77,39 @@ func TestNewSDK(t *testing.T) {
 }
 
 var v02OpenTelemetryConfig = OpenTelemetryConfiguration{
-	Disabled:   ptr(false),
+	Disabled:   new(false),
 	FileFormat: "0.2",
 	AttributeLimits: &AttributeLimits{
-		AttributeCountLimit:       ptr(128),
-		AttributeValueLengthLimit: ptr(4096),
+		AttributeCountLimit:       new(128),
+		AttributeValueLengthLimit: new(4096),
 	},
 	LoggerProvider: &LoggerProvider{
 		Limits: &LogRecordLimits{
-			AttributeCountLimit:       ptr(128),
-			AttributeValueLengthLimit: ptr(4096),
+			AttributeCountLimit:       new(128),
+			AttributeValueLengthLimit: new(4096),
 		},
 		Processors: []LogRecordProcessor{
 			{
 				Batch: &BatchLogRecordProcessor{
-					ExportTimeout: ptr(30000),
+					ExportTimeout: new(30000),
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
-							Certificate:       ptr("/app/cert.pem"),
-							ClientCertificate: ptr("/app/cert.pem"),
-							ClientKey:         ptr("/app/cert.pem"),
-							Compression:       ptr("gzip"),
+							Certificate:       new("/app/cert.pem"),
+							ClientCertificate: new("/app/cert.pem"),
+							ClientKey:         new("/app/cert.pem"),
+							Compression:       new("gzip"),
 							Endpoint:          "http://localhost:4318",
 							Headers: Headers{
 								"api-key": "1234",
 							},
-							Insecure: ptr(false),
+							Insecure: new(false),
 							Protocol: "http/protobuf",
-							Timeout:  ptr(10000),
+							Timeout:  new(10000),
 						},
 					},
-					MaxExportBatchSize: ptr(512),
-					MaxQueueSize:       ptr(2048),
-					ScheduleDelay:      ptr(5000),
+					MaxExportBatchSize: new(512),
+					MaxQueueSize:       new(2048),
+					ScheduleDelay:      new(5000),
 				},
 			},
 			{
@@ -127,15 +127,15 @@ var v02OpenTelemetryConfig = OpenTelemetryConfiguration{
 				Pull: &PullMetricReader{
 					Exporter: MetricExporter{
 						Prometheus: &Prometheus{
-							Host: ptr("localhost"),
-							Port: ptr(9464),
+							Host: new("localhost"),
+							Port: new(9464),
 							WithResourceConstantLabels: &IncludeExclude{
 								Excluded: []string{"service.attr1"},
 								Included: []string{"service*"},
 							},
-							WithoutScopeInfo:  ptr(false),
-							WithoutTypeSuffix: ptr(false),
-							WithoutUnits:      ptr(false),
+							WithoutScopeInfo:  new(false),
+							WithoutTypeSuffix: new(false),
+							WithoutUnits:      new(false),
 						},
 					},
 				},
@@ -144,23 +144,23 @@ var v02OpenTelemetryConfig = OpenTelemetryConfiguration{
 				Periodic: &PeriodicMetricReader{
 					Exporter: MetricExporter{
 						OTLP: &OTLPMetric{
-							Certificate:                 ptr("/app/cert.pem"),
-							ClientCertificate:           ptr("/app/cert.pem"),
-							ClientKey:                   ptr("/app/cert.pem"),
-							Compression:                 ptr("gzip"),
-							DefaultHistogramAggregation: ptr(OTLPMetricDefaultHistogramAggregationBase2ExponentialBucketHistogram),
+							Certificate:                 new("/app/cert.pem"),
+							ClientCertificate:           new("/app/cert.pem"),
+							ClientKey:                   new("/app/cert.pem"),
+							Compression:                 new("gzip"),
+							DefaultHistogramAggregation: new(OTLPMetricDefaultHistogramAggregationBase2ExponentialBucketHistogram),
 							Endpoint:                    "http://localhost:4318",
 							Headers: Headers{
 								"api-key": "1234",
 							},
-							Insecure:              ptr(false),
+							Insecure:              new(false),
 							Protocol:              "http/protobuf",
-							TemporalityPreference: ptr("delta"),
-							Timeout:               ptr(10000),
+							TemporalityPreference: new("delta"),
+							Timeout:               new(10000),
 						},
 					},
-					Interval: ptr(5000),
-					Timeout:  ptr(30000),
+					Interval: new(5000),
+					Timeout:  new(30000),
 				},
 			},
 			{
@@ -174,23 +174,23 @@ var v02OpenTelemetryConfig = OpenTelemetryConfiguration{
 		Views: []View{
 			{
 				Selector: &ViewSelector{
-					InstrumentName: ptr("my-instrument"),
-					InstrumentType: ptr(ViewSelectorInstrumentTypeHistogram),
-					MeterName:      ptr("my-meter"),
-					MeterSchemaUrl: ptr("https://opentelemetry.io/schemas/1.16.0"),
-					MeterVersion:   ptr("1.0.0"),
-					Unit:           ptr("ms"),
+					InstrumentName: new("my-instrument"),
+					InstrumentType: new(ViewSelectorInstrumentTypeHistogram),
+					MeterName:      new("my-meter"),
+					MeterSchemaUrl: new("https://opentelemetry.io/schemas/1.16.0"),
+					MeterVersion:   new("1.0.0"),
+					Unit:           new("ms"),
 				},
 				Stream: &ViewStream{
 					Aggregation: &ViewStreamAggregation{
 						ExplicitBucketHistogram: &ViewStreamAggregationExplicitBucketHistogram{
 							Boundaries:   []float64{0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000},
-							RecordMinMax: ptr(true),
+							RecordMinMax: new(true),
 						},
 					},
 					AttributeKeys: []string{"key1", "key2"},
-					Description:   ptr("new_description"),
-					Name:          ptr("new_instrument_name"),
+					Description:   new("new_description"),
+					Name:          new("new_instrument_name"),
 				},
 			},
 		},
@@ -208,39 +208,39 @@ var v02OpenTelemetryConfig = OpenTelemetryConfiguration{
 				Included: []string{"process.*"},
 			},
 		},
-		SchemaUrl: ptr("https://opentelemetry.io/schemas/1.16.0"),
+		SchemaUrl: new("https://opentelemetry.io/schemas/1.16.0"),
 	},
 	TracerProvider: &TracerProvider{
 		Limits: &SpanLimits{
-			AttributeCountLimit:       ptr(128),
-			AttributeValueLengthLimit: ptr(4096),
-			EventCountLimit:           ptr(128),
-			EventAttributeCountLimit:  ptr(128),
-			LinkCountLimit:            ptr(128),
-			LinkAttributeCountLimit:   ptr(128),
+			AttributeCountLimit:       new(128),
+			AttributeValueLengthLimit: new(4096),
+			EventCountLimit:           new(128),
+			EventAttributeCountLimit:  new(128),
+			LinkCountLimit:            new(128),
+			LinkAttributeCountLimit:   new(128),
 		},
 		Processors: []SpanProcessor{
 			{
 				Batch: &BatchSpanProcessor{
-					ExportTimeout: ptr(30000),
+					ExportTimeout: new(30000),
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
-							Certificate:       ptr("/app/cert.pem"),
-							ClientCertificate: ptr("/app/cert.pem"),
-							ClientKey:         ptr("/app/cert.pem"),
-							Compression:       ptr("gzip"),
+							Certificate:       new("/app/cert.pem"),
+							ClientCertificate: new("/app/cert.pem"),
+							ClientKey:         new("/app/cert.pem"),
+							Compression:       new("gzip"),
 							Endpoint:          "http://localhost:4318",
 							Headers: Headers{
 								"api-key": "1234",
 							},
-							Insecure: ptr(false),
+							Insecure: new(false),
 							Protocol: "http/protobuf",
-							Timeout:  ptr(10000),
+							Timeout:  new(10000),
 						},
 					},
-					MaxExportBatchSize: ptr(512),
-					MaxQueueSize:       ptr(2048),
-					ScheduleDelay:      ptr(5000),
+					MaxExportBatchSize: new(512),
+					MaxQueueSize:       new(2048),
+					ScheduleDelay:      new(5000),
 				},
 			},
 			{
@@ -248,7 +248,7 @@ var v02OpenTelemetryConfig = OpenTelemetryConfiguration{
 					Exporter: SpanExporter{
 						Zipkin: &Zipkin{
 							Endpoint: "http://localhost:9411/api/v2/spans",
-							Timeout:  ptr(10000),
+							Timeout:  new(10000),
 						},
 					},
 				},
@@ -277,7 +277,7 @@ var v02OpenTelemetryConfig = OpenTelemetryConfiguration{
 				},
 				Root: &Sampler{
 					TraceIDRatioBased: &SamplerTraceIDRatioBased{
-						Ratio: ptr(0.0001),
+						Ratio: new(0.0001),
 					},
 				},
 			},
@@ -297,7 +297,7 @@ func TestParseYAML(t *testing.T) {
 			input:   `valid_empty.yaml`,
 			wantErr: nil,
 			wantType: &OpenTelemetryConfiguration{
-				Disabled:   ptr(false),
+				Disabled:   new(false),
 				FileFormat: "0.1",
 			},
 		},
@@ -342,7 +342,7 @@ func TestSerializeJSON(t *testing.T) {
 			input:   `valid_empty.json`,
 			wantErr: nil,
 			wantType: OpenTelemetryConfiguration{
-				Disabled:   ptr(false),
+				Disabled:   new(false),
 				FileFormat: "0.1",
 			},
 		},
@@ -374,8 +374,4 @@ func TestSerializeJSON(t *testing.T) {
 			}
 		})
 	}
-}
-
-func ptr[T any](v T) *T {
-	return &v
 }

--- a/otelconf/v0.2.0/log_test.go
+++ b/otelconf/v0.2.0/log_test.go
@@ -93,7 +93,7 @@ func TestLogProcessor(t *testing.T) {
 
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(-1),
+					MaxExportBatchSize: new(-1),
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
 							Protocol: "http/protobuf",
@@ -107,7 +107,7 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch processor invalid export timeout otlphttp exporter",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					ExportTimeout: ptr(-2),
+					ExportTimeout: new(-2),
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
 							Protocol: "http/protobuf",
@@ -122,7 +122,7 @@ func TestLogProcessor(t *testing.T) {
 
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxQueueSize: ptr(-3),
+					MaxQueueSize: new(-3),
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
 							Protocol: "http/protobuf",
@@ -136,7 +136,7 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch processor invalid schedule delay console exporter",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					ScheduleDelay: ptr(-4),
+					ScheduleDelay: new(-4),
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
 							Protocol: "http/protobuf",
@@ -159,10 +159,10 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/console",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						Console: map[string]any{},
 					},
@@ -174,16 +174,16 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-http-exporter",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
 							Protocol:    "http/protobuf",
 							Endpoint:    "http://localhost:4318",
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
@@ -197,16 +197,16 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-http-exporter-with-path",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
 							Protocol:    "http/protobuf",
 							Endpoint:    "http://localhost:4318/path/123",
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
@@ -220,15 +220,15 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-http-exporter-no-endpoint",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
 							Protocol:    "http/protobuf",
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
@@ -242,16 +242,16 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-http-exporter-no-scheme",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
 							Protocol:    "http/protobuf",
 							Endpoint:    "localhost:4318",
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
@@ -265,16 +265,16 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-http-invalid-protocol",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
 							Protocol:    "invalid",
 							Endpoint:    "https://10.0.0.0:443",
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
@@ -288,16 +288,16 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-http-invalid-endpoint",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
 							Protocol:    "http/protobuf",
 							Endpoint:    " ",
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
@@ -311,16 +311,16 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-http-none-compression",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
 							Protocol:    "http/protobuf",
 							Endpoint:    "localhost:4318",
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
@@ -334,16 +334,16 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-http-invalid-compression",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
 							Protocol:    "http/protobuf",
 							Endpoint:    "localhost:4318",
-							Compression: ptr("invalid"),
-							Timeout:     ptr(1000),
+							Compression: new("invalid"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
@@ -381,8 +381,8 @@ func TestLogProcessor(t *testing.T) {
 						OTLP: &OTLP{
 							Protocol:    "http/protobuf",
 							Endpoint:    "localhost:4318",
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},

--- a/otelconf/v0.2.0/metric_test.go
+++ b/otelconf/v0.2.0/metric_test.go
@@ -138,7 +138,7 @@ func TestReader(t *testing.T) {
 				Pull: &PullMetricReader{
 					Exporter: MetricExporter{
 						Prometheus: &Prometheus{
-							Host: ptr("localhost"),
+							Host: new("localhost"),
 						},
 					},
 				},
@@ -151,11 +151,11 @@ func TestReader(t *testing.T) {
 				Pull: &PullMetricReader{
 					Exporter: MetricExporter{
 						Prometheus: &Prometheus{
-							Host:              ptr("localhost"),
-							Port:              ptr(0),
-							WithoutScopeInfo:  ptr(true),
-							WithoutUnits:      ptr(true),
-							WithoutTypeSuffix: ptr(true),
+							Host:              new("localhost"),
+							Port:              new(0),
+							WithoutScopeInfo:  new(true),
+							WithoutUnits:      new(true),
+							WithoutTypeSuffix: new(true),
 							WithResourceConstantLabels: &IncludeExclude{
 								Included: []string{"include"},
 								Excluded: []string{"exclude"},
@@ -187,8 +187,8 @@ func TestReader(t *testing.T) {
 						OTLP: &OTLPMetric{
 							Protocol:    "grpc/protobuf",
 							Endpoint:    "http://localhost:4318",
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
@@ -206,8 +206,8 @@ func TestReader(t *testing.T) {
 						OTLP: &OTLPMetric{
 							Protocol:    "grpc/protobuf",
 							Endpoint:    "http://localhost:4318/path/123",
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
@@ -224,8 +224,8 @@ func TestReader(t *testing.T) {
 					Exporter: MetricExporter{
 						OTLP: &OTLPMetric{
 							Protocol:    "grpc/protobuf",
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
@@ -243,8 +243,8 @@ func TestReader(t *testing.T) {
 						OTLP: &OTLPMetric{
 							Protocol:    "grpc/protobuf",
 							Endpoint:    "localhost:4318",
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
@@ -262,8 +262,8 @@ func TestReader(t *testing.T) {
 						OTLP: &OTLPMetric{
 							Protocol:    "grpc/protobuf",
 							Endpoint:    " ",
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
@@ -281,8 +281,8 @@ func TestReader(t *testing.T) {
 						OTLP: &OTLPMetric{
 							Protocol:    "grpc/protobuf",
 							Endpoint:    "localhost:4318",
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
@@ -300,12 +300,12 @@ func TestReader(t *testing.T) {
 						OTLP: &OTLPMetric{
 							Protocol:    "grpc/protobuf",
 							Endpoint:    "localhost:4318",
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
-							TemporalityPreference: ptr("delta"),
+							TemporalityPreference: new("delta"),
 						},
 					},
 				},
@@ -320,12 +320,12 @@ func TestReader(t *testing.T) {
 						OTLP: &OTLPMetric{
 							Protocol:    "grpc/protobuf",
 							Endpoint:    "localhost:4318",
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
-							TemporalityPreference: ptr("cumulative"),
+							TemporalityPreference: new("cumulative"),
 						},
 					},
 				},
@@ -340,12 +340,12 @@ func TestReader(t *testing.T) {
 						OTLP: &OTLPMetric{
 							Protocol:    "grpc/protobuf",
 							Endpoint:    "localhost:4318",
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
-							TemporalityPreference: ptr("lowmemory"),
+							TemporalityPreference: new("lowmemory"),
 						},
 					},
 				},
@@ -360,12 +360,12 @@ func TestReader(t *testing.T) {
 						OTLP: &OTLPMetric{
 							Protocol:    "grpc/protobuf",
 							Endpoint:    "localhost:4318",
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
-							TemporalityPreference: ptr("invalid"),
+							TemporalityPreference: new("invalid"),
 						},
 					},
 				},
@@ -380,8 +380,8 @@ func TestReader(t *testing.T) {
 						OTLP: &OTLPMetric{
 							Protocol:    "grpc/protobuf",
 							Endpoint:    "localhost:4318",
-							Compression: ptr("invalid"),
-							Timeout:     ptr(1000),
+							Compression: new("invalid"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
@@ -399,8 +399,8 @@ func TestReader(t *testing.T) {
 						OTLP: &OTLPMetric{
 							Protocol:    "http/protobuf",
 							Endpoint:    "http://localhost:4318",
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
@@ -418,8 +418,8 @@ func TestReader(t *testing.T) {
 						OTLP: &OTLPMetric{
 							Protocol:    "http/protobuf",
 							Endpoint:    "http://localhost:4318/path/123",
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
@@ -436,8 +436,8 @@ func TestReader(t *testing.T) {
 					Exporter: MetricExporter{
 						OTLP: &OTLPMetric{
 							Protocol:    "http/protobuf",
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
@@ -455,8 +455,8 @@ func TestReader(t *testing.T) {
 						OTLP: &OTLPMetric{
 							Protocol:    "http/protobuf",
 							Endpoint:    "localhost:4318",
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
@@ -474,8 +474,8 @@ func TestReader(t *testing.T) {
 						OTLP: &OTLPMetric{
 							Protocol:    "http/protobuf",
 							Endpoint:    " ",
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
@@ -493,8 +493,8 @@ func TestReader(t *testing.T) {
 						OTLP: &OTLPMetric{
 							Protocol:    "http/protobuf",
 							Endpoint:    "localhost:4318",
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
@@ -512,12 +512,12 @@ func TestReader(t *testing.T) {
 						OTLP: &OTLPMetric{
 							Protocol:    "http/protobuf",
 							Endpoint:    "localhost:4318",
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
-							TemporalityPreference: ptr("cumulative"),
+							TemporalityPreference: new("cumulative"),
 						},
 					},
 				},
@@ -532,12 +532,12 @@ func TestReader(t *testing.T) {
 						OTLP: &OTLPMetric{
 							Protocol:    "http/protobuf",
 							Endpoint:    "localhost:4318",
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
-							TemporalityPreference: ptr("lowmemory"),
+							TemporalityPreference: new("lowmemory"),
 						},
 					},
 				},
@@ -552,12 +552,12 @@ func TestReader(t *testing.T) {
 						OTLP: &OTLPMetric{
 							Protocol:    "http/protobuf",
 							Endpoint:    "localhost:4318",
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
-							TemporalityPreference: ptr("delta"),
+							TemporalityPreference: new("delta"),
 						},
 					},
 				},
@@ -572,12 +572,12 @@ func TestReader(t *testing.T) {
 						OTLP: &OTLPMetric{
 							Protocol:    "http/protobuf",
 							Endpoint:    "localhost:4318",
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
-							TemporalityPreference: ptr("invalid"),
+							TemporalityPreference: new("invalid"),
 						},
 					},
 				},
@@ -592,8 +592,8 @@ func TestReader(t *testing.T) {
 						OTLP: &OTLPMetric{
 							Protocol:    "http/protobuf",
 							Endpoint:    "localhost:4318",
-							Compression: ptr("invalid"),
-							Timeout:     ptr(1000),
+							Compression: new("invalid"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
@@ -627,8 +627,8 @@ func TestReader(t *testing.T) {
 			name: "periodic/console-exporter-with-extra-options",
 			reader: MetricReader{
 				Periodic: &PeriodicMetricReader{
-					Interval: ptr(30_000),
-					Timeout:  ptr(5_000),
+					Interval: new(30_000),
+					Timeout:  new(5_000),
 					Exporter: MetricExporter{
 						Console: Console{},
 					},
@@ -685,7 +685,7 @@ func TestView(t *testing.T) {
 			name: "selector/invalid_type",
 			view: View{
 				Selector: &ViewSelector{
-					InstrumentType: (*ViewSelectorInstrumentType)(ptr("invalid_type")),
+					InstrumentType: (*ViewSelectorInstrumentType)(new("invalid_type")),
 				},
 			},
 			wantErr: "view_selector: instrument_type: invalid value",
@@ -701,12 +701,12 @@ func TestView(t *testing.T) {
 			name: "all selectors match",
 			view: View{
 				Selector: &ViewSelector{
-					InstrumentName: ptr("test_name"),
-					InstrumentType: (*ViewSelectorInstrumentType)(ptr("counter")),
-					Unit:           ptr("test_unit"),
-					MeterName:      ptr("test_meter_name"),
-					MeterVersion:   ptr("test_meter_version"),
-					MeterSchemaUrl: ptr("test_schema_url"),
+					InstrumentName: new("test_name"),
+					InstrumentType: (*ViewSelectorInstrumentType)(new("counter")),
+					Unit:           new("test_unit"),
+					MeterName:      new("test_meter_name"),
+					MeterVersion:   new("test_meter_version"),
+					MeterSchemaUrl: new("test_schema_url"),
 				},
 			},
 			matchInstrument: &sdkmetric.Instrument{
@@ -726,12 +726,12 @@ func TestView(t *testing.T) {
 			name: "all selectors no match name",
 			view: View{
 				Selector: &ViewSelector{
-					InstrumentName: ptr("test_name"),
-					InstrumentType: (*ViewSelectorInstrumentType)(ptr("counter")),
-					Unit:           ptr("test_unit"),
-					MeterName:      ptr("test_meter_name"),
-					MeterVersion:   ptr("test_meter_version"),
-					MeterSchemaUrl: ptr("test_schema_url"),
+					InstrumentName: new("test_name"),
+					InstrumentType: (*ViewSelectorInstrumentType)(new("counter")),
+					Unit:           new("test_unit"),
+					MeterName:      new("test_meter_name"),
+					MeterVersion:   new("test_meter_version"),
+					MeterSchemaUrl: new("test_schema_url"),
 				},
 			},
 			matchInstrument: &sdkmetric.Instrument{
@@ -751,12 +751,12 @@ func TestView(t *testing.T) {
 			name: "all selectors no match unit",
 			view: View{
 				Selector: &ViewSelector{
-					InstrumentName: ptr("test_name"),
-					InstrumentType: (*ViewSelectorInstrumentType)(ptr("counter")),
-					Unit:           ptr("test_unit"),
-					MeterName:      ptr("test_meter_name"),
-					MeterVersion:   ptr("test_meter_version"),
-					MeterSchemaUrl: ptr("test_schema_url"),
+					InstrumentName: new("test_name"),
+					InstrumentType: (*ViewSelectorInstrumentType)(new("counter")),
+					Unit:           new("test_unit"),
+					MeterName:      new("test_meter_name"),
+					MeterVersion:   new("test_meter_version"),
+					MeterSchemaUrl: new("test_schema_url"),
 				},
 			},
 			matchInstrument: &sdkmetric.Instrument{
@@ -776,12 +776,12 @@ func TestView(t *testing.T) {
 			name: "all selectors no match kind",
 			view: View{
 				Selector: &ViewSelector{
-					InstrumentName: ptr("test_name"),
-					InstrumentType: (*ViewSelectorInstrumentType)(ptr("histogram")),
-					Unit:           ptr("test_unit"),
-					MeterName:      ptr("test_meter_name"),
-					MeterVersion:   ptr("test_meter_version"),
-					MeterSchemaUrl: ptr("test_schema_url"),
+					InstrumentName: new("test_name"),
+					InstrumentType: (*ViewSelectorInstrumentType)(new("histogram")),
+					Unit:           new("test_unit"),
+					MeterName:      new("test_meter_name"),
+					MeterVersion:   new("test_meter_version"),
+					MeterSchemaUrl: new("test_schema_url"),
 				},
 			},
 			matchInstrument: &sdkmetric.Instrument{
@@ -801,12 +801,12 @@ func TestView(t *testing.T) {
 			name: "all selectors no match meter name",
 			view: View{
 				Selector: &ViewSelector{
-					InstrumentName: ptr("test_name"),
-					InstrumentType: (*ViewSelectorInstrumentType)(ptr("counter")),
-					Unit:           ptr("test_unit"),
-					MeterName:      ptr("test_meter_name"),
-					MeterVersion:   ptr("test_meter_version"),
-					MeterSchemaUrl: ptr("test_schema_url"),
+					InstrumentName: new("test_name"),
+					InstrumentType: (*ViewSelectorInstrumentType)(new("counter")),
+					Unit:           new("test_unit"),
+					MeterName:      new("test_meter_name"),
+					MeterVersion:   new("test_meter_version"),
+					MeterSchemaUrl: new("test_schema_url"),
 				},
 			},
 			matchInstrument: &sdkmetric.Instrument{
@@ -826,12 +826,12 @@ func TestView(t *testing.T) {
 			name: "all selectors no match meter version",
 			view: View{
 				Selector: &ViewSelector{
-					InstrumentName: ptr("test_name"),
-					InstrumentType: (*ViewSelectorInstrumentType)(ptr("counter")),
-					Unit:           ptr("test_unit"),
-					MeterName:      ptr("test_meter_name"),
-					MeterVersion:   ptr("test_meter_version"),
-					MeterSchemaUrl: ptr("test_schema_url"),
+					InstrumentName: new("test_name"),
+					InstrumentType: (*ViewSelectorInstrumentType)(new("counter")),
+					Unit:           new("test_unit"),
+					MeterName:      new("test_meter_name"),
+					MeterVersion:   new("test_meter_version"),
+					MeterSchemaUrl: new("test_schema_url"),
 				},
 			},
 			matchInstrument: &sdkmetric.Instrument{
@@ -851,12 +851,12 @@ func TestView(t *testing.T) {
 			name: "all selectors no match meter schema url",
 			view: View{
 				Selector: &ViewSelector{
-					InstrumentName: ptr("test_name"),
-					InstrumentType: (*ViewSelectorInstrumentType)(ptr("counter")),
-					Unit:           ptr("test_unit"),
-					MeterName:      ptr("test_meter_name"),
-					MeterVersion:   ptr("test_meter_version"),
-					MeterSchemaUrl: ptr("test_schema_url"),
+					InstrumentName: new("test_name"),
+					InstrumentType: (*ViewSelectorInstrumentType)(new("counter")),
+					Unit:           new("test_unit"),
+					MeterName:      new("test_meter_name"),
+					MeterVersion:   new("test_meter_version"),
+					MeterSchemaUrl: new("test_schema_url"),
 				},
 			},
 			matchInstrument: &sdkmetric.Instrument{
@@ -876,12 +876,12 @@ func TestView(t *testing.T) {
 			name: "with stream",
 			view: View{
 				Selector: &ViewSelector{
-					InstrumentName: ptr("test_name"),
-					Unit:           ptr("test_unit"),
+					InstrumentName: new("test_name"),
+					Unit:           new("test_unit"),
 				},
 				Stream: &ViewStream{
-					Name:          ptr("new_name"),
-					Description:   ptr("new_description"),
+					Name:          new("new_name"),
+					Description:   new("new_description"),
 					AttributeKeys: []string{"foo", "bar"},
 					Aggregation:   &ViewStreamAggregation{Sum: make(ViewStreamAggregationSum)},
 				},
@@ -931,37 +931,37 @@ func TestInstrumentType(t *testing.T) {
 		},
 		{
 			name:     "counter",
-			instType: (*ViewSelectorInstrumentType)(ptr("counter")),
+			instType: (*ViewSelectorInstrumentType)(new("counter")),
 			wantKind: sdkmetric.InstrumentKindCounter,
 		},
 		{
 			name:     "up_down_counter",
-			instType: (*ViewSelectorInstrumentType)(ptr("up_down_counter")),
+			instType: (*ViewSelectorInstrumentType)(new("up_down_counter")),
 			wantKind: sdkmetric.InstrumentKindUpDownCounter,
 		},
 		{
 			name:     "histogram",
-			instType: (*ViewSelectorInstrumentType)(ptr("histogram")),
+			instType: (*ViewSelectorInstrumentType)(new("histogram")),
 			wantKind: sdkmetric.InstrumentKindHistogram,
 		},
 		{
 			name:     "observable_counter",
-			instType: (*ViewSelectorInstrumentType)(ptr("observable_counter")),
+			instType: (*ViewSelectorInstrumentType)(new("observable_counter")),
 			wantKind: sdkmetric.InstrumentKindObservableCounter,
 		},
 		{
 			name:     "observable_up_down_counter",
-			instType: (*ViewSelectorInstrumentType)(ptr("observable_up_down_counter")),
+			instType: (*ViewSelectorInstrumentType)(new("observable_up_down_counter")),
 			wantKind: sdkmetric.InstrumentKindObservableUpDownCounter,
 		},
 		{
 			name:     "observable_gauge",
-			instType: (*ViewSelectorInstrumentType)(ptr("observable_gauge")),
+			instType: (*ViewSelectorInstrumentType)(new("observable_gauge")),
 			wantKind: sdkmetric.InstrumentKindObservableGauge,
 		},
 		{
 			name:     "invalid",
-			instType: (*ViewSelectorInstrumentType)(ptr("invalid")),
+			instType: (*ViewSelectorInstrumentType)(new("invalid")),
 			wantErr:  errors.New("instrument_type: invalid value"),
 		},
 	}
@@ -1009,9 +1009,9 @@ func TestAggregation(t *testing.T) {
 			name: "Base2ExponentialBucketHistogram",
 			aggregation: &ViewStreamAggregation{
 				Base2ExponentialBucketHistogram: &ViewStreamAggregationBase2ExponentialBucketHistogram{
-					MaxSize:      ptr(2),
-					MaxScale:     ptr(3),
-					RecordMinMax: ptr(true),
+					MaxSize:      new(2),
+					MaxScale:     new(3),
+					RecordMinMax: new(true),
 				},
 			},
 			wantAggregation: sdkmetric.AggregationBase2ExponentialHistogram{
@@ -1049,7 +1049,7 @@ func TestAggregation(t *testing.T) {
 			aggregation: &ViewStreamAggregation{
 				ExplicitBucketHistogram: &ViewStreamAggregationExplicitBucketHistogram{
 					Boundaries:   []float64{1, 2, 3},
-					RecordMinMax: ptr(true),
+					RecordMinMax: new(true),
 				},
 			},
 			wantAggregation: sdkmetric.AggregationExplicitBucketHistogram{
@@ -1128,7 +1128,7 @@ func TestNewIncludeExcludeFilter(t *testing.T) {
 		},
 		{
 			name: "filter-with-include",
-			attributeKeys: ptr(IncludeExclude{
+			attributeKeys: new(IncludeExclude{
 				Included: []string{"foo"},
 			}),
 			wantPass: []string{"foo"},
@@ -1136,7 +1136,7 @@ func TestNewIncludeExcludeFilter(t *testing.T) {
 		},
 		{
 			name: "filter-with-exclude",
-			attributeKeys: ptr(IncludeExclude{
+			attributeKeys: new(IncludeExclude{
 				Excluded: []string{"foo"},
 			}),
 			wantPass: []string{"bar"},
@@ -1144,7 +1144,7 @@ func TestNewIncludeExcludeFilter(t *testing.T) {
 		},
 		{
 			name: "filter-with-include-and-exclude",
-			attributeKeys: ptr(IncludeExclude{
+			attributeKeys: new(IncludeExclude{
 				Included: []string{"bar"},
 				Excluded: []string{"foo"},
 			}),
@@ -1167,7 +1167,7 @@ func TestNewIncludeExcludeFilter(t *testing.T) {
 }
 
 func TestNewIncludeExcludeFilterError(t *testing.T) {
-	_, err := newIncludeExcludeFilter(ptr(IncludeExclude{
+	_, err := newIncludeExcludeFilter(new(IncludeExclude{
 		Included: []string{"foo"},
 		Excluded: []string{"foo"},
 	}))
@@ -1194,9 +1194,9 @@ func TestPrometheusIPv6(t *testing.T) {
 			cfg := Prometheus{
 				Host:                       &tt.host,
 				Port:                       &port,
-				WithoutScopeInfo:           ptr(true),
-				WithoutTypeSuffix:          ptr(true),
-				WithoutUnits:               ptr(true),
+				WithoutScopeInfo:           new(true),
+				WithoutTypeSuffix:          new(true),
+				WithoutUnits:               new(true),
 				WithResourceConstantLabels: &IncludeExclude{},
 			}
 
@@ -1235,22 +1235,22 @@ func TestPrometheusReaderErrorCases(t *testing.T) {
 	}{
 		{
 			name:   "missing host",
-			config: &Prometheus{Port: ptr(8080)},
+			config: &Prometheus{Port: new(8080)},
 			errMsg: "host must be specified",
 		},
 		{
 			name:   "missing port",
-			config: &Prometheus{Host: ptr("localhost")},
+			config: &Prometheus{Host: new("localhost")},
 			errMsg: "port must be specified",
 		},
 		{
 			name: "invalid port",
 			config: &Prometheus{
-				Host:                       ptr("localhost"),
-				Port:                       ptr(99999), // invalid port
-				WithoutScopeInfo:           ptr(true),
-				WithoutTypeSuffix:          ptr(true),
-				WithoutUnits:               ptr(true),
+				Host:                       new("localhost"),
+				Port:                       new(99999), // invalid port
+				WithoutScopeInfo:           new(true),
+				WithoutTypeSuffix:          new(true),
+				WithoutUnits:               new(true),
 				WithResourceConstantLabels: &IncludeExclude{},
 			},
 			errMsg: "binding address",
@@ -1258,8 +1258,8 @@ func TestPrometheusReaderErrorCases(t *testing.T) {
 		{
 			name: "invalid with_resource_constant_labels",
 			config: &Prometheus{
-				Host: ptr("localhost"),
-				Port: ptr(0),
+				Host: new("localhost"),
+				Port: new(0),
 				WithResourceConstantLabels: &IncludeExclude{
 					Included: []string{"foo"},
 					Excluded: []string{"foo"},
@@ -1284,9 +1284,9 @@ func TestPrometheusReaderConfigurationOptions(t *testing.T) {
 	cfg := &Prometheus{
 		Host:              &host,
 		Port:              &port,
-		WithoutScopeInfo:  ptr(true),
-		WithoutTypeSuffix: ptr(true),
-		WithoutUnits:      ptr(true),
+		WithoutScopeInfo:  new(true),
+		WithoutTypeSuffix: new(true),
+		WithoutUnits:      new(true),
 		WithResourceConstantLabels: &IncludeExclude{
 			Included: []string{"service.name"},
 			Excluded: []string{"host.name"},
@@ -1332,8 +1332,8 @@ func TestPrometheusReaderDotStyleLabels(t *testing.T) {
 	reader, err := prometheusReader(t.Context(), &Prometheus{
 		Host:              &host,
 		Port:              &port,
-		WithoutTypeSuffix: ptr(true),
-		WithoutUnits:      ptr(true),
+		WithoutTypeSuffix: new(true),
+		WithoutUnits:      new(true),
 	})
 	require.NoError(t, err)
 
@@ -1398,9 +1398,9 @@ func TestPrometheusReaderHostParsing(t *testing.T) {
 			cfg := Prometheus{
 				Host:                       &tt.host,
 				Port:                       &port,
-				WithoutScopeInfo:           ptr(true),
-				WithoutTypeSuffix:          ptr(true),
-				WithoutUnits:               ptr(true),
+				WithoutScopeInfo:           new(true),
+				WithoutTypeSuffix:          new(true),
+				WithoutUnits:               new(true),
 				WithResourceConstantLabels: &IncludeExclude{},
 			}
 

--- a/otelconf/v0.2.0/resource_test.go
+++ b/otelconf/v0.2.0/resource_test.go
@@ -46,7 +46,7 @@ func TestNewResource(t *testing.T) {
 		{
 			name: "resource-with-attributes-invalid-schema",
 			config: &Resource{
-				SchemaUrl: ptr("https://opentelemetry.io/"),
+				SchemaUrl: new("https://opentelemetry.io/"),
 				Attributes: Attributes{
 					"service.name": "service-a",
 				},
@@ -60,7 +60,7 @@ func TestNewResource(t *testing.T) {
 				Attributes: Attributes{
 					"service.name": "service-a",
 				},
-				SchemaUrl: ptr(schemaURL),
+				SchemaUrl: new(schemaURL),
 			},
 			wantResource: res,
 		},
@@ -71,7 +71,7 @@ func TestNewResource(t *testing.T) {
 					"service.name": "service-a",
 					"attr-bool":    true,
 				},
-				SchemaUrl: ptr(schemaURL),
+				SchemaUrl: new(schemaURL),
 			},
 			wantResource: resWithAttrs,
 		},

--- a/otelconf/v0.2.0/trace_test.go
+++ b/otelconf/v0.2.0/trace_test.go
@@ -126,7 +126,7 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch processor invalid batch size console exporter",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(-1),
+					MaxExportBatchSize: new(-1),
 					Exporter: SpanExporter{
 						Console: Console{},
 					},
@@ -138,7 +138,7 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch processor invalid export timeout console exporter",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					ExportTimeout: ptr(-2),
+					ExportTimeout: new(-2),
 					Exporter: SpanExporter{
 						Console: Console{},
 					},
@@ -150,7 +150,7 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch processor invalid queue size console exporter",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxQueueSize: ptr(-3),
+					MaxQueueSize: new(-3),
 					Exporter: SpanExporter{
 						Console: Console{},
 					},
@@ -162,7 +162,7 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch processor invalid schedule delay console exporter",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					ScheduleDelay: ptr(-4),
+					ScheduleDelay: new(-4),
 					Exporter: SpanExporter{
 						Console: Console{},
 					},
@@ -186,10 +186,10 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch processor console exporter",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						Console: Console{},
 					},
@@ -201,10 +201,10 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-exporter-invalid-protocol",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
 							Protocol: "http/invalid",
@@ -218,15 +218,15 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-exporter-no-endpoint",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
 							Protocol:    "grpc/protobuf",
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
@@ -240,16 +240,16 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-exporter",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
 							Protocol:    "grpc/protobuf",
 							Endpoint:    "http://localhost:4317",
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
@@ -263,16 +263,16 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-exporter-no-scheme",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
 							Protocol:    "grpc/protobuf",
 							Endpoint:    "localhost:4317",
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
@@ -286,16 +286,16 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-invalid-endpoint",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
 							Protocol:    "grpc/protobuf",
 							Endpoint:    " ",
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
@@ -309,16 +309,16 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-invalid-compression",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
 							Protocol:    "grpc/protobuf",
 							Endpoint:    "localhost:4317",
-							Compression: ptr("invalid"),
-							Timeout:     ptr(1000),
+							Compression: new("invalid"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
@@ -332,16 +332,16 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-http-exporter",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
 							Protocol:    "http/protobuf",
 							Endpoint:    "http://localhost:4318",
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
@@ -355,16 +355,16 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-http-exporter-with-path",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
 							Protocol:    "http/protobuf",
 							Endpoint:    "http://localhost:4318/path/123",
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
@@ -378,15 +378,15 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-http-exporter-no-endpoint",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
 							Protocol:    "http/protobuf",
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
@@ -400,16 +400,16 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-http-exporter-no-scheme",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
 							Protocol:    "http/protobuf",
 							Endpoint:    "localhost:4318",
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
@@ -423,16 +423,16 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-http-invalid-endpoint",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
 							Protocol:    "http/protobuf",
 							Endpoint:    " ",
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
@@ -446,16 +446,16 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-http-none-compression",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
 							Protocol:    "http/protobuf",
 							Endpoint:    "localhost:4318",
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},
@@ -469,16 +469,16 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-http-invalid-compression",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
 							Protocol:    "http/protobuf",
 							Endpoint:    "localhost:4318",
-							Compression: ptr("invalid"),
-							Timeout:     ptr(1000),
+							Compression: new("invalid"),
+							Timeout:     new(1000),
 							Headers: map[string]string{
 								"test": "test1",
 							},

--- a/otelconf/v0.3.0/config_resource_test.go
+++ b/otelconf/v0.3.0/config_resource_test.go
@@ -37,7 +37,7 @@ func TestSDKResource(t *testing.T) {
 	t.Run("returns empty resource for disabled sdk", func(t *testing.T) {
 		sdk, err := NewSDK(
 			WithOpenTelemetryConfiguration(OpenTelemetryConfiguration{
-				Disabled: ptr(true),
+				Disabled: new(true),
 			}),
 		)
 		assert.NoError(t, err)

--- a/otelconf/v0.3.0/config_test.go
+++ b/otelconf/v0.3.0/config_test.go
@@ -56,7 +56,7 @@ func TestNewSDK(t *testing.T) {
 			cfg: []ConfigurationOption{
 				WithContext(t.Context()),
 				WithOpenTelemetryConfiguration(OpenTelemetryConfiguration{
-					Disabled:       ptr(true),
+					Disabled:       new(true),
 					TracerProvider: &TracerProvider{},
 					MeterProvider:  &MeterProvider{},
 					LoggerProvider: &LoggerProvider{},
@@ -78,11 +78,11 @@ func TestNewSDK(t *testing.T) {
 }
 
 var v03OpenTelemetryConfig = OpenTelemetryConfiguration{
-	Disabled:   ptr(false),
-	FileFormat: ptr("0.3"),
+	Disabled:   new(false),
+	FileFormat: new("0.3"),
 	AttributeLimits: &AttributeLimits{
-		AttributeCountLimit:       ptr(128),
-		AttributeValueLengthLimit: ptr(4096),
+		AttributeCountLimit:       new(128),
+		AttributeValueLengthLimit: new(4096),
 	},
 	Instrumentation: &Instrumentation{
 		Cpp: LanguageSpecificInstrumentation{
@@ -161,32 +161,32 @@ var v03OpenTelemetryConfig = OpenTelemetryConfiguration{
 	},
 	LoggerProvider: &LoggerProvider{
 		Limits: &LogRecordLimits{
-			AttributeCountLimit:       ptr(128),
-			AttributeValueLengthLimit: ptr(4096),
+			AttributeCountLimit:       new(128),
+			AttributeValueLengthLimit: new(4096),
 		},
 		Processors: []LogRecordProcessor{
 			{
 				Batch: &BatchLogRecordProcessor{
-					ExportTimeout: ptr(30000),
+					ExportTimeout: new(30000),
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
-							Certificate:       ptr("/app/cert.pem"),
-							ClientCertificate: ptr("/app/cert.pem"),
-							ClientKey:         ptr("/app/cert.pem"),
-							Compression:       ptr("gzip"),
-							Endpoint:          ptr("http://localhost:4318/v1/logs"),
+							Certificate:       new("/app/cert.pem"),
+							ClientCertificate: new("/app/cert.pem"),
+							ClientKey:         new("/app/cert.pem"),
+							Compression:       new("gzip"),
+							Endpoint:          new("http://localhost:4318/v1/logs"),
 							Headers: []NameStringValuePair{
-								{Name: "api-key", Value: ptr("1234")},
+								{Name: "api-key", Value: new("1234")},
 							},
-							HeadersList: ptr("api-key=1234"),
-							Insecure:    ptr(false),
-							Protocol:    ptr("http/protobuf"),
-							Timeout:     ptr(10000),
+							HeadersList: new("api-key=1234"),
+							Insecure:    new(false),
+							Protocol:    new("http/protobuf"),
+							Timeout:     new(10000),
 						},
 					},
-					MaxExportBatchSize: ptr(512),
-					MaxQueueSize:       ptr(2048),
-					ScheduleDelay:      ptr(5000),
+					MaxExportBatchSize: new(512),
+					MaxQueueSize:       new(2048),
+					ScheduleDelay:      new(5000),
 				},
 			},
 			{
@@ -207,15 +207,15 @@ var v03OpenTelemetryConfig = OpenTelemetryConfiguration{
 				Pull: &PullMetricReader{
 					Exporter: PullMetricExporter{
 						Prometheus: &Prometheus{
-							Host: ptr("localhost"),
-							Port: ptr(9464),
+							Host: new("localhost"),
+							Port: new(9464),
 							WithResourceConstantLabels: &IncludeExclude{
 								Excluded: []string{"service.attr1"},
 								Included: []string{"service*"},
 							},
-							WithoutScopeInfo:  ptr(false),
-							WithoutTypeSuffix: ptr(false),
-							WithoutUnits:      ptr(false),
+							WithoutScopeInfo:  new(false),
+							WithoutTypeSuffix: new(false),
+							WithoutUnits:      new(false),
 						},
 					},
 				},
@@ -227,24 +227,24 @@ var v03OpenTelemetryConfig = OpenTelemetryConfiguration{
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLP: &OTLPMetric{
-							Certificate:                 ptr("/app/cert.pem"),
-							ClientCertificate:           ptr("/app/cert.pem"),
-							ClientKey:                   ptr("/app/cert.pem"),
-							Compression:                 ptr("gzip"),
-							DefaultHistogramAggregation: ptr(OTLPMetricDefaultHistogramAggregationBase2ExponentialBucketHistogram),
-							Endpoint:                    ptr("http://localhost:4318/v1/metrics"),
+							Certificate:                 new("/app/cert.pem"),
+							ClientCertificate:           new("/app/cert.pem"),
+							ClientKey:                   new("/app/cert.pem"),
+							Compression:                 new("gzip"),
+							DefaultHistogramAggregation: new(OTLPMetricDefaultHistogramAggregationBase2ExponentialBucketHistogram),
+							Endpoint:                    new("http://localhost:4318/v1/metrics"),
 							Headers: []NameStringValuePair{
-								{Name: "api-key", Value: ptr("1234")},
+								{Name: "api-key", Value: new("1234")},
 							},
-							HeadersList:           ptr("api-key=1234"),
-							Insecure:              ptr(false),
-							Protocol:              ptr("http/protobuf"),
-							TemporalityPreference: ptr("delta"),
-							Timeout:               ptr(10000),
+							HeadersList:           new("api-key=1234"),
+							Insecure:              new(false),
+							Protocol:              new("http/protobuf"),
+							TemporalityPreference: new("delta"),
+							Timeout:               new(10000),
 						},
 					},
-					Interval: ptr(5000),
-					Timeout:  ptr(30000),
+					Interval: new(5000),
+					Timeout:  new(30000),
 				},
 			},
 			{
@@ -258,32 +258,32 @@ var v03OpenTelemetryConfig = OpenTelemetryConfiguration{
 		Views: []View{
 			{
 				Selector: &ViewSelector{
-					InstrumentName: ptr("my-instrument"),
-					InstrumentType: ptr(ViewSelectorInstrumentTypeHistogram),
-					MeterName:      ptr("my-meter"),
-					MeterSchemaUrl: ptr("https://opentelemetry.io/schemas/1.16.0"),
-					MeterVersion:   ptr("1.0.0"),
-					Unit:           ptr("ms"),
+					InstrumentName: new("my-instrument"),
+					InstrumentType: new(ViewSelectorInstrumentTypeHistogram),
+					MeterName:      new("my-meter"),
+					MeterSchemaUrl: new("https://opentelemetry.io/schemas/1.16.0"),
+					MeterVersion:   new("1.0.0"),
+					Unit:           new("ms"),
 				},
 				Stream: &ViewStream{
 					Aggregation: &ViewStreamAggregation{
 						ExplicitBucketHistogram: &ViewStreamAggregationExplicitBucketHistogram{
 							Boundaries:   []float64{0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000},
-							RecordMinMax: ptr(true),
+							RecordMinMax: new(true),
 						},
 					},
 					AttributeKeys: &IncludeExclude{
 						Included: []string{"key1", "key2"},
 						Excluded: []string{"key3"},
 					},
-					Description: ptr("new_description"),
-					Name:        ptr("new_instrument_name"),
+					Description: new("new_description"),
+					Name:        new("new_instrument_name"),
 				},
 			},
 		},
 	},
 	Propagator: &Propagator{
-		Composite: []*string{ptr("tracecontext"), ptr("baggage"), ptr("b3"), ptr("b3multi"), ptr("jaeger"), ptr("xray"), ptr("ottrace")},
+		Composite: []*string{new("tracecontext"), new("baggage"), new("b3"), new("b3multi"), new("jaeger"), new("xray"), new("ottrace")},
 	},
 	Resource: &Resource{
 		Attributes: []AttributeNameValue{
@@ -297,55 +297,55 @@ var v03OpenTelemetryConfig = OpenTelemetryConfiguration{
 			{Name: "int_array_key", Type: &AttributeNameValueType{Value: "int_array"}, Value: []any{1, 2}},
 			{Name: "double_array_key", Type: &AttributeNameValueType{Value: "double_array"}, Value: []any{1.1, 2.2}},
 		},
-		AttributesList: ptr("service.namespace=my-namespace,service.version=1.0.0"),
+		AttributesList: new("service.namespace=my-namespace,service.version=1.0.0"),
 		Detectors: &Detectors{
 			Attributes: &DetectorsAttributes{
 				Excluded: []string{"process.command_args"},
 				Included: []string{"process.*"},
 			},
 		},
-		SchemaUrl: ptr("https://opentelemetry.io/schemas/1.16.0"),
+		SchemaUrl: new("https://opentelemetry.io/schemas/1.16.0"),
 	},
 	TracerProvider: &TracerProvider{
 		Limits: &SpanLimits{
-			AttributeCountLimit:       ptr(128),
-			AttributeValueLengthLimit: ptr(4096),
-			EventCountLimit:           ptr(128),
-			EventAttributeCountLimit:  ptr(128),
-			LinkCountLimit:            ptr(128),
-			LinkAttributeCountLimit:   ptr(128),
+			AttributeCountLimit:       new(128),
+			AttributeValueLengthLimit: new(4096),
+			EventCountLimit:           new(128),
+			EventAttributeCountLimit:  new(128),
+			LinkCountLimit:            new(128),
+			LinkAttributeCountLimit:   new(128),
 		},
 		Processors: []SpanProcessor{
 			{
 				Batch: &BatchSpanProcessor{
-					ExportTimeout: ptr(30000),
+					ExportTimeout: new(30000),
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
-							Certificate:       ptr("/app/cert.pem"),
-							ClientCertificate: ptr("/app/cert.pem"),
-							ClientKey:         ptr("/app/cert.pem"),
-							Compression:       ptr("gzip"),
-							Endpoint:          ptr("http://localhost:4318/v1/traces"),
+							Certificate:       new("/app/cert.pem"),
+							ClientCertificate: new("/app/cert.pem"),
+							ClientKey:         new("/app/cert.pem"),
+							Compression:       new("gzip"),
+							Endpoint:          new("http://localhost:4318/v1/traces"),
 							Headers: []NameStringValuePair{
-								{Name: "api-key", Value: ptr("1234")},
+								{Name: "api-key", Value: new("1234")},
 							},
-							HeadersList: ptr("api-key=1234"),
-							Insecure:    ptr(false),
-							Protocol:    ptr("http/protobuf"),
-							Timeout:     ptr(10000),
+							HeadersList: new("api-key=1234"),
+							Insecure:    new(false),
+							Protocol:    new("http/protobuf"),
+							Timeout:     new(10000),
 						},
 					},
-					MaxExportBatchSize: ptr(512),
-					MaxQueueSize:       ptr(2048),
-					ScheduleDelay:      ptr(5000),
+					MaxExportBatchSize: new(512),
+					MaxQueueSize:       new(2048),
+					ScheduleDelay:      new(5000),
 				},
 			},
 			{
 				Batch: &BatchSpanProcessor{
 					Exporter: SpanExporter{
 						Zipkin: &Zipkin{
-							Endpoint: ptr("http://localhost:9411/api/v2/spans"),
-							Timeout:  ptr(10000),
+							Endpoint: new("http://localhost:9411/api/v2/spans"),
+							Timeout:  new(10000),
 						},
 					},
 				},
@@ -374,7 +374,7 @@ var v03OpenTelemetryConfig = OpenTelemetryConfiguration{
 				},
 				Root: &Sampler{
 					TraceIDRatioBased: &SamplerTraceIDRatioBased{
-						Ratio: ptr(0.0001),
+						Ratio: new(0.0001),
 					},
 				},
 			},
@@ -383,11 +383,11 @@ var v03OpenTelemetryConfig = OpenTelemetryConfiguration{
 }
 
 var v03OpenTelemetryConfigEnvParsing = OpenTelemetryConfiguration{
-	Disabled:   ptr(false),
-	FileFormat: ptr("0.3"),
+	Disabled:   new(false),
+	FileFormat: new("0.3"),
 	AttributeLimits: &AttributeLimits{
-		AttributeCountLimit:       ptr(128),
-		AttributeValueLengthLimit: ptr(4096),
+		AttributeCountLimit:       new(128),
+		AttributeValueLengthLimit: new(4096),
 	},
 	Resource: &Resource{
 		Attributes: []AttributeNameValue{
@@ -428,14 +428,14 @@ var v03OpenTelemetryConfigEnvParsing = OpenTelemetryConfiguration{
 			{Name: "escape_sequence", Type: &AttributeNameValueType{Value: "string"}, Value: "a $ b"},
 			{Name: "no_escape_sequence", Type: &AttributeNameValueType{Value: "string"}, Value: "a $ b"},
 		},
-		AttributesList: ptr("service.namespace=my-namespace,service.version=1.0.0"),
+		AttributesList: new("service.namespace=my-namespace,service.version=1.0.0"),
 		Detectors: &Detectors{
 			Attributes: &DetectorsAttributes{
 				Excluded: []string{"process.command_args"},
 				Included: []string{"process.*"},
 			},
 		},
-		SchemaUrl: ptr("https://opentelemetry.io/schemas/1.16.0"),
+		SchemaUrl: new("https://opentelemetry.io/schemas/1.16.0"),
 	},
 }
 
@@ -451,8 +451,8 @@ func TestParseYAML(t *testing.T) {
 			input:   `valid_empty.yaml`,
 			wantErr: nil,
 			wantType: &OpenTelemetryConfiguration{
-				Disabled:   ptr(false),
-				FileFormat: ptr("0.1"),
+				Disabled:   new(false),
+				FileFormat: new("0.1"),
 			},
 		},
 		{
@@ -560,8 +560,8 @@ func TestSerializeJSON(t *testing.T) {
 			input:   `valid_empty.json`,
 			wantErr: nil,
 			wantType: OpenTelemetryConfiguration{
-				Disabled:   ptr(false),
-				FileFormat: ptr("0.1"),
+				Disabled:   new(false),
+				FileFormat: new("0.1"),
 			},
 		},
 		{
@@ -637,7 +637,7 @@ func TestCreateHeadersConfig(t *testing.T) {
 		{
 			name:        "headerslist only",
 			headers:     []NameStringValuePair{},
-			headersList: ptr("a=b,c=d"),
+			headersList: new("a=b,c=d"),
 			wantHeaders: map[string]string{
 				"a": "b",
 				"c": "d",
@@ -648,11 +648,11 @@ func TestCreateHeadersConfig(t *testing.T) {
 			headers: []NameStringValuePair{
 				{
 					Name:  "a",
-					Value: ptr("b"),
+					Value: new("b"),
 				},
 				{
 					Name:  "c",
-					Value: ptr("d"),
+					Value: new("d"),
 				},
 			},
 			headersList: nil,
@@ -666,10 +666,10 @@ func TestCreateHeadersConfig(t *testing.T) {
 			headers: []NameStringValuePair{
 				{
 					Name:  "a",
-					Value: ptr("b"),
+					Value: new("b"),
 				},
 			},
-			headersList: ptr("c=d"),
+			headersList: new("c=d"),
 			wantHeaders: map[string]string{
 				"a": "b",
 				"c": "d",
@@ -680,14 +680,14 @@ func TestCreateHeadersConfig(t *testing.T) {
 			headers: []NameStringValuePair{
 				{
 					Name:  "a",
-					Value: ptr("b"),
+					Value: new("b"),
 				},
 				{
 					Name:  "c",
-					Value: ptr("override"),
+					Value: new("override"),
 				},
 			},
-			headersList: ptr("c=d"),
+			headersList: new("c=d"),
 			wantHeaders: map[string]string{
 				"a": "b",
 				"c": "override",
@@ -695,7 +695,7 @@ func TestCreateHeadersConfig(t *testing.T) {
 		},
 		{
 			name:        "invalid headerslist",
-			headersList: ptr("==="),
+			headersList: new("==="),
 			wantErr:     "invalid headers list: invalid key: \"\"",
 		},
 		{
@@ -703,7 +703,7 @@ func TestCreateHeadersConfig(t *testing.T) {
 			headers: []NameStringValuePair{
 				{
 					Name:  "",
-					Value: ptr("token"),
+					Value: new("token"),
 				},
 			},
 			wantErr: "invalid header: empty name",
@@ -721,8 +721,4 @@ func TestCreateHeadersConfig(t *testing.T) {
 			require.Equal(t, tt.wantHeaders, headersMap)
 		})
 	}
-}
-
-func ptr[T any](v T) *T {
-	return &v
 }

--- a/otelconf/v0.3.0/log_test.go
+++ b/otelconf/v0.3.0/log_test.go
@@ -112,10 +112,10 @@ func TestLogProcessor(t *testing.T) {
 
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(-1),
+					MaxExportBatchSize: new(-1),
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
-							Protocol: ptr("http/protobuf"),
+							Protocol: new("http/protobuf"),
 						},
 					},
 				},
@@ -126,10 +126,10 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch processor invalid export timeout otlphttp exporter",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					ExportTimeout: ptr(-2),
+					ExportTimeout: new(-2),
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
-							Protocol: ptr("http/protobuf"),
+							Protocol: new("http/protobuf"),
 						},
 					},
 				},
@@ -141,10 +141,10 @@ func TestLogProcessor(t *testing.T) {
 
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxQueueSize: ptr(-3),
+					MaxQueueSize: new(-3),
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
-							Protocol: ptr("http/protobuf"),
+							Protocol: new("http/protobuf"),
 						},
 					},
 				},
@@ -155,10 +155,10 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch processor invalid schedule delay console exporter",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					ScheduleDelay: ptr(-4),
+					ScheduleDelay: new(-4),
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
-							Protocol: ptr("http/protobuf"),
+							Protocol: new("http/protobuf"),
 						},
 					},
 				},
@@ -178,10 +178,10 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/console",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						Console: map[string]any{},
 					},
@@ -193,17 +193,17 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-exporter-no-endpoint",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("grpc"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Protocol:    new("grpc"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -215,18 +215,18 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-exporter",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("grpc"),
-							Endpoint:    ptr("http://localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Protocol:    new("grpc"),
+							Endpoint:    new("http://localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -238,18 +238,18 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-exporter-socket-endpoint",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("grpc"),
-							Endpoint:    ptr("unix:collector.sock"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Protocol:    new("grpc"),
+							Endpoint:    new("unix:collector.sock"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -263,11 +263,11 @@ func TestLogProcessor(t *testing.T) {
 				Batch: &BatchLogRecordProcessor{
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("grpc"),
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
-							Certificate: ptr(material.CACertPath),
+							Protocol:    new("grpc"),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
+							Certificate: new(material.CACertPath),
 						},
 					},
 				},
@@ -280,11 +280,11 @@ func TestLogProcessor(t *testing.T) {
 				Batch: &BatchLogRecordProcessor{
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("grpc"),
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
-							Certificate: ptr(material.BadCertPath),
+							Protocol:    new("grpc"),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
+							Certificate: new(material.BadCertPath),
 						},
 					},
 				},
@@ -297,11 +297,11 @@ func TestLogProcessor(t *testing.T) {
 				Batch: &BatchLogRecordProcessor{
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("grpc"),
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
-							HeadersList: ptr("==="),
+							Protocol:    new("grpc"),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
+							HeadersList: new("==="),
 						},
 					},
 				},
@@ -314,12 +314,12 @@ func TestLogProcessor(t *testing.T) {
 				Batch: &BatchLogRecordProcessor{
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
-							Protocol:          ptr("grpc"),
-							Endpoint:          ptr("localhost:4317"),
-							Compression:       ptr("gzip"),
-							Timeout:           ptr(1000),
-							ClientCertificate: ptr(material.BadCertPath),
-							ClientKey:         ptr(material.BadCertPath),
+							Protocol:          new("grpc"),
+							Endpoint:          new("localhost:4317"),
+							Compression:       new("gzip"),
+							Timeout:           new(1000),
+							ClientCertificate: new(material.BadCertPath),
+							ClientKey:         new(material.BadCertPath),
 						},
 					},
 				},
@@ -330,18 +330,18 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-exporter-no-scheme",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("grpc"),
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Protocol:    new("grpc"),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -353,18 +353,18 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-invalid-endpoint",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("grpc"),
-							Endpoint:    ptr(" "),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Protocol:    new("grpc"),
+							Endpoint:    new(" "),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -376,18 +376,18 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-invalid-compression",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("grpc"),
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("invalid"),
-							Timeout:     ptr(1000),
+							Protocol:    new("grpc"),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("invalid"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -399,18 +399,18 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-http-exporter",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("http/protobuf"),
-							Endpoint:    ptr("http://localhost:4318"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Protocol:    new("http/protobuf"),
+							Endpoint:    new("http://localhost:4318"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -424,11 +424,11 @@ func TestLogProcessor(t *testing.T) {
 				Batch: &BatchLogRecordProcessor{
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("http/protobuf"),
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
-							Certificate: ptr(material.CACertPath),
+							Protocol:    new("http/protobuf"),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
+							Certificate: new(material.CACertPath),
 						},
 					},
 				},
@@ -441,11 +441,11 @@ func TestLogProcessor(t *testing.T) {
 				Batch: &BatchLogRecordProcessor{
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("http/protobuf"),
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
-							Certificate: ptr(material.BadCertPath),
+							Protocol:    new("http/protobuf"),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
+							Certificate: new(material.BadCertPath),
 						},
 					},
 				},
@@ -458,12 +458,12 @@ func TestLogProcessor(t *testing.T) {
 				Batch: &BatchLogRecordProcessor{
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
-							Protocol:          ptr("http/protobuf"),
-							Endpoint:          ptr("localhost:4317"),
-							Compression:       ptr("gzip"),
-							Timeout:           ptr(1000),
-							ClientCertificate: ptr(material.BadCertPath),
-							ClientKey:         ptr(material.BadCertPath),
+							Protocol:          new("http/protobuf"),
+							Endpoint:          new("localhost:4317"),
+							Compression:       new("gzip"),
+							Timeout:           new(1000),
+							ClientCertificate: new(material.BadCertPath),
+							ClientKey:         new(material.BadCertPath),
 						},
 					},
 				},
@@ -476,11 +476,11 @@ func TestLogProcessor(t *testing.T) {
 				Batch: &BatchLogRecordProcessor{
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("http/protobuf"),
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
-							HeadersList: ptr("==="),
+							Protocol:    new("http/protobuf"),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
+							HeadersList: new("==="),
 						},
 					},
 				},
@@ -491,18 +491,18 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-http-exporter-with-path",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("http/protobuf"),
-							Endpoint:    ptr("http://localhost:4318/path/123"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Protocol:    new("http/protobuf"),
+							Endpoint:    new("http://localhost:4318/path/123"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -514,17 +514,17 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-http-exporter-no-endpoint",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("http/protobuf"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Protocol:    new("http/protobuf"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -536,18 +536,18 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-http-exporter-no-scheme",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("http/protobuf"),
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Protocol:    new("http/protobuf"),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -559,18 +559,18 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-http-invalid-protocol",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("invalid"),
-							Endpoint:    ptr("https://10.0.0.0:443"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Protocol:    new("invalid"),
+							Endpoint:    new("https://10.0.0.0:443"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -582,18 +582,18 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-http-invalid-endpoint",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("http/protobuf"),
-							Endpoint:    ptr(" "),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Protocol:    new("http/protobuf"),
+							Endpoint:    new(" "),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -605,18 +605,18 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-http-none-compression",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("http/protobuf"),
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Protocol:    new("http/protobuf"),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -628,18 +628,18 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-http-invalid-compression",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("http/protobuf"),
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("invalid"),
-							Timeout:     ptr(1000),
+							Protocol:    new("http/protobuf"),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("invalid"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -673,12 +673,12 @@ func TestLogProcessor(t *testing.T) {
 				Simple: &SimpleLogRecordProcessor{
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("http/protobuf"),
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Protocol:    new("http/protobuf"),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -721,9 +721,9 @@ func TestLoggerProviderOptions(t *testing.T) {
 				Simple: &SimpleLogRecordProcessor{
 					Exporter: LogRecordExporter{
 						OTLP: &OTLP{
-							Protocol: ptr("http/protobuf"),
-							Endpoint: ptr(srv.URL),
-							Insecure: ptr(true),
+							Protocol: new("http/protobuf"),
+							Endpoint: new(srv.URL),
+							Insecure: new(true),
 						},
 					},
 				},
@@ -775,12 +775,12 @@ func Test_otlpGRPCLogExporter(t *testing.T) {
 			args: args{
 				ctx: t.Context(),
 				otlpConfig: &OTLP{
-					Protocol:    ptr("grpc"),
-					Compression: ptr("gzip"),
-					Timeout:     ptr(50000),
-					Insecure:    ptr(true),
+					Protocol:    new("grpc"),
+					Compression: new("gzip"),
+					Timeout:     new(50000),
+					Insecure:    new(true),
 					Headers: []NameStringValuePair{
-						{Name: "test", Value: ptr("test1")},
+						{Name: "test", Value: new("test1")},
 					},
 				},
 			},
@@ -793,12 +793,12 @@ func Test_otlpGRPCLogExporter(t *testing.T) {
 			args: args{
 				ctx: t.Context(),
 				otlpConfig: &OTLP{
-					Protocol:    ptr("grpc"),
-					Compression: ptr("gzip"),
-					Timeout:     ptr(50000),
-					Certificate: ptr(material.CACertPath),
+					Protocol:    new("grpc"),
+					Compression: new("gzip"),
+					Timeout:     new(50000),
+					Certificate: new(material.CACertPath),
 					Headers: []NameStringValuePair{
-						{Name: "test", Value: ptr("test1")},
+						{Name: "test", Value: new("test1")},
 					},
 				},
 			},
@@ -817,14 +817,14 @@ func Test_otlpGRPCLogExporter(t *testing.T) {
 			args: args{
 				ctx: t.Context(),
 				otlpConfig: &OTLP{
-					Protocol:          ptr("grpc"),
-					Compression:       ptr("gzip"),
-					Timeout:           ptr(50000),
-					Certificate:       ptr(material.CACertPath),
-					ClientKey:         ptr(material.ClientKeyPath),
-					ClientCertificate: ptr(material.ClientCertPath),
+					Protocol:          new("grpc"),
+					Compression:       new("gzip"),
+					Timeout:           new(50000),
+					Certificate:       new(material.CACertPath),
+					ClientKey:         new(material.ClientKeyPath),
+					ClientCertificate: new(material.ClientCertPath),
 					Headers: []NameStringValuePair{
-						{Name: "test", Value: ptr("test1")},
+						{Name: "test", Value: new("test1")},
 					},
 				},
 			},
@@ -859,7 +859,7 @@ func Test_otlpGRPCLogExporter(t *testing.T) {
 			if tt.args.otlpConfig.Insecure != nil && *tt.args.otlpConfig.Insecure {
 				scheme = "http"
 			}
-			tt.args.otlpConfig.Endpoint = ptr(scheme + "://" + n.Addr().String())
+			tt.args.otlpConfig.Endpoint = new(scheme + "://" + n.Addr().String())
 
 			serverOpts, err := tt.grpcServerOpts()
 			require.NoError(t, err)

--- a/otelconf/v0.3.0/metric_test.go
+++ b/otelconf/v0.3.0/metric_test.go
@@ -114,9 +114,9 @@ func TestMeterProviderOptions(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLP: &OTLPMetric{
-							Protocol: ptr("http/protobuf"),
-							Endpoint: ptr(srv.URL),
-							Insecure: ptr(true),
+							Protocol: new("http/protobuf"),
+							Endpoint: new(srv.URL),
+							Insecure: new(true),
 						},
 					},
 				},
@@ -201,7 +201,7 @@ func TestReader(t *testing.T) {
 				Pull: &PullMetricReader{
 					Exporter: PullMetricExporter{
 						Prometheus: &Prometheus{
-							Host: ptr("localhost"),
+							Host: new("localhost"),
 						},
 					},
 				},
@@ -214,11 +214,11 @@ func TestReader(t *testing.T) {
 				Pull: &PullMetricReader{
 					Exporter: PullMetricExporter{
 						Prometheus: &Prometheus{
-							Host:              ptr("localhost"),
-							Port:              ptr(0),
-							WithoutScopeInfo:  ptr(true),
-							WithoutUnits:      ptr(true),
-							WithoutTypeSuffix: ptr(true),
+							Host:              new("localhost"),
+							Port:              new(0),
+							WithoutScopeInfo:  new(true),
+							WithoutUnits:      new(true),
+							WithoutTypeSuffix: new(true),
 							WithResourceConstantLabels: &IncludeExclude{
 								Included: []string{"include"},
 								Excluded: []string{"exclude"},
@@ -235,7 +235,7 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLP: &OTLPMetric{
-							Protocol: ptr("http/invalid"),
+							Protocol: new("http/invalid"),
 						},
 					},
 				},
@@ -248,12 +248,12 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLP: &OTLPMetric{
-							Protocol:    ptr("grpc"),
-							Endpoint:    ptr("http://localhost:4318"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Protocol:    new("grpc"),
+							Endpoint:    new("http://localhost:4318"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -267,12 +267,12 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLP: &OTLPMetric{
-							Protocol:    ptr("grpc"),
-							Endpoint:    ptr("http://localhost:4318/path/123"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Protocol:    new("grpc"),
+							Endpoint:    new("http://localhost:4318/path/123"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -286,11 +286,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLP: &OTLPMetric{
-							Protocol:    ptr("grpc"),
-							Endpoint:    ptr("https://localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
-							Certificate: ptr(material.CACertPath),
+							Protocol:    new("grpc"),
+							Endpoint:    new("https://localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
+							Certificate: new(material.CACertPath),
 						},
 					},
 				},
@@ -303,11 +303,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLP: &OTLPMetric{
-							Protocol:    ptr("grpc"),
-							Endpoint:    ptr("https://localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
-							Certificate: ptr(material.BadCertPath),
+							Protocol:    new("grpc"),
+							Endpoint:    new("https://localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
+							Certificate: new(material.BadCertPath),
 						},
 					},
 				},
@@ -320,12 +320,12 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLP: &OTLPMetric{
-							Protocol:          ptr("grpc"),
-							Endpoint:          ptr("localhost:4317"),
-							Compression:       ptr("gzip"),
-							Timeout:           ptr(1000),
-							ClientCertificate: ptr(material.BadCertPath),
-							ClientKey:         ptr(material.BadCertPath),
+							Protocol:          new("grpc"),
+							Endpoint:          new("localhost:4317"),
+							Compression:       new("gzip"),
+							Timeout:           new(1000),
+							ClientCertificate: new(material.BadCertPath),
+							ClientKey:         new(material.BadCertPath),
 						},
 					},
 				},
@@ -338,11 +338,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLP: &OTLPMetric{
-							Protocol:    ptr("grpc"),
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
-							HeadersList: ptr("==="),
+							Protocol:    new("grpc"),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
+							HeadersList: new("==="),
 						},
 					},
 				},
@@ -355,11 +355,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLP: &OTLPMetric{
-							Protocol:    ptr("grpc"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Protocol:    new("grpc"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -373,12 +373,12 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLP: &OTLPMetric{
-							Protocol:    ptr("grpc"),
-							Endpoint:    ptr("unix:collector.sock"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Protocol:    new("grpc"),
+							Endpoint:    new("unix:collector.sock"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -392,12 +392,12 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLP: &OTLPMetric{
-							Protocol:    ptr("grpc"),
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Protocol:    new("grpc"),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -411,12 +411,12 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLP: &OTLPMetric{
-							Protocol:    ptr("grpc"),
-							Endpoint:    ptr(" "),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Protocol:    new("grpc"),
+							Endpoint:    new(" "),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -430,12 +430,12 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLP: &OTLPMetric{
-							Protocol:    ptr("grpc"),
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Protocol:    new("grpc"),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -449,14 +449,14 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLP: &OTLPMetric{
-							Protocol:    ptr("grpc"),
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Protocol:    new("grpc"),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
-							TemporalityPreference: ptr("delta"),
+							TemporalityPreference: new("delta"),
 						},
 					},
 				},
@@ -469,14 +469,14 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLP: &OTLPMetric{
-							Protocol:    ptr("grpc"),
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Protocol:    new("grpc"),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
-							TemporalityPreference: ptr("cumulative"),
+							TemporalityPreference: new("cumulative"),
 						},
 					},
 				},
@@ -489,14 +489,14 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLP: &OTLPMetric{
-							Protocol:    ptr("grpc"),
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Protocol:    new("grpc"),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
-							TemporalityPreference: ptr("lowmemory"),
+							TemporalityPreference: new("lowmemory"),
 						},
 					},
 				},
@@ -509,14 +509,14 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLP: &OTLPMetric{
-							Protocol:    ptr("grpc"),
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Protocol:    new("grpc"),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
-							TemporalityPreference: ptr("invalid"),
+							TemporalityPreference: new("invalid"),
 						},
 					},
 				},
@@ -529,12 +529,12 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLP: &OTLPMetric{
-							Protocol:    ptr("grpc"),
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("invalid"),
-							Timeout:     ptr(1000),
+							Protocol:    new("grpc"),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("invalid"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -548,12 +548,12 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLP: &OTLPMetric{
-							Protocol:    ptr("http/protobuf"),
-							Endpoint:    ptr("http://localhost:4318"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Protocol:    new("http/protobuf"),
+							Endpoint:    new("http://localhost:4318"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -567,11 +567,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLP: &OTLPMetric{
-							Protocol:    ptr("http/protobuf"),
-							Endpoint:    ptr("https://localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
-							Certificate: ptr(material.CACertPath),
+							Protocol:    new("http/protobuf"),
+							Endpoint:    new("https://localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
+							Certificate: new(material.CACertPath),
 						},
 					},
 				},
@@ -584,11 +584,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLP: &OTLPMetric{
-							Protocol:    ptr("http/protobuf"),
-							Endpoint:    ptr("https://localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
-							Certificate: ptr(material.BadCertPath),
+							Protocol:    new("http/protobuf"),
+							Endpoint:    new("https://localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
+							Certificate: new(material.BadCertPath),
 						},
 					},
 				},
@@ -601,12 +601,12 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLP: &OTLPMetric{
-							Protocol:          ptr("http/protobuf"),
-							Endpoint:          ptr("localhost:4317"),
-							Compression:       ptr("gzip"),
-							Timeout:           ptr(1000),
-							ClientCertificate: ptr(material.BadCertPath),
-							ClientKey:         ptr(material.BadCertPath),
+							Protocol:          new("http/protobuf"),
+							Endpoint:          new("localhost:4317"),
+							Compression:       new("gzip"),
+							Timeout:           new(1000),
+							ClientCertificate: new(material.BadCertPath),
+							ClientKey:         new(material.BadCertPath),
 						},
 					},
 				},
@@ -619,11 +619,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLP: &OTLPMetric{
-							Protocol:    ptr("http/protobuf"),
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
-							HeadersList: ptr("==="),
+							Protocol:    new("http/protobuf"),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
+							HeadersList: new("==="),
 						},
 					},
 				},
@@ -636,12 +636,12 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLP: &OTLPMetric{
-							Protocol:    ptr("http/protobuf"),
-							Endpoint:    ptr("http://localhost:4318/path/123"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Protocol:    new("http/protobuf"),
+							Endpoint:    new("http://localhost:4318/path/123"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -655,11 +655,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLP: &OTLPMetric{
-							Protocol:    ptr("http/protobuf"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Protocol:    new("http/protobuf"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -673,12 +673,12 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLP: &OTLPMetric{
-							Protocol:    ptr("http/protobuf"),
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Protocol:    new("http/protobuf"),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -692,12 +692,12 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLP: &OTLPMetric{
-							Protocol:    ptr("http/protobuf"),
-							Endpoint:    ptr(" "),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Protocol:    new("http/protobuf"),
+							Endpoint:    new(" "),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -711,12 +711,12 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLP: &OTLPMetric{
-							Protocol:    ptr("http/protobuf"),
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Protocol:    new("http/protobuf"),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -730,14 +730,14 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLP: &OTLPMetric{
-							Protocol:    ptr("http/protobuf"),
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Protocol:    new("http/protobuf"),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
-							TemporalityPreference: ptr("cumulative"),
+							TemporalityPreference: new("cumulative"),
 						},
 					},
 				},
@@ -750,14 +750,14 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLP: &OTLPMetric{
-							Protocol:    ptr("http/protobuf"),
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Protocol:    new("http/protobuf"),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
-							TemporalityPreference: ptr("lowmemory"),
+							TemporalityPreference: new("lowmemory"),
 						},
 					},
 				},
@@ -770,14 +770,14 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLP: &OTLPMetric{
-							Protocol:    ptr("http/protobuf"),
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Protocol:    new("http/protobuf"),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
-							TemporalityPreference: ptr("delta"),
+							TemporalityPreference: new("delta"),
 						},
 					},
 				},
@@ -790,14 +790,14 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLP: &OTLPMetric{
-							Protocol:    ptr("http/protobuf"),
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Protocol:    new("http/protobuf"),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
-							TemporalityPreference: ptr("invalid"),
+							TemporalityPreference: new("invalid"),
 						},
 					},
 				},
@@ -810,12 +810,12 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLP: &OTLPMetric{
-							Protocol:    ptr("http/protobuf"),
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("invalid"),
-							Timeout:     ptr(1000),
+							Protocol:    new("http/protobuf"),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("invalid"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -847,8 +847,8 @@ func TestReader(t *testing.T) {
 			name: "periodic/console-exporter-with-extra-options",
 			reader: MetricReader{
 				Periodic: &PeriodicMetricReader{
-					Interval: ptr(30_000),
-					Timeout:  ptr(5_000),
+					Interval: new(30_000),
+					Timeout:  new(5_000),
 					Exporter: PushMetricExporter{
 						Console: Console{},
 					},
@@ -910,7 +910,7 @@ func TestView(t *testing.T) {
 			name: "selector/invalid_type",
 			view: View{
 				Selector: &ViewSelector{
-					InstrumentType: (*ViewSelectorInstrumentType)(ptr("invalid_type")),
+					InstrumentType: (*ViewSelectorInstrumentType)(new("invalid_type")),
 				},
 			},
 			wantErr: "view_selector: instrument_type: invalid value",
@@ -926,12 +926,12 @@ func TestView(t *testing.T) {
 			name: "all selectors match",
 			view: View{
 				Selector: &ViewSelector{
-					InstrumentName: ptr("test_name"),
-					InstrumentType: (*ViewSelectorInstrumentType)(ptr("counter")),
-					Unit:           ptr("test_unit"),
-					MeterName:      ptr("test_meter_name"),
-					MeterVersion:   ptr("test_meter_version"),
-					MeterSchemaUrl: ptr("test_schema_url"),
+					InstrumentName: new("test_name"),
+					InstrumentType: (*ViewSelectorInstrumentType)(new("counter")),
+					Unit:           new("test_unit"),
+					MeterName:      new("test_meter_name"),
+					MeterVersion:   new("test_meter_version"),
+					MeterSchemaUrl: new("test_schema_url"),
 				},
 			},
 			matchInstrument: &sdkmetric.Instrument{
@@ -951,12 +951,12 @@ func TestView(t *testing.T) {
 			name: "all selectors no match name",
 			view: View{
 				Selector: &ViewSelector{
-					InstrumentName: ptr("test_name"),
-					InstrumentType: (*ViewSelectorInstrumentType)(ptr("counter")),
-					Unit:           ptr("test_unit"),
-					MeterName:      ptr("test_meter_name"),
-					MeterVersion:   ptr("test_meter_version"),
-					MeterSchemaUrl: ptr("test_schema_url"),
+					InstrumentName: new("test_name"),
+					InstrumentType: (*ViewSelectorInstrumentType)(new("counter")),
+					Unit:           new("test_unit"),
+					MeterName:      new("test_meter_name"),
+					MeterVersion:   new("test_meter_version"),
+					MeterSchemaUrl: new("test_schema_url"),
 				},
 			},
 			matchInstrument: &sdkmetric.Instrument{
@@ -976,12 +976,12 @@ func TestView(t *testing.T) {
 			name: "all selectors no match unit",
 			view: View{
 				Selector: &ViewSelector{
-					InstrumentName: ptr("test_name"),
-					InstrumentType: (*ViewSelectorInstrumentType)(ptr("counter")),
-					Unit:           ptr("test_unit"),
-					MeterName:      ptr("test_meter_name"),
-					MeterVersion:   ptr("test_meter_version"),
-					MeterSchemaUrl: ptr("test_schema_url"),
+					InstrumentName: new("test_name"),
+					InstrumentType: (*ViewSelectorInstrumentType)(new("counter")),
+					Unit:           new("test_unit"),
+					MeterName:      new("test_meter_name"),
+					MeterVersion:   new("test_meter_version"),
+					MeterSchemaUrl: new("test_schema_url"),
 				},
 			},
 			matchInstrument: &sdkmetric.Instrument{
@@ -1001,12 +1001,12 @@ func TestView(t *testing.T) {
 			name: "all selectors no match kind",
 			view: View{
 				Selector: &ViewSelector{
-					InstrumentName: ptr("test_name"),
-					InstrumentType: (*ViewSelectorInstrumentType)(ptr("histogram")),
-					Unit:           ptr("test_unit"),
-					MeterName:      ptr("test_meter_name"),
-					MeterVersion:   ptr("test_meter_version"),
-					MeterSchemaUrl: ptr("test_schema_url"),
+					InstrumentName: new("test_name"),
+					InstrumentType: (*ViewSelectorInstrumentType)(new("histogram")),
+					Unit:           new("test_unit"),
+					MeterName:      new("test_meter_name"),
+					MeterVersion:   new("test_meter_version"),
+					MeterSchemaUrl: new("test_schema_url"),
 				},
 			},
 			matchInstrument: &sdkmetric.Instrument{
@@ -1026,12 +1026,12 @@ func TestView(t *testing.T) {
 			name: "all selectors no match meter name",
 			view: View{
 				Selector: &ViewSelector{
-					InstrumentName: ptr("test_name"),
-					InstrumentType: (*ViewSelectorInstrumentType)(ptr("counter")),
-					Unit:           ptr("test_unit"),
-					MeterName:      ptr("test_meter_name"),
-					MeterVersion:   ptr("test_meter_version"),
-					MeterSchemaUrl: ptr("test_schema_url"),
+					InstrumentName: new("test_name"),
+					InstrumentType: (*ViewSelectorInstrumentType)(new("counter")),
+					Unit:           new("test_unit"),
+					MeterName:      new("test_meter_name"),
+					MeterVersion:   new("test_meter_version"),
+					MeterSchemaUrl: new("test_schema_url"),
 				},
 			},
 			matchInstrument: &sdkmetric.Instrument{
@@ -1051,12 +1051,12 @@ func TestView(t *testing.T) {
 			name: "all selectors no match meter version",
 			view: View{
 				Selector: &ViewSelector{
-					InstrumentName: ptr("test_name"),
-					InstrumentType: (*ViewSelectorInstrumentType)(ptr("counter")),
-					Unit:           ptr("test_unit"),
-					MeterName:      ptr("test_meter_name"),
-					MeterVersion:   ptr("test_meter_version"),
-					MeterSchemaUrl: ptr("test_schema_url"),
+					InstrumentName: new("test_name"),
+					InstrumentType: (*ViewSelectorInstrumentType)(new("counter")),
+					Unit:           new("test_unit"),
+					MeterName:      new("test_meter_name"),
+					MeterVersion:   new("test_meter_version"),
+					MeterSchemaUrl: new("test_schema_url"),
 				},
 			},
 			matchInstrument: &sdkmetric.Instrument{
@@ -1076,12 +1076,12 @@ func TestView(t *testing.T) {
 			name: "all selectors no match meter schema url",
 			view: View{
 				Selector: &ViewSelector{
-					InstrumentName: ptr("test_name"),
-					InstrumentType: (*ViewSelectorInstrumentType)(ptr("counter")),
-					Unit:           ptr("test_unit"),
-					MeterName:      ptr("test_meter_name"),
-					MeterVersion:   ptr("test_meter_version"),
-					MeterSchemaUrl: ptr("test_schema_url"),
+					InstrumentName: new("test_name"),
+					InstrumentType: (*ViewSelectorInstrumentType)(new("counter")),
+					Unit:           new("test_unit"),
+					MeterName:      new("test_meter_name"),
+					MeterVersion:   new("test_meter_version"),
+					MeterSchemaUrl: new("test_schema_url"),
 				},
 			},
 			matchInstrument: &sdkmetric.Instrument{
@@ -1101,13 +1101,13 @@ func TestView(t *testing.T) {
 			name: "with stream",
 			view: View{
 				Selector: &ViewSelector{
-					InstrumentName: ptr("test_name"),
-					Unit:           ptr("test_unit"),
+					InstrumentName: new("test_name"),
+					Unit:           new("test_unit"),
 				},
 				Stream: &ViewStream{
-					Name:          ptr("new_name"),
-					Description:   ptr("new_description"),
-					AttributeKeys: ptr(IncludeExclude{Included: []string{"foo", "bar"}}),
+					Name:          new("new_name"),
+					Description:   new("new_description"),
+					AttributeKeys: new(IncludeExclude{Included: []string{"foo", "bar"}}),
 					Aggregation:   &ViewStreamAggregation{Sum: make(ViewStreamAggregationSum)},
 				},
 			},
@@ -1156,37 +1156,37 @@ func TestInstrumentType(t *testing.T) {
 		},
 		{
 			name:     "counter",
-			instType: (*ViewSelectorInstrumentType)(ptr("counter")),
+			instType: (*ViewSelectorInstrumentType)(new("counter")),
 			wantKind: sdkmetric.InstrumentKindCounter,
 		},
 		{
 			name:     "up_down_counter",
-			instType: (*ViewSelectorInstrumentType)(ptr("up_down_counter")),
+			instType: (*ViewSelectorInstrumentType)(new("up_down_counter")),
 			wantKind: sdkmetric.InstrumentKindUpDownCounter,
 		},
 		{
 			name:     "histogram",
-			instType: (*ViewSelectorInstrumentType)(ptr("histogram")),
+			instType: (*ViewSelectorInstrumentType)(new("histogram")),
 			wantKind: sdkmetric.InstrumentKindHistogram,
 		},
 		{
 			name:     "observable_counter",
-			instType: (*ViewSelectorInstrumentType)(ptr("observable_counter")),
+			instType: (*ViewSelectorInstrumentType)(new("observable_counter")),
 			wantKind: sdkmetric.InstrumentKindObservableCounter,
 		},
 		{
 			name:     "observable_up_down_counter",
-			instType: (*ViewSelectorInstrumentType)(ptr("observable_up_down_counter")),
+			instType: (*ViewSelectorInstrumentType)(new("observable_up_down_counter")),
 			wantKind: sdkmetric.InstrumentKindObservableUpDownCounter,
 		},
 		{
 			name:     "observable_gauge",
-			instType: (*ViewSelectorInstrumentType)(ptr("observable_gauge")),
+			instType: (*ViewSelectorInstrumentType)(new("observable_gauge")),
 			wantKind: sdkmetric.InstrumentKindObservableGauge,
 		},
 		{
 			name:     "invalid",
-			instType: (*ViewSelectorInstrumentType)(ptr("invalid")),
+			instType: (*ViewSelectorInstrumentType)(new("invalid")),
 			wantErr:  errors.New("instrument_type: invalid value"),
 		},
 	}
@@ -1234,9 +1234,9 @@ func TestAggregation(t *testing.T) {
 			name: "Base2ExponentialBucketHistogram",
 			aggregation: &ViewStreamAggregation{
 				Base2ExponentialBucketHistogram: &ViewStreamAggregationBase2ExponentialBucketHistogram{
-					MaxSize:      ptr(2),
-					MaxScale:     ptr(3),
-					RecordMinMax: ptr(true),
+					MaxSize:      new(2),
+					MaxScale:     new(3),
+					RecordMinMax: new(true),
 				},
 			},
 			wantAggregation: sdkmetric.AggregationBase2ExponentialHistogram{
@@ -1274,7 +1274,7 @@ func TestAggregation(t *testing.T) {
 			aggregation: &ViewStreamAggregation{
 				ExplicitBucketHistogram: &ViewStreamAggregationExplicitBucketHistogram{
 					Boundaries:   []float64{1, 2, 3},
-					RecordMinMax: ptr(true),
+					RecordMinMax: new(true),
 				},
 			},
 			wantAggregation: sdkmetric.AggregationExplicitBucketHistogram{
@@ -1320,7 +1320,7 @@ func TestNewIncludeExcludeFilter(t *testing.T) {
 		},
 		{
 			name: "filter-with-include",
-			attributeKeys: ptr(IncludeExclude{
+			attributeKeys: new(IncludeExclude{
 				Included: []string{"foo"},
 			}),
 			wantPass: []string{"foo"},
@@ -1328,7 +1328,7 @@ func TestNewIncludeExcludeFilter(t *testing.T) {
 		},
 		{
 			name: "filter-with-exclude",
-			attributeKeys: ptr(IncludeExclude{
+			attributeKeys: new(IncludeExclude{
 				Excluded: []string{"foo"},
 			}),
 			wantPass: []string{"bar"},
@@ -1336,7 +1336,7 @@ func TestNewIncludeExcludeFilter(t *testing.T) {
 		},
 		{
 			name: "filter-with-include-and-exclude",
-			attributeKeys: ptr(IncludeExclude{
+			attributeKeys: new(IncludeExclude{
 				Included: []string{"bar"},
 				Excluded: []string{"foo"},
 			}),
@@ -1359,7 +1359,7 @@ func TestNewIncludeExcludeFilter(t *testing.T) {
 }
 
 func TestNewIncludeExcludeFilterError(t *testing.T) {
-	_, err := newIncludeExcludeFilter(ptr(IncludeExclude{
+	_, err := newIncludeExcludeFilter(new(IncludeExclude{
 		Included: []string{"foo"},
 		Excluded: []string{"foo"},
 	}))
@@ -1380,9 +1380,9 @@ func TestPrometheusReaderOpts(t *testing.T) {
 		{
 			name: "all set",
 			cfg: Prometheus{
-				WithoutScopeInfo:           ptr(true),
-				WithoutTypeSuffix:          ptr(true),
-				WithoutUnits:               ptr(true),
+				WithoutScopeInfo:           new(true),
+				WithoutTypeSuffix:          new(true),
+				WithoutUnits:               new(true),
 				WithResourceConstantLabels: &IncludeExclude{},
 			},
 			wantOptions: 3,
@@ -1390,9 +1390,9 @@ func TestPrometheusReaderOpts(t *testing.T) {
 		{
 			name: "all set false",
 			cfg: Prometheus{
-				WithoutScopeInfo:           ptr(false),
-				WithoutTypeSuffix:          ptr(false),
-				WithoutUnits:               ptr(false),
+				WithoutScopeInfo:           new(false),
+				WithoutTypeSuffix:          new(false),
+				WithoutUnits:               new(false),
 				WithResourceConstantLabels: &IncludeExclude{},
 			},
 			wantOptions: 2,
@@ -1427,9 +1427,9 @@ func TestPrometheusIPv6(t *testing.T) {
 			cfg := Prometheus{
 				Host:                       &tt.host,
 				Port:                       &port,
-				WithoutScopeInfo:           ptr(true),
-				WithoutTypeSuffix:          ptr(true),
-				WithoutUnits:               ptr(true),
+				WithoutScopeInfo:           new(true),
+				WithoutTypeSuffix:          new(true),
+				WithoutUnits:               new(true),
 				WithResourceConstantLabels: &IncludeExclude{},
 			}
 
@@ -1466,22 +1466,22 @@ func TestPrometheusReaderErrorCases(t *testing.T) {
 	}{
 		{
 			name:   "missing host",
-			config: Prometheus{Port: ptr(8080)},
+			config: Prometheus{Port: new(8080)},
 			errMsg: "host must be specified",
 		},
 		{
 			name:   "missing port",
-			config: Prometheus{Host: ptr("localhost")},
+			config: Prometheus{Host: new("localhost")},
 			errMsg: "port must be specified",
 		},
 		{
 			name: "invalid port",
 			config: Prometheus{
-				Host:                       ptr("localhost"),
-				Port:                       ptr(99999), // invalid port
-				WithoutScopeInfo:           ptr(true),
-				WithoutTypeSuffix:          ptr(true),
-				WithoutUnits:               ptr(true),
+				Host:                       new("localhost"),
+				Port:                       new(99999), // invalid port
+				WithoutScopeInfo:           new(true),
+				WithoutTypeSuffix:          new(true),
+				WithoutUnits:               new(true),
 				WithResourceConstantLabels: &IncludeExclude{},
 			},
 			errMsg: "binding address",
@@ -1531,9 +1531,9 @@ func TestPrometheusReaderHostParsing(t *testing.T) {
 			cfg := Prometheus{
 				Host:                       &tt.host,
 				Port:                       &port,
-				WithoutScopeInfo:           ptr(true),
-				WithoutTypeSuffix:          ptr(true),
-				WithoutUnits:               ptr(true),
+				WithoutScopeInfo:           new(true),
+				WithoutTypeSuffix:          new(true),
+				WithoutUnits:               new(true),
 				WithResourceConstantLabels: &IncludeExclude{},
 			}
 
@@ -1561,9 +1561,9 @@ func TestPrometheusReaderConfigurationOptions(t *testing.T) {
 	cfg := &Prometheus{
 		Host:              &host,
 		Port:              &port,
-		WithoutScopeInfo:  ptr(true),
-		WithoutTypeSuffix: ptr(true),
-		WithoutUnits:      ptr(true),
+		WithoutScopeInfo:  new(true),
+		WithoutTypeSuffix: new(true),
+		WithoutUnits:      new(true),
 		WithResourceConstantLabels: &IncludeExclude{
 			Included: []string{"service.name"},
 			Excluded: []string{"host.name"},
@@ -1607,8 +1607,8 @@ func TestPrometheusReaderDotStyleLabels(t *testing.T) {
 	reader, err := prometheusReader(t.Context(), &Prometheus{
 		Host:              &host,
 		Port:              &port,
-		WithoutTypeSuffix: ptr(true),
-		WithoutUnits:      ptr(true),
+		WithoutTypeSuffix: new(true),
+		WithoutUnits:      new(true),
 	})
 	require.NoError(t, err)
 
@@ -1656,12 +1656,12 @@ func Test_otlpGRPCMetricExporter(t *testing.T) {
 			args: args{
 				ctx: t.Context(),
 				otlpConfig: &OTLPMetric{
-					Protocol:    ptr("grpc"),
-					Compression: ptr("gzip"),
-					Timeout:     ptr(50000),
-					Insecure:    ptr(true),
+					Protocol:    new("grpc"),
+					Compression: new("gzip"),
+					Timeout:     new(50000),
+					Insecure:    new(true),
 					Headers: []NameStringValuePair{
-						{Name: "test", Value: ptr("test1")},
+						{Name: "test", Value: new("test1")},
 					},
 				},
 			},
@@ -1674,12 +1674,12 @@ func Test_otlpGRPCMetricExporter(t *testing.T) {
 			args: args{
 				ctx: t.Context(),
 				otlpConfig: &OTLPMetric{
-					Protocol:    ptr("grpc"),
-					Compression: ptr("gzip"),
-					Timeout:     ptr(50000),
-					Certificate: ptr(material.CACertPath),
+					Protocol:    new("grpc"),
+					Compression: new("gzip"),
+					Timeout:     new(50000),
+					Certificate: new(material.CACertPath),
 					Headers: []NameStringValuePair{
-						{Name: "test", Value: ptr("test1")},
+						{Name: "test", Value: new("test1")},
 					},
 				},
 			},
@@ -1698,14 +1698,14 @@ func Test_otlpGRPCMetricExporter(t *testing.T) {
 			args: args{
 				ctx: t.Context(),
 				otlpConfig: &OTLPMetric{
-					Protocol:          ptr("grpc"),
-					Compression:       ptr("gzip"),
-					Timeout:           ptr(50000),
-					Certificate:       ptr(material.CACertPath),
-					ClientKey:         ptr(material.ClientKeyPath),
-					ClientCertificate: ptr(material.ClientCertPath),
+					Protocol:          new("grpc"),
+					Compression:       new("gzip"),
+					Timeout:           new(50000),
+					Certificate:       new(material.CACertPath),
+					ClientKey:         new(material.ClientKeyPath),
+					ClientCertificate: new(material.ClientCertPath),
 					Headers: []NameStringValuePair{
-						{Name: "test", Value: ptr("test1")},
+						{Name: "test", Value: new("test1")},
 					},
 				},
 			},
@@ -1740,7 +1740,7 @@ func Test_otlpGRPCMetricExporter(t *testing.T) {
 			if tt.args.otlpConfig.Insecure != nil && *tt.args.otlpConfig.Insecure {
 				scheme = "http"
 			}
-			tt.args.otlpConfig.Endpoint = ptr(scheme + "://" + n.Addr().String())
+			tt.args.otlpConfig.Endpoint = new(scheme + "://" + n.Addr().String())
 
 			serverOpts, err := tt.grpcServerOpts()
 			require.NoError(t, err)

--- a/otelconf/v0.3.0/resource_test.go
+++ b/otelconf/v0.3.0/resource_test.go
@@ -30,7 +30,7 @@ func TestNewResource(t *testing.T) {
 		{
 			name: "resource-with-schema",
 			config: &Resource{
-				SchemaUrl: ptr(semconv.SchemaURL),
+				SchemaUrl: new(semconv.SchemaURL),
 			},
 			wantResource: resource.NewWithAttributes(semconv.SchemaURL),
 		},
@@ -52,7 +52,7 @@ func TestNewResource(t *testing.T) {
 				Attributes: []AttributeNameValue{
 					{Name: "service.name", Value: "service-a"},
 				},
-				SchemaUrl: ptr(semconv.SchemaURL),
+				SchemaUrl: new(semconv.SchemaURL),
 			},
 			wantResource: resource.NewWithAttributes(
 				semconv.SchemaURL,
@@ -66,7 +66,7 @@ func TestNewResource(t *testing.T) {
 					{Name: "service.name", Value: "service-a"},
 					{Name: "attr-bool", Value: true},
 				},
-				SchemaUrl: ptr(semconv.SchemaURL),
+				SchemaUrl: new(semconv.SchemaURL),
 			},
 			wantResource: resource.NewWithAttributes(semconv.SchemaURL,
 				semconv.ServiceName("service-a"),

--- a/otelconf/v0.3.0/trace_test.go
+++ b/otelconf/v0.3.0/trace_test.go
@@ -130,9 +130,9 @@ func TestTracerProviderOptions(t *testing.T) {
 				Simple: &SimpleSpanProcessor{
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
-							Protocol: ptr("http/protobuf"),
-							Endpoint: ptr(srv.URL),
-							Insecure: ptr(true),
+							Protocol: new("http/protobuf"),
+							Endpoint: new(srv.URL),
+							Insecure: new(true),
 						},
 					},
 				},
@@ -214,7 +214,7 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch processor invalid batch size console exporter",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(-1),
+					MaxExportBatchSize: new(-1),
 					Exporter: SpanExporter{
 						Console: Console{},
 					},
@@ -226,7 +226,7 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch processor invalid export timeout console exporter",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					ExportTimeout: ptr(-2),
+					ExportTimeout: new(-2),
 					Exporter: SpanExporter{
 						Console: Console{},
 					},
@@ -238,7 +238,7 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch processor invalid queue size console exporter",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxQueueSize: ptr(-3),
+					MaxQueueSize: new(-3),
 					Exporter: SpanExporter{
 						Console: Console{},
 					},
@@ -250,7 +250,7 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch processor invalid schedule delay console exporter",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					ScheduleDelay: ptr(-4),
+					ScheduleDelay: new(-4),
 					Exporter: SpanExporter{
 						Console: Console{},
 					},
@@ -274,10 +274,10 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch processor console exporter",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						Console: Console{},
 					},
@@ -289,13 +289,13 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-exporter-invalid-protocol",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
-							Protocol: ptr("http/invalid"),
+							Protocol: new("http/invalid"),
 						},
 					},
 				},
@@ -306,17 +306,17 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-exporter-no-endpoint",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("grpc"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Protocol:    new("grpc"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -328,18 +328,18 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-exporter",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("grpc"),
-							Endpoint:    ptr("http://localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Protocol:    new("grpc"),
+							Endpoint:    new("http://localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -351,18 +351,18 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-exporter-socket-endpoint",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("grpc"),
-							Endpoint:    ptr("unix:collector.sock"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Protocol:    new("grpc"),
+							Endpoint:    new("unix:collector.sock"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -376,11 +376,11 @@ func TestSpanProcessor(t *testing.T) {
 				Batch: &BatchSpanProcessor{
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("grpc"),
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
-							Certificate: ptr(material.CACertPath),
+							Protocol:    new("grpc"),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
+							Certificate: new(material.CACertPath),
 						},
 					},
 				},
@@ -393,11 +393,11 @@ func TestSpanProcessor(t *testing.T) {
 				Batch: &BatchSpanProcessor{
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("grpc"),
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
-							Certificate: ptr(material.BadCertPath),
+							Protocol:    new("grpc"),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
+							Certificate: new(material.BadCertPath),
 						},
 					},
 				},
@@ -410,12 +410,12 @@ func TestSpanProcessor(t *testing.T) {
 				Batch: &BatchSpanProcessor{
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
-							Protocol:          ptr("grpc"),
-							Endpoint:          ptr("localhost:4317"),
-							Compression:       ptr("gzip"),
-							Timeout:           ptr(1000),
-							ClientCertificate: ptr(material.BadCertPath),
-							ClientKey:         ptr(material.BadCertPath),
+							Protocol:          new("grpc"),
+							Endpoint:          new("localhost:4317"),
+							Compression:       new("gzip"),
+							Timeout:           new(1000),
+							ClientCertificate: new(material.BadCertPath),
+							ClientKey:         new(material.BadCertPath),
 						},
 					},
 				},
@@ -428,11 +428,11 @@ func TestSpanProcessor(t *testing.T) {
 				Batch: &BatchSpanProcessor{
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("grpc"),
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
-							HeadersList: ptr("==="),
+							Protocol:    new("grpc"),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
+							HeadersList: new("==="),
 						},
 					},
 				},
@@ -443,18 +443,18 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-exporter-no-scheme",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("grpc"),
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Protocol:    new("grpc"),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -466,18 +466,18 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-invalid-endpoint",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("grpc"),
-							Endpoint:    ptr(" "),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Protocol:    new("grpc"),
+							Endpoint:    new(" "),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -489,18 +489,18 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-invalid-compression",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("grpc"),
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("invalid"),
-							Timeout:     ptr(1000),
+							Protocol:    new("grpc"),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("invalid"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -512,18 +512,18 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-http-exporter",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("http/protobuf"),
-							Endpoint:    ptr("http://localhost:4318"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Protocol:    new("http/protobuf"),
+							Endpoint:    new("http://localhost:4318"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -537,11 +537,11 @@ func TestSpanProcessor(t *testing.T) {
 				Batch: &BatchSpanProcessor{
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("http/protobuf"),
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
-							Certificate: ptr(material.CACertPath),
+							Protocol:    new("http/protobuf"),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
+							Certificate: new(material.CACertPath),
 						},
 					},
 				},
@@ -554,11 +554,11 @@ func TestSpanProcessor(t *testing.T) {
 				Batch: &BatchSpanProcessor{
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("http/protobuf"),
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
-							Certificate: ptr(material.BadCertPath),
+							Protocol:    new("http/protobuf"),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
+							Certificate: new(material.BadCertPath),
 						},
 					},
 				},
@@ -571,12 +571,12 @@ func TestSpanProcessor(t *testing.T) {
 				Batch: &BatchSpanProcessor{
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
-							Protocol:          ptr("http/protobuf"),
-							Endpoint:          ptr("localhost:4317"),
-							Compression:       ptr("gzip"),
-							Timeout:           ptr(1000),
-							ClientCertificate: ptr(material.BadCertPath),
-							ClientKey:         ptr(material.BadCertPath),
+							Protocol:          new("http/protobuf"),
+							Endpoint:          new("localhost:4317"),
+							Compression:       new("gzip"),
+							Timeout:           new(1000),
+							ClientCertificate: new(material.BadCertPath),
+							ClientKey:         new(material.BadCertPath),
 						},
 					},
 				},
@@ -589,11 +589,11 @@ func TestSpanProcessor(t *testing.T) {
 				Batch: &BatchSpanProcessor{
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("http/protobuf"),
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
-							HeadersList: ptr("==="),
+							Protocol:    new("http/protobuf"),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
+							HeadersList: new("==="),
 						},
 					},
 				},
@@ -604,18 +604,18 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-http-exporter-with-path",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("http/protobuf"),
-							Endpoint:    ptr("http://localhost:4318/path/123"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Protocol:    new("http/protobuf"),
+							Endpoint:    new("http://localhost:4318/path/123"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -627,17 +627,17 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-http-exporter-no-endpoint",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("http/protobuf"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Protocol:    new("http/protobuf"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -649,18 +649,18 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-http-exporter-no-scheme",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("http/protobuf"),
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Protocol:    new("http/protobuf"),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -672,18 +672,18 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-http-invalid-endpoint",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("http/protobuf"),
-							Endpoint:    ptr(" "),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Protocol:    new("http/protobuf"),
+							Endpoint:    new(" "),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -695,18 +695,18 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-http-none-compression",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("http/protobuf"),
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Protocol:    new("http/protobuf"),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -718,18 +718,18 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-http-invalid-compression",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(0),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(0),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(0),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(0),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLP: &OTLP{
-							Protocol:    ptr("http/protobuf"),
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("invalid"),
-							Timeout:     ptr(1000),
+							Protocol:    new("http/protobuf"),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("invalid"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -822,7 +822,7 @@ func TestSampler(t *testing.T) {
 			name: "sampler configuration trace ID ratio",
 			sampler: &Sampler{
 				TraceIDRatioBased: &SamplerTraceIDRatioBased{
-					Ratio: ptr(0.54),
+					Ratio: new(0.54),
 				},
 			},
 			wantSampler: sdktrace.TraceIDRatioBased(0.54),
@@ -853,7 +853,7 @@ func TestSampler(t *testing.T) {
 					},
 					RemoteParentSampled: &Sampler{
 						TraceIDRatioBased: &SamplerTraceIDRatioBased{
-							Ratio: ptr(0.009),
+							Ratio: new(0.009),
 						},
 					},
 					LocalParentNotSampled: &Sampler{
@@ -861,7 +861,7 @@ func TestSampler(t *testing.T) {
 					},
 					LocalParentSampled: &Sampler{
 						TraceIDRatioBased: &SamplerTraceIDRatioBased{
-							Ratio: ptr(0.05),
+							Ratio: new(0.05),
 						},
 					},
 				},
@@ -924,12 +924,12 @@ func Test_otlpGRPCTraceExporter(t *testing.T) {
 			args: args{
 				ctx: t.Context(),
 				otlpConfig: &OTLP{
-					Protocol:    ptr("grpc"),
-					Compression: ptr("gzip"),
-					Timeout:     ptr(50000),
-					Insecure:    ptr(true),
+					Protocol:    new("grpc"),
+					Compression: new("gzip"),
+					Timeout:     new(50000),
+					Insecure:    new(true),
 					Headers: []NameStringValuePair{
-						{Name: "test", Value: ptr("test1")},
+						{Name: "test", Value: new("test1")},
 					},
 				},
 			},
@@ -942,12 +942,12 @@ func Test_otlpGRPCTraceExporter(t *testing.T) {
 			args: args{
 				ctx: t.Context(),
 				otlpConfig: &OTLP{
-					Protocol:    ptr("grpc"),
-					Compression: ptr("gzip"),
-					Timeout:     ptr(50000),
-					Certificate: ptr(material.CACertPath),
+					Protocol:    new("grpc"),
+					Compression: new("gzip"),
+					Timeout:     new(50000),
+					Certificate: new(material.CACertPath),
 					Headers: []NameStringValuePair{
-						{Name: "test", Value: ptr("test1")},
+						{Name: "test", Value: new("test1")},
 					},
 				},
 			},
@@ -966,14 +966,14 @@ func Test_otlpGRPCTraceExporter(t *testing.T) {
 			args: args{
 				ctx: t.Context(),
 				otlpConfig: &OTLP{
-					Protocol:          ptr("grpc"),
-					Compression:       ptr("gzip"),
-					Timeout:           ptr(50000),
-					Certificate:       ptr(material.CACertPath),
-					ClientKey:         ptr(material.ClientKeyPath),
-					ClientCertificate: ptr(material.ClientCertPath),
+					Protocol:          new("grpc"),
+					Compression:       new("gzip"),
+					Timeout:           new(50000),
+					Certificate:       new(material.CACertPath),
+					ClientKey:         new(material.ClientKeyPath),
+					ClientCertificate: new(material.ClientCertPath),
 					Headers: []NameStringValuePair{
-						{Name: "test", Value: ptr("test1")},
+						{Name: "test", Value: new("test1")},
 					},
 				},
 			},
@@ -1008,7 +1008,7 @@ func Test_otlpGRPCTraceExporter(t *testing.T) {
 			if tt.args.otlpConfig.Insecure != nil && *tt.args.otlpConfig.Insecure {
 				scheme = "http"
 			}
-			tt.args.otlpConfig.Endpoint = ptr(scheme + "://" + n.Addr().String())
+			tt.args.otlpConfig.Endpoint = new(scheme + "://" + n.Addr().String())
 
 			serverOpts, err := tt.grpcServerOpts()
 			require.NoError(t, err)

--- a/otelconf/x/config_common.go
+++ b/otelconf/x/config_common.go
@@ -273,10 +273,6 @@ func validateSpanLimits(plain *SpanLimits) error {
 	return nil
 }
 
-func ptr[T any](v T) *T {
-	return &v
-}
-
 // validateOTLPHTTPEncoding validates the encoding configuration.
 // The Go SDK only supports protobuf encoding for OTLP HTTP exporters.
 func validateOTLPHTTPEncoding(encoding *OTLPHttpEncoding) error {

--- a/otelconf/x/config_json.go
+++ b/otelconf/x/config_json.go
@@ -655,7 +655,7 @@ func (j *OpenTelemetryConfiguration) UnmarshalJSON(b []byte) error {
 	} else {
 		// Configure if the SDK is disabled or not.
 		// If omitted or null, false is used.
-		sh.Plain.Disabled = ptr(false)
+		sh.Plain.Disabled = new(false)
 	}
 
 	if sh.LogLevel != nil {
@@ -665,7 +665,7 @@ func (j *OpenTelemetryConfiguration) UnmarshalJSON(b []byte) error {
 	} else {
 		// Configure the log level of the internal logger used by the SDK.
 		// If omitted, info is used.
-		sh.Plain.LogLevel = ptr(SeverityNumberInfo)
+		sh.Plain.LogLevel = new(SeverityNumberInfo)
 	}
 
 	*j = OpenTelemetryConfiguration(sh.Plain)

--- a/otelconf/x/config_resource_test.go
+++ b/otelconf/x/config_resource_test.go
@@ -37,7 +37,7 @@ func TestSDKResource(t *testing.T) {
 	t.Run("returns empty resource for disabled sdk", func(t *testing.T) {
 		sdk, err := NewSDK(
 			WithOpenTelemetryConfiguration(OpenTelemetryConfiguration{
-				Disabled: ptr(true),
+				Disabled: new(true),
 			}),
 		)
 		assert.NoError(t, err)

--- a/otelconf/x/config_test.go
+++ b/otelconf/x/config_test.go
@@ -388,7 +388,7 @@ func TestNewSDK(t *testing.T) {
 			cfg: []ConfigurationOption{
 				WithContext(t.Context()),
 				WithOpenTelemetryConfiguration(OpenTelemetryConfiguration{
-					Disabled:       ptr(true),
+					Disabled:       new(true),
 					TracerProvider: &TracerProvider{},
 					MeterProvider:  &MeterProvider{},
 					LoggerProvider: &LoggerProvider{},
@@ -438,11 +438,11 @@ func newV10OpenTelemetryConfig(material testtls.Material) *OpenTelemetryConfigur
 	material.ClientCertPath = filepath.ToSlash(material.ClientCertPath)
 	material.ClientKeyPath = filepath.ToSlash(material.ClientKeyPath)
 	return &OpenTelemetryConfiguration{
-		Disabled:   ptr(false),
+		Disabled:   new(false),
 		FileFormat: "1.0-rc.2",
 		AttributeLimits: &AttributeLimits{
-			AttributeCountLimit:       ptr(128),
-			AttributeValueLengthLimit: ptr(4096),
+			AttributeCountLimit:       new(128),
+			AttributeValueLengthLimit: new(4096),
 		},
 		InstrumentationDevelopment: &ExperimentalInstrumentation{
 			Cpp: ExperimentalLanguageSpecificInstrumentation{
@@ -519,49 +519,49 @@ func newV10OpenTelemetryConfig(material testtls.Material) *OpenTelemetryConfigur
 				},
 			},
 		},
-		LogLevel: ptr(SeverityNumberInfo),
+		LogLevel: new(SeverityNumberInfo),
 		LoggerProvider: &LoggerProvider{
 			LoggerConfiguratorDevelopment: &ExperimentalLoggerConfigurator{
 				DefaultConfig: &ExperimentalLoggerConfig{
-					Disabled: ptr(true),
+					Disabled: new(true),
 				},
 				Loggers: []ExperimentalLoggerMatcherAndConfig{
 					{
 						Config: ExperimentalLoggerConfig{
-							Disabled: ptr(false),
+							Disabled: new(false),
 						},
 						Name: "io.opentelemetry.contrib.*",
 					},
 				},
 			},
 			Limits: &LogRecordLimits{
-				AttributeCountLimit:       ptr(128),
-				AttributeValueLengthLimit: ptr(4096),
+				AttributeCountLimit:       new(128),
+				AttributeValueLengthLimit: new(4096),
 			},
 			Processors: []LogRecordProcessor{
 				{
 					Batch: &BatchLogRecordProcessor{
-						ExportTimeout: ptr(30000),
+						ExportTimeout: new(30000),
 						Exporter: LogRecordExporter{
 							OTLPHttp: &OTLPHttpExporter{
 								Tls: &HttpTls{
-									CaFile:   ptr(material.CACertPath),
-									CertFile: ptr(material.ClientCertPath),
-									KeyFile:  ptr(material.ClientKeyPath),
+									CaFile:   new(material.CACertPath),
+									CertFile: new(material.ClientCertPath),
+									KeyFile:  new(material.ClientKeyPath),
 								},
-								Compression: ptr("gzip"),
-								Encoding:    ptr(OTLPHttpEncodingProtobuf),
-								Endpoint:    ptr("http://localhost:4318/v1/logs"),
+								Compression: new("gzip"),
+								Encoding:    new(OTLPHttpEncodingProtobuf),
+								Endpoint:    new("http://localhost:4318/v1/logs"),
 								Headers: []NameStringValuePair{
-									{Name: "api-key", Value: ptr("1234")},
+									{Name: "api-key", Value: new("1234")},
 								},
-								HeadersList: ptr("api-key=1234"),
-								Timeout:     ptr(10000),
+								HeadersList: new("api-key=1234"),
+								Timeout:     new(10000),
 							},
 						},
-						MaxExportBatchSize: ptr(512),
-						MaxQueueSize:       ptr(2048),
-						ScheduleDelay:      ptr(5000),
+						MaxExportBatchSize: new(512),
+						MaxQueueSize:       new(2048),
+						ScheduleDelay:      new(5000),
 					},
 				},
 				{
@@ -569,18 +569,18 @@ func newV10OpenTelemetryConfig(material testtls.Material) *OpenTelemetryConfigur
 						Exporter: LogRecordExporter{
 							OTLPGrpc: &OTLPGrpcExporter{
 								Tls: &GrpcTls{
-									CaFile:   ptr(material.CACertPath),
-									CertFile: ptr(material.ClientCertPath),
-									KeyFile:  ptr(material.ClientKeyPath),
-									Insecure: ptr(false),
+									CaFile:   new(material.CACertPath),
+									CertFile: new(material.ClientCertPath),
+									KeyFile:  new(material.ClientKeyPath),
+									Insecure: new(false),
 								},
-								Compression: ptr("gzip"),
-								Endpoint:    ptr("http://localhost:4317"),
+								Compression: new("gzip"),
+								Endpoint:    new("http://localhost:4317"),
 								Headers: []NameStringValuePair{
-									{Name: "api-key", Value: ptr("1234")},
+									{Name: "api-key", Value: new("1234")},
 								},
-								HeadersList: ptr("api-key=1234"),
-								Timeout:     ptr(10000),
+								HeadersList: new("api-key=1234"),
+								Timeout:     new(10000),
 							},
 						},
 					},
@@ -589,7 +589,7 @@ func newV10OpenTelemetryConfig(material testtls.Material) *OpenTelemetryConfigur
 					Batch: &BatchLogRecordProcessor{
 						Exporter: LogRecordExporter{
 							OTLPFileDevelopment: &ExperimentalOTLPFileExporter{
-								OutputStream: ptr("file:///var/log/logs.jsonl"),
+								OutputStream: new("file:///var/log/logs.jsonl"),
 							},
 						},
 					},
@@ -598,7 +598,7 @@ func newV10OpenTelemetryConfig(material testtls.Material) *OpenTelemetryConfigur
 					Batch: &BatchLogRecordProcessor{
 						Exporter: LogRecordExporter{
 							OTLPFileDevelopment: &ExperimentalOTLPFileExporter{
-								OutputStream: ptr("stdout"),
+								OutputStream: new("stdout"),
 							},
 						},
 					},
@@ -613,15 +613,15 @@ func newV10OpenTelemetryConfig(material testtls.Material) *OpenTelemetryConfigur
 			},
 		},
 		MeterProvider: &MeterProvider{
-			ExemplarFilter: ptr(ExemplarFilter("trace_based")),
+			ExemplarFilter: new(ExemplarFilter("trace_based")),
 			MeterConfiguratorDevelopment: &ExperimentalMeterConfigurator{
 				DefaultConfig: &ExperimentalMeterConfig{
-					Disabled: ptr(true),
+					Disabled: new(true),
 				},
 				Meters: []ExperimentalMeterMatcherAndConfig{
 					{
 						Config: ExperimentalMeterConfig{
-							Disabled: ptr(false),
+							Disabled: new(false),
 						},
 						Name: "io.opentelemetry.contrib.*",
 					},
@@ -636,25 +636,25 @@ func newV10OpenTelemetryConfig(material testtls.Material) *OpenTelemetryConfigur
 							},
 						},
 						CardinalityLimits: &CardinalityLimits{
-							Default:                 ptr(2000),
-							Counter:                 ptr(2000),
-							Gauge:                   ptr(2000),
-							Histogram:               ptr(2000),
-							ObservableCounter:       ptr(2000),
-							ObservableGauge:         ptr(2000),
-							ObservableUpDownCounter: ptr(2000),
-							UpDownCounter:           ptr(2000),
+							Default:                 new(2000),
+							Counter:                 new(2000),
+							Gauge:                   new(2000),
+							Histogram:               new(2000),
+							ObservableCounter:       new(2000),
+							ObservableGauge:         new(2000),
+							ObservableUpDownCounter: new(2000),
+							UpDownCounter:           new(2000),
 						},
 						Exporter: PullMetricExporter{
 							PrometheusDevelopment: &ExperimentalPrometheusMetricExporter{
-								Host:                ptr("localhost"),
-								Port:                ptr(9464),
-								TranslationStrategy: ptr(ExperimentalPrometheusTranslationStrategyUnderscoreEscapingWithSuffixes),
+								Host:                new("localhost"),
+								Port:                new(9464),
+								TranslationStrategy: new(ExperimentalPrometheusTranslationStrategyUnderscoreEscapingWithSuffixes),
 								WithResourceConstantLabels: &IncludeExclude{
 									Excluded: []string{"service.attr1"},
 									Included: []string{"service*"},
 								},
-								WithoutScopeInfo: ptr(false),
+								WithoutScopeInfo: new(false),
 							},
 						},
 					},
@@ -669,36 +669,36 @@ func newV10OpenTelemetryConfig(material testtls.Material) *OpenTelemetryConfigur
 							},
 						},
 						CardinalityLimits: &CardinalityLimits{
-							Default:                 ptr(2000),
-							Counter:                 ptr(2000),
-							Gauge:                   ptr(2000),
-							Histogram:               ptr(2000),
-							ObservableCounter:       ptr(2000),
-							ObservableGauge:         ptr(2000),
-							ObservableUpDownCounter: ptr(2000),
-							UpDownCounter:           ptr(2000),
+							Default:                 new(2000),
+							Counter:                 new(2000),
+							Gauge:                   new(2000),
+							Histogram:               new(2000),
+							ObservableCounter:       new(2000),
+							ObservableGauge:         new(2000),
+							ObservableUpDownCounter: new(2000),
+							UpDownCounter:           new(2000),
 						},
 						Exporter: PushMetricExporter{
 							OTLPHttp: &OTLPHttpMetricExporter{
 								Tls: &HttpTls{
-									CaFile:   ptr(material.CACertPath),
-									CertFile: ptr(material.ClientCertPath),
-									KeyFile:  ptr(material.ClientKeyPath),
+									CaFile:   new(material.CACertPath),
+									CertFile: new(material.ClientCertPath),
+									KeyFile:  new(material.ClientKeyPath),
 								},
-								Compression:                 ptr("gzip"),
-								DefaultHistogramAggregation: ptr(ExporterDefaultHistogramAggregationBase2ExponentialBucketHistogram),
-								Endpoint:                    ptr("http://localhost:4318/v1/metrics"),
-								Encoding:                    ptr(OTLPHttpEncodingProtobuf),
+								Compression:                 new("gzip"),
+								DefaultHistogramAggregation: new(ExporterDefaultHistogramAggregationBase2ExponentialBucketHistogram),
+								Endpoint:                    new("http://localhost:4318/v1/metrics"),
+								Encoding:                    new(OTLPHttpEncodingProtobuf),
 								Headers: []NameStringValuePair{
-									{Name: "api-key", Value: ptr("1234")},
+									{Name: "api-key", Value: new("1234")},
 								},
-								HeadersList:           ptr("api-key=1234"),
-								TemporalityPreference: ptr(ExporterTemporalityPreferenceDelta),
-								Timeout:               ptr(10000),
+								HeadersList:           new("api-key=1234"),
+								TemporalityPreference: new(ExporterTemporalityPreferenceDelta),
+								Timeout:               new(10000),
 							},
 						},
-						Interval: ptr(60000),
-						Timeout:  ptr(30000),
+						Interval: new(60000),
+						Timeout:  new(30000),
 					},
 				},
 				{
@@ -706,20 +706,20 @@ func newV10OpenTelemetryConfig(material testtls.Material) *OpenTelemetryConfigur
 						Exporter: PushMetricExporter{
 							OTLPGrpc: &OTLPGrpcMetricExporter{
 								Tls: &GrpcTls{
-									CaFile:   ptr(material.CACertPath),
-									CertFile: ptr(material.ClientCertPath),
-									KeyFile:  ptr(material.ClientKeyPath),
-									Insecure: ptr(false),
+									CaFile:   new(material.CACertPath),
+									CertFile: new(material.ClientCertPath),
+									KeyFile:  new(material.ClientKeyPath),
+									Insecure: new(false),
 								},
-								Compression:                 ptr("gzip"),
-								DefaultHistogramAggregation: ptr(ExporterDefaultHistogramAggregationBase2ExponentialBucketHistogram),
-								Endpoint:                    ptr("http://localhost:4317"),
+								Compression:                 new("gzip"),
+								DefaultHistogramAggregation: new(ExporterDefaultHistogramAggregationBase2ExponentialBucketHistogram),
+								Endpoint:                    new("http://localhost:4317"),
 								Headers: []NameStringValuePair{
-									{Name: "api-key", Value: ptr("1234")},
+									{Name: "api-key", Value: new("1234")},
 								},
-								HeadersList:           ptr("api-key=1234"),
-								TemporalityPreference: ptr(ExporterTemporalityPreferenceDelta),
-								Timeout:               ptr(10000),
+								HeadersList:           new("api-key=1234"),
+								TemporalityPreference: new(ExporterTemporalityPreferenceDelta),
+								Timeout:               new(10000),
 							},
 						},
 					},
@@ -728,9 +728,9 @@ func newV10OpenTelemetryConfig(material testtls.Material) *OpenTelemetryConfigur
 					Periodic: &PeriodicMetricReader{
 						Exporter: PushMetricExporter{
 							OTLPFileDevelopment: &ExperimentalOTLPFileMetricExporter{
-								OutputStream:                ptr("file:///var/log/metrics.jsonl"),
-								DefaultHistogramAggregation: ptr(ExporterDefaultHistogramAggregationBase2ExponentialBucketHistogram),
-								TemporalityPreference:       ptr(ExporterTemporalityPreferenceDelta),
+								OutputStream:                new("file:///var/log/metrics.jsonl"),
+								DefaultHistogramAggregation: new(ExporterDefaultHistogramAggregationBase2ExponentialBucketHistogram),
+								TemporalityPreference:       new(ExporterTemporalityPreferenceDelta),
 							},
 						},
 					},
@@ -739,9 +739,9 @@ func newV10OpenTelemetryConfig(material testtls.Material) *OpenTelemetryConfigur
 					Periodic: &PeriodicMetricReader{
 						Exporter: PushMetricExporter{
 							OTLPFileDevelopment: &ExperimentalOTLPFileMetricExporter{
-								OutputStream:                ptr("stdout"),
-								DefaultHistogramAggregation: ptr(ExporterDefaultHistogramAggregationBase2ExponentialBucketHistogram),
-								TemporalityPreference:       ptr(ExporterTemporalityPreferenceDelta),
+								OutputStream:                new("stdout"),
+								DefaultHistogramAggregation: new(ExporterDefaultHistogramAggregationBase2ExponentialBucketHistogram),
+								TemporalityPreference:       new(ExporterTemporalityPreferenceDelta),
 							},
 						},
 					},
@@ -757,27 +757,27 @@ func newV10OpenTelemetryConfig(material testtls.Material) *OpenTelemetryConfigur
 			Views: []View{
 				{
 					Selector: ViewSelector{
-						InstrumentName: ptr("my-instrument"),
-						InstrumentType: ptr(InstrumentTypeHistogram),
-						MeterName:      ptr("my-meter"),
-						MeterSchemaUrl: ptr("https://opentelemetry.io/schemas/1.16.0"),
-						MeterVersion:   ptr("1.0.0"),
-						Unit:           ptr("ms"),
+						InstrumentName: new("my-instrument"),
+						InstrumentType: new(InstrumentTypeHistogram),
+						MeterName:      new("my-meter"),
+						MeterSchemaUrl: new("https://opentelemetry.io/schemas/1.16.0"),
+						MeterVersion:   new("1.0.0"),
+						Unit:           new("ms"),
 					},
 					Stream: ViewStream{
 						Aggregation: &Aggregation{
 							ExplicitBucketHistogram: &ExplicitBucketHistogramAggregation{
 								Boundaries:   []float64{0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000},
-								RecordMinMax: ptr(true),
+								RecordMinMax: new(true),
 							},
 						},
-						AggregationCardinalityLimit: ptr(2000),
+						AggregationCardinalityLimit: new(2000),
 						AttributeKeys: &IncludeExclude{
 							Included: []string{"key1", "key2"},
 							Excluded: []string{"key3"},
 						},
-						Description: ptr("new_description"),
-						Name:        ptr("new_instrument_name"),
+						Description: new("new_description"),
+						Name:        new("new_instrument_name"),
 					},
 				},
 			},
@@ -803,21 +803,21 @@ func newV10OpenTelemetryConfig(material testtls.Material) *OpenTelemetryConfigur
 					Ottrace: OpenTracingPropagator{},
 				},
 			},
-			CompositeList: ptr("tracecontext,baggage,b3,b3multi,jaeger,ottrace,xray"),
+			CompositeList: new("tracecontext,baggage,b3,b3multi,jaeger,ottrace,xray"),
 		},
 		Resource: &Resource{
 			Attributes: []AttributeNameValue{
 				{Name: "service.name", Value: "unknown_service"},
-				{Name: "string_key", Type: ptr(AttributeTypeString), Value: "value"},
-				{Name: "bool_key", Type: ptr(AttributeTypeBool), Value: true},
-				{Name: "int_key", Type: ptr(AttributeTypeInt), Value: 1},
-				{Name: "double_key", Type: ptr(AttributeTypeDouble), Value: 1.1},
-				{Name: "string_array_key", Type: ptr(AttributeTypeStringArray), Value: []any{"value1", "value2"}},
-				{Name: "bool_array_key", Type: ptr(AttributeTypeBoolArray), Value: []any{true, false}},
-				{Name: "int_array_key", Type: ptr(AttributeTypeIntArray), Value: []any{1, 2}},
-				{Name: "double_array_key", Type: ptr(AttributeTypeDoubleArray), Value: []any{1.1, 2.2}},
+				{Name: "string_key", Type: new(AttributeTypeString), Value: "value"},
+				{Name: "bool_key", Type: new(AttributeTypeBool), Value: true},
+				{Name: "int_key", Type: new(AttributeTypeInt), Value: 1},
+				{Name: "double_key", Type: new(AttributeTypeDouble), Value: 1.1},
+				{Name: "string_array_key", Type: new(AttributeTypeStringArray), Value: []any{"value1", "value2"}},
+				{Name: "bool_array_key", Type: new(AttributeTypeBoolArray), Value: []any{true, false}},
+				{Name: "int_array_key", Type: new(AttributeTypeIntArray), Value: []any{1, 2}},
+				{Name: "double_array_key", Type: new(AttributeTypeDoubleArray), Value: []any{1.1, 2.2}},
 			},
-			AttributesList: ptr("service.namespace=my-namespace,service.version=1.0.0"),
+			AttributesList: new("service.namespace=my-namespace,service.version=1.0.0"),
 			DetectionDevelopment: &ExperimentalResourceDetection{
 				Attributes: &IncludeExclude{
 					Excluded: []string{"process.command_args"},
@@ -834,12 +834,12 @@ func newV10OpenTelemetryConfig(material testtls.Material) *OpenTelemetryConfigur
 		TracerProvider: &TracerProvider{
 			TracerConfiguratorDevelopment: &ExperimentalTracerConfigurator{
 				DefaultConfig: &ExperimentalTracerConfig{
-					Disabled: ptr(true),
+					Disabled: new(true),
 				},
 				Tracers: []ExperimentalTracerMatcherAndConfig{
 					{
 						Config: ExperimentalTracerConfig{
-							Disabled: ptr(false),
+							Disabled: new(false),
 						},
 						Name: "io.opentelemetry.contrib.*",
 					},
@@ -847,37 +847,37 @@ func newV10OpenTelemetryConfig(material testtls.Material) *OpenTelemetryConfigur
 			},
 
 			Limits: &SpanLimits{
-				AttributeCountLimit:       ptr(128),
-				AttributeValueLengthLimit: ptr(4096),
-				EventCountLimit:           ptr(128),
-				EventAttributeCountLimit:  ptr(128),
-				LinkCountLimit:            ptr(128),
-				LinkAttributeCountLimit:   ptr(128),
+				AttributeCountLimit:       new(128),
+				AttributeValueLengthLimit: new(4096),
+				EventCountLimit:           new(128),
+				EventAttributeCountLimit:  new(128),
+				LinkCountLimit:            new(128),
+				LinkAttributeCountLimit:   new(128),
 			},
 			Processors: []SpanProcessor{
 				{
 					Batch: &BatchSpanProcessor{
-						ExportTimeout: ptr(30000),
+						ExportTimeout: new(30000),
 						Exporter: SpanExporter{
 							OTLPHttp: &OTLPHttpExporter{
 								Tls: &HttpTls{
-									CaFile:   ptr(material.CACertPath),
-									CertFile: ptr(material.ClientCertPath),
-									KeyFile:  ptr(material.ClientKeyPath),
+									CaFile:   new(material.CACertPath),
+									CertFile: new(material.ClientCertPath),
+									KeyFile:  new(material.ClientKeyPath),
 								},
-								Compression: ptr("gzip"),
-								Encoding:    ptr(OTLPHttpEncodingProtobuf),
-								Endpoint:    ptr("http://localhost:4318/v1/traces"),
+								Compression: new("gzip"),
+								Encoding:    new(OTLPHttpEncodingProtobuf),
+								Endpoint:    new("http://localhost:4318/v1/traces"),
 								Headers: []NameStringValuePair{
-									{Name: "api-key", Value: ptr("1234")},
+									{Name: "api-key", Value: new("1234")},
 								},
-								HeadersList: ptr("api-key=1234"),
-								Timeout:     ptr(10000),
+								HeadersList: new("api-key=1234"),
+								Timeout:     new(10000),
 							},
 						},
-						MaxExportBatchSize: ptr(512),
-						MaxQueueSize:       ptr(2048),
-						ScheduleDelay:      ptr(5000),
+						MaxExportBatchSize: new(512),
+						MaxQueueSize:       new(2048),
+						ScheduleDelay:      new(5000),
 					},
 				},
 				{
@@ -885,18 +885,18 @@ func newV10OpenTelemetryConfig(material testtls.Material) *OpenTelemetryConfigur
 						Exporter: SpanExporter{
 							OTLPGrpc: &OTLPGrpcExporter{
 								Tls: &GrpcTls{
-									CaFile:   ptr(material.CACertPath),
-									CertFile: ptr(material.ClientCertPath),
-									KeyFile:  ptr(material.ClientKeyPath),
-									Insecure: ptr(false),
+									CaFile:   new(material.CACertPath),
+									CertFile: new(material.ClientCertPath),
+									KeyFile:  new(material.ClientKeyPath),
+									Insecure: new(false),
 								},
-								Compression: ptr("gzip"),
-								Endpoint:    ptr("http://localhost:4317"),
+								Compression: new("gzip"),
+								Endpoint:    new("http://localhost:4317"),
 								Headers: []NameStringValuePair{
-									{Name: "api-key", Value: ptr("1234")},
+									{Name: "api-key", Value: new("1234")},
 								},
-								HeadersList: ptr("api-key=1234"),
-								Timeout:     ptr(10000),
+								HeadersList: new("api-key=1234"),
+								Timeout:     new(10000),
 							},
 						},
 					},
@@ -905,7 +905,7 @@ func newV10OpenTelemetryConfig(material testtls.Material) *OpenTelemetryConfigur
 					Batch: &BatchSpanProcessor{
 						Exporter: SpanExporter{
 							OTLPFileDevelopment: &ExperimentalOTLPFileExporter{
-								OutputStream: ptr("file:///var/log/traces.jsonl"),
+								OutputStream: new("file:///var/log/traces.jsonl"),
 							},
 						},
 					},
@@ -914,7 +914,7 @@ func newV10OpenTelemetryConfig(material testtls.Material) *OpenTelemetryConfigur
 					Batch: &BatchSpanProcessor{
 						Exporter: SpanExporter{
 							OTLPFileDevelopment: &ExperimentalOTLPFileExporter{
-								OutputStream: ptr("stdout"),
+								OutputStream: new("stdout"),
 							},
 						},
 					},
@@ -943,7 +943,7 @@ func newV10OpenTelemetryConfig(material testtls.Material) *OpenTelemetryConfigur
 					},
 					Root: &Sampler{
 						TraceIDRatioBased: &TraceIDRatioBasedSampler{
-							Ratio: ptr(0.0001),
+							Ratio: new(0.0001),
 						},
 					},
 				},
@@ -953,60 +953,60 @@ func newV10OpenTelemetryConfig(material testtls.Material) *OpenTelemetryConfigur
 }
 
 var v100OpenTelemetryConfigEnvParsing = OpenTelemetryConfiguration{
-	Disabled:   ptr(false),
+	Disabled:   new(false),
 	FileFormat: "1.0",
-	LogLevel:   ptr(SeverityNumberInfo),
+	LogLevel:   new(SeverityNumberInfo),
 	AttributeLimits: &AttributeLimits{
-		AttributeCountLimit:       ptr(128),
-		AttributeValueLengthLimit: ptr(4096),
+		AttributeCountLimit:       new(128),
+		AttributeValueLengthLimit: new(4096),
 	},
 	Resource: &Resource{
 		Attributes: []AttributeNameValue{
 			{Name: "service.name", Value: "unknown_service"},
-			{Name: "string_key", Type: ptr(AttributeTypeString), Value: "value"},
-			{Name: "bool_key", Type: ptr(AttributeTypeBool), Value: true},
-			{Name: "int_key", Type: ptr(AttributeTypeInt), Value: 1},
-			{Name: "double_key", Type: ptr(AttributeTypeDouble), Value: 1.1},
-			{Name: "string_array_key", Type: ptr(AttributeTypeStringArray), Value: []any{"value1", "value2"}},
-			{Name: "bool_array_key", Type: ptr(AttributeTypeBoolArray), Value: []any{true, false}},
-			{Name: "int_array_key", Type: ptr(AttributeTypeIntArray), Value: []any{1, 2}},
-			{Name: "double_array_key", Type: ptr(AttributeTypeDoubleArray), Value: []any{1.1, 2.2}},
-			{Name: "string_value", Type: ptr(AttributeTypeString), Value: "value"},
-			{Name: "bool_value", Type: ptr(AttributeTypeBool), Value: true},
-			{Name: "int_value", Type: ptr(AttributeTypeInt), Value: 1},
-			{Name: "float_value", Type: ptr(AttributeTypeDouble), Value: 1.1},
-			{Name: "hex_value", Type: ptr(AttributeTypeInt), Value: int(48879)},
-			{Name: "quoted_string_value", Type: ptr(AttributeTypeString), Value: "value"},
-			{Name: "quoted_bool_value", Type: ptr(AttributeTypeString), Value: "true"},
-			{Name: "quoted_int_value", Type: ptr(AttributeTypeString), Value: "1"},
-			{Name: "quoted_float_value", Type: ptr(AttributeTypeString), Value: "1.1"},
-			{Name: "quoted_hex_value", Type: ptr(AttributeTypeString), Value: "0xbeef"},
-			{Name: "alternative_env_syntax", Type: ptr(AttributeTypeString), Value: "value"},
-			{Name: "invalid_map_value", Type: ptr(AttributeTypeString), Value: "value\nkey:value"},
-			{Name: "multiple_references_inject", Type: ptr(AttributeTypeString), Value: "foo value 1.1"},
-			{Name: "undefined_key", Type: ptr(AttributeTypeString), Value: nil},
-			{Name: "undefined_key_fallback", Type: ptr(AttributeTypeString), Value: "fallback"},
-			{Name: "env_var_in_key", Type: ptr(AttributeTypeString), Value: "value"},
-			{Name: "replace_me", Type: ptr(AttributeTypeString), Value: "${DO_NOT_REPLACE_ME}"},
-			{Name: "undefined_defaults_to_var", Type: ptr(AttributeTypeString), Value: "${STRING_VALUE}"},
-			{Name: "escaped_does_not_substitute", Type: ptr(AttributeTypeString), Value: "${STRING_VALUE}"},
-			{Name: "escaped_does_not_substitute_fallback", Type: ptr(AttributeTypeString), Value: "${STRING_VALUE:-fallback}"},
-			{Name: "escaped_and_substituted_fallback", Type: ptr(AttributeTypeString), Value: "${STRING_VALUE:-value}"},
-			{Name: "escaped_and_substituted", Type: ptr(AttributeTypeString), Value: "$value"},
-			{Name: "multiple_escaped_and_not_substituted", Type: ptr(AttributeTypeString), Value: "$${STRING_VALUE}"},
-			{Name: "undefined_key_with_escape_sequence_in_fallback", Type: ptr(AttributeTypeString), Value: "${UNDEFINED_KEY}"},
-			{Name: "value_with_escape", Type: ptr(AttributeTypeString), Value: "value$$"},
-			{Name: "escape_sequence", Type: ptr(AttributeTypeString), Value: "a $ b"},
-			{Name: "no_escape_sequence", Type: ptr(AttributeTypeString), Value: "a $ b"},
+			{Name: "string_key", Type: new(AttributeTypeString), Value: "value"},
+			{Name: "bool_key", Type: new(AttributeTypeBool), Value: true},
+			{Name: "int_key", Type: new(AttributeTypeInt), Value: 1},
+			{Name: "double_key", Type: new(AttributeTypeDouble), Value: 1.1},
+			{Name: "string_array_key", Type: new(AttributeTypeStringArray), Value: []any{"value1", "value2"}},
+			{Name: "bool_array_key", Type: new(AttributeTypeBoolArray), Value: []any{true, false}},
+			{Name: "int_array_key", Type: new(AttributeTypeIntArray), Value: []any{1, 2}},
+			{Name: "double_array_key", Type: new(AttributeTypeDoubleArray), Value: []any{1.1, 2.2}},
+			{Name: "string_value", Type: new(AttributeTypeString), Value: "value"},
+			{Name: "bool_value", Type: new(AttributeTypeBool), Value: true},
+			{Name: "int_value", Type: new(AttributeTypeInt), Value: 1},
+			{Name: "float_value", Type: new(AttributeTypeDouble), Value: 1.1},
+			{Name: "hex_value", Type: new(AttributeTypeInt), Value: int(48879)},
+			{Name: "quoted_string_value", Type: new(AttributeTypeString), Value: "value"},
+			{Name: "quoted_bool_value", Type: new(AttributeTypeString), Value: "true"},
+			{Name: "quoted_int_value", Type: new(AttributeTypeString), Value: "1"},
+			{Name: "quoted_float_value", Type: new(AttributeTypeString), Value: "1.1"},
+			{Name: "quoted_hex_value", Type: new(AttributeTypeString), Value: "0xbeef"},
+			{Name: "alternative_env_syntax", Type: new(AttributeTypeString), Value: "value"},
+			{Name: "invalid_map_value", Type: new(AttributeTypeString), Value: "value\nkey:value"},
+			{Name: "multiple_references_inject", Type: new(AttributeTypeString), Value: "foo value 1.1"},
+			{Name: "undefined_key", Type: new(AttributeTypeString), Value: nil},
+			{Name: "undefined_key_fallback", Type: new(AttributeTypeString), Value: "fallback"},
+			{Name: "env_var_in_key", Type: new(AttributeTypeString), Value: "value"},
+			{Name: "replace_me", Type: new(AttributeTypeString), Value: "${DO_NOT_REPLACE_ME}"},
+			{Name: "undefined_defaults_to_var", Type: new(AttributeTypeString), Value: "${STRING_VALUE}"},
+			{Name: "escaped_does_not_substitute", Type: new(AttributeTypeString), Value: "${STRING_VALUE}"},
+			{Name: "escaped_does_not_substitute_fallback", Type: new(AttributeTypeString), Value: "${STRING_VALUE:-fallback}"},
+			{Name: "escaped_and_substituted_fallback", Type: new(AttributeTypeString), Value: "${STRING_VALUE:-value}"},
+			{Name: "escaped_and_substituted", Type: new(AttributeTypeString), Value: "$value"},
+			{Name: "multiple_escaped_and_not_substituted", Type: new(AttributeTypeString), Value: "$${STRING_VALUE}"},
+			{Name: "undefined_key_with_escape_sequence_in_fallback", Type: new(AttributeTypeString), Value: "${UNDEFINED_KEY}"},
+			{Name: "value_with_escape", Type: new(AttributeTypeString), Value: "value$$"},
+			{Name: "escape_sequence", Type: new(AttributeTypeString), Value: "a $ b"},
+			{Name: "no_escape_sequence", Type: new(AttributeTypeString), Value: "a $ b"},
 		},
-		AttributesList: ptr("service.namespace=my-namespace,service.version=1.0.0"),
+		AttributesList: new("service.namespace=my-namespace,service.version=1.0.0"),
 		// Detectors: &Detectors{
 		// 	Attributes: &DetectorsAttributes{
 		// 		Excluded: []string{"process.command_args"},
 		// 		Included: []string{"process.*"},
 		// 	},
 		// },
-		SchemaUrl: ptr("https://opentelemetry.io/schemas/1.16.0"),
+		SchemaUrl: new("https://opentelemetry.io/schemas/1.16.0"),
 	},
 }
 
@@ -1093,9 +1093,9 @@ func TestUnmarshalOpenTelemetryConfiguration(t *testing.T) {
 			jsonConfig: []byte(`{"file_format": "1.0"}`),
 			yamlConfig: []byte("file_format: 1.0"),
 			wantType: OpenTelemetryConfiguration{
-				Disabled:   ptr(false),
+				Disabled:   new(false),
 				FileFormat: "1.0",
-				LogLevel:   ptr(SeverityNumberInfo),
+				LogLevel:   new(SeverityNumberInfo),
 			},
 		},
 		{
@@ -1538,7 +1538,7 @@ func TestCreateHeadersConfig(t *testing.T) {
 		{
 			name:        "headerslist only",
 			headers:     []NameStringValuePair{},
-			headersList: ptr("a=b,c=d"),
+			headersList: new("a=b,c=d"),
 			wantHeaders: map[string]string{
 				"a": "b",
 				"c": "d",
@@ -1549,11 +1549,11 @@ func TestCreateHeadersConfig(t *testing.T) {
 			headers: []NameStringValuePair{
 				{
 					Name:  "a",
-					Value: ptr("b"),
+					Value: new("b"),
 				},
 				{
 					Name:  "c",
-					Value: ptr("d"),
+					Value: new("d"),
 				},
 			},
 			headersList: nil,
@@ -1567,10 +1567,10 @@ func TestCreateHeadersConfig(t *testing.T) {
 			headers: []NameStringValuePair{
 				{
 					Name:  "a",
-					Value: ptr("b"),
+					Value: new("b"),
 				},
 			},
-			headersList: ptr("c=d"),
+			headersList: new("c=d"),
 			wantHeaders: map[string]string{
 				"a": "b",
 				"c": "d",
@@ -1581,14 +1581,14 @@ func TestCreateHeadersConfig(t *testing.T) {
 			headers: []NameStringValuePair{
 				{
 					Name:  "a",
-					Value: ptr("b"),
+					Value: new("b"),
 				},
 				{
 					Name:  "c",
-					Value: ptr("override"),
+					Value: new("override"),
 				},
 			},
-			headersList: ptr("c=d"),
+			headersList: new("c=d"),
 			wantHeaders: map[string]string{
 				"a": "b",
 				"c": "override",
@@ -1596,7 +1596,7 @@ func TestCreateHeadersConfig(t *testing.T) {
 		},
 		{
 			name:        "invalid headerslist",
-			headersList: ptr("==="),
+			headersList: new("==="),
 			wantErr:     newErrInvalid("invalid headers_list"),
 		},
 		{
@@ -1604,7 +1604,7 @@ func TestCreateHeadersConfig(t *testing.T) {
 			headers: []NameStringValuePair{
 				{
 					Name:  "",
-					Value: ptr("token"),
+					Value: new("token"),
 				},
 			},
 			wantErr: newErrInvalid("invalid header: empty name"),
@@ -1708,7 +1708,7 @@ func TestUnmarshalOTLPHttpExporter(t *testing.T) {
 			name:         "valid with exporter",
 			jsonConfig:   []byte(`{"endpoint":"localhost:4318"}`),
 			yamlConfig:   []byte("endpoint: localhost:4318\n"),
-			wantExporter: OTLPHttpExporter{Endpoint: ptr("localhost:4318")},
+			wantExporter: OTLPHttpExporter{Endpoint: new("localhost:4318")},
 		},
 		{
 			name:       "missing required endpoint field",
@@ -1720,7 +1720,7 @@ func TestUnmarshalOTLPHttpExporter(t *testing.T) {
 			name:         "valid with zero timeout",
 			jsonConfig:   []byte(`{"endpoint":"localhost:4318", "timeout":0}`),
 			yamlConfig:   []byte("endpoint: localhost:4318\ntimeout: 0"),
-			wantExporter: OTLPHttpExporter{Endpoint: ptr("localhost:4318"), Timeout: ptr(0)},
+			wantExporter: OTLPHttpExporter{Endpoint: new("localhost:4318"), Timeout: new(0)},
 		},
 		{
 			name:       "invalid data",
@@ -1761,7 +1761,7 @@ func TestUnmarshalOTLPGrpcExporter(t *testing.T) {
 			name:         "valid with exporter",
 			jsonConfig:   []byte(`{"endpoint":"localhost:4318"}`),
 			yamlConfig:   []byte("endpoint: localhost:4318\n"),
-			wantExporter: OTLPGrpcExporter{Endpoint: ptr("localhost:4318")},
+			wantExporter: OTLPGrpcExporter{Endpoint: new("localhost:4318")},
 		},
 		{
 			name:       "missing required endpoint field",
@@ -1773,7 +1773,7 @@ func TestUnmarshalOTLPGrpcExporter(t *testing.T) {
 			name:         "valid with zero timeout",
 			jsonConfig:   []byte(`{"endpoint":"localhost:4318", "timeout":0}`),
 			yamlConfig:   []byte("endpoint: localhost:4318\ntimeout: 0"),
-			wantExporter: OTLPGrpcExporter{Endpoint: ptr("localhost:4318"), Timeout: ptr(0)},
+			wantExporter: OTLPGrpcExporter{Endpoint: new("localhost:4318"), Timeout: new(0)},
 		},
 		{
 			name:       "invalid data",
@@ -1814,7 +1814,7 @@ func TestUnmarshalOTLPHttpMetricExporter(t *testing.T) {
 			name:         "valid with exporter",
 			jsonConfig:   []byte(`{"endpoint":"localhost:4318"}`),
 			yamlConfig:   []byte("endpoint: localhost:4318\n"),
-			wantExporter: OTLPHttpMetricExporter{Endpoint: ptr("localhost:4318")},
+			wantExporter: OTLPHttpMetricExporter{Endpoint: new("localhost:4318")},
 		},
 		{
 			name:       "missing required endpoint field",
@@ -1826,7 +1826,7 @@ func TestUnmarshalOTLPHttpMetricExporter(t *testing.T) {
 			name:         "valid with zero timeout",
 			jsonConfig:   []byte(`{"endpoint":"localhost:4318", "timeout":0}`),
 			yamlConfig:   []byte("endpoint: localhost:4318\ntimeout: 0"),
-			wantExporter: OTLPHttpMetricExporter{Endpoint: ptr("localhost:4318"), Timeout: ptr(0)},
+			wantExporter: OTLPHttpMetricExporter{Endpoint: new("localhost:4318"), Timeout: new(0)},
 		},
 		{
 			name:       "invalid data",
@@ -1867,7 +1867,7 @@ func TestUnmarshalOTLPGrpcMetricExporter(t *testing.T) {
 			name:         "valid with exporter",
 			jsonConfig:   []byte(`{"endpoint":"localhost:4318"}`),
 			yamlConfig:   []byte("endpoint: localhost:4318\n"),
-			wantExporter: OTLPGrpcMetricExporter{Endpoint: ptr("localhost:4318")},
+			wantExporter: OTLPGrpcMetricExporter{Endpoint: new("localhost:4318")},
 		},
 		{
 			name:       "missing required endpoint field",
@@ -1879,7 +1879,7 @@ func TestUnmarshalOTLPGrpcMetricExporter(t *testing.T) {
 			name:         "valid with zero timeout",
 			jsonConfig:   []byte(`{"endpoint":"localhost:4318", "timeout":0}`),
 			yamlConfig:   []byte("endpoint: localhost:4318\ntimeout: 0"),
-			wantExporter: OTLPGrpcMetricExporter{Endpoint: ptr("localhost:4318"), Timeout: ptr(0)},
+			wantExporter: OTLPGrpcMetricExporter{Endpoint: new("localhost:4318"), Timeout: new(0)},
 		},
 		{
 			name:       "invalid data",
@@ -1941,7 +1941,7 @@ func TestUnmarshalAttributeNameValueType(t *testing.T) {
 			wantAttributeNameValue: AttributeNameValue{
 				Name:  "test",
 				Value: "test-val",
-				Type:  ptr(AttributeTypeString),
+				Type:  new(AttributeTypeString),
 			},
 		},
 		{
@@ -1951,7 +1951,7 @@ func TestUnmarshalAttributeNameValueType(t *testing.T) {
 			wantAttributeNameValue: AttributeNameValue{
 				Name:  "test",
 				Value: []any{"test-val", "test-val-2"},
-				Type:  ptr(AttributeTypeStringArray),
+				Type:  new(AttributeTypeStringArray),
 			},
 		},
 		{
@@ -1961,7 +1961,7 @@ func TestUnmarshalAttributeNameValueType(t *testing.T) {
 			wantAttributeNameValue: AttributeNameValue{
 				Name:  "test",
 				Value: true,
-				Type:  ptr(AttributeTypeBool),
+				Type:  new(AttributeTypeBool),
 			},
 		},
 		{
@@ -1971,7 +1971,7 @@ func TestUnmarshalAttributeNameValueType(t *testing.T) {
 			wantAttributeNameValue: AttributeNameValue{
 				Name:  "test",
 				Value: []any{"test-val", "test-val-2"},
-				Type:  ptr(AttributeTypeStringArray),
+				Type:  new(AttributeTypeStringArray),
 			},
 		},
 		{
@@ -1981,7 +1981,7 @@ func TestUnmarshalAttributeNameValueType(t *testing.T) {
 			wantAttributeNameValue: AttributeNameValue{
 				Name:  "test",
 				Value: int(1),
-				Type:  ptr(AttributeTypeInt),
+				Type:  new(AttributeTypeInt),
 			},
 		},
 		{
@@ -1991,7 +1991,7 @@ func TestUnmarshalAttributeNameValueType(t *testing.T) {
 			wantAttributeNameValue: AttributeNameValue{
 				Name:  "test",
 				Value: []any{1, 2},
-				Type:  ptr(AttributeTypeIntArray),
+				Type:  new(AttributeTypeIntArray),
 			},
 		},
 		{
@@ -2001,7 +2001,7 @@ func TestUnmarshalAttributeNameValueType(t *testing.T) {
 			wantAttributeNameValue: AttributeNameValue{
 				Name:  "test",
 				Value: float64(1),
-				Type:  ptr(AttributeTypeDouble),
+				Type:  new(AttributeTypeDouble),
 			},
 		},
 		{
@@ -2011,7 +2011,7 @@ func TestUnmarshalAttributeNameValueType(t *testing.T) {
 			wantAttributeNameValue: AttributeNameValue{
 				Name:  "test",
 				Value: []any{float64(1), float64(2)},
-				Type:  ptr(AttributeTypeDoubleArray),
+				Type:  new(AttributeTypeDoubleArray),
 			},
 		},
 		{
@@ -2073,7 +2073,7 @@ func TestUnmarshalNameStringValuePairType(t *testing.T) {
 			yamlConfig: []byte("name: test\nvalue: test-val\ntype: string\n"),
 			wantNameStringValuePair: NameStringValuePair{
 				Name:  "test",
-				Value: ptr("test-val"),
+				Value: new("test-val"),
 			},
 		},
 		{

--- a/otelconf/x/config_yaml.go
+++ b/otelconf/x/config_yaml.go
@@ -114,7 +114,7 @@ func (j *OpenTelemetryConfiguration) UnmarshalYAML(node *yaml.Node) error {
 	} else {
 		// Configure the log level of the internal logger used by the SDK.
 		// If omitted, info is used.
-		sh.Plain.Disabled = ptr(false)
+		sh.Plain.Disabled = new(false)
 	}
 	if sh.LoggerProvider != nil {
 		sh.Plain.LoggerProvider = sh.LoggerProvider
@@ -140,7 +140,7 @@ func (j *OpenTelemetryConfiguration) UnmarshalYAML(node *yaml.Node) error {
 	} else {
 		// Configure the log level of the internal logger used by the SDK.
 		// If omitted, info is used.
-		sh.Plain.LogLevel = ptr(SeverityNumberInfo)
+		sh.Plain.LogLevel = new(SeverityNumberInfo)
 	}
 
 	*j = OpenTelemetryConfiguration(sh.Plain)

--- a/otelconf/x/log_test.go
+++ b/otelconf/x/log_test.go
@@ -114,7 +114,7 @@ func TestLogProcessor(t *testing.T) {
 
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(0),
+					MaxExportBatchSize: new(0),
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{},
 					},
@@ -126,7 +126,7 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch processor invalid export timeout otlphttp exporter",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					ExportTimeout: ptr(-2),
+					ExportTimeout: new(-2),
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{},
 					},
@@ -139,7 +139,7 @@ func TestLogProcessor(t *testing.T) {
 
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxQueueSize: ptr(-3),
+					MaxQueueSize: new(-3),
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{},
 					},
@@ -151,7 +151,7 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch processor invalid schedule delay console exporter",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					ScheduleDelay: ptr(-4),
+					ScheduleDelay: new(-4),
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{},
 					},
@@ -172,10 +172,10 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/console",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						Console: ConsoleExporter{},
 					},
@@ -187,16 +187,16 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-exporter-no-endpoint",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -208,17 +208,17 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-exporter",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr("http://localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("http://localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -230,17 +230,17 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-exporter-socket-endpoint",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr("unix:collector.sock"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("unix:collector.sock"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -254,11 +254,11 @@ func TestLogProcessor(t *testing.T) {
 				Batch: &BatchLogRecordProcessor{
 					Exporter: LogRecordExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &GrpcTls{
-								CaFile: ptr(material.CACertPath),
+								CaFile: new(material.CACertPath),
 							},
 						},
 					},
@@ -272,11 +272,11 @@ func TestLogProcessor(t *testing.T) {
 				Batch: &BatchLogRecordProcessor{
 					Exporter: LogRecordExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &GrpcTls{
-								CaFile: ptr(material.BadCertPath),
+								CaFile: new(material.BadCertPath),
 							},
 						},
 					},
@@ -290,10 +290,10 @@ func TestLogProcessor(t *testing.T) {
 				Batch: &BatchLogRecordProcessor{
 					Exporter: LogRecordExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
-							HeadersList: ptr("==="),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
+							HeadersList: new("==="),
 						},
 					},
 				},
@@ -306,12 +306,12 @@ func TestLogProcessor(t *testing.T) {
 				Batch: &BatchLogRecordProcessor{
 					Exporter: LogRecordExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &GrpcTls{
-								KeyFile:  ptr(material.BadCertPath),
-								CertFile: ptr(material.BadCertPath),
+								KeyFile:  new(material.BadCertPath),
+								CertFile: new(material.BadCertPath),
 							},
 						},
 					},
@@ -323,17 +323,17 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-exporter-no-scheme",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -345,17 +345,17 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-invalid-endpoint",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr(" "),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new(" "),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -367,17 +367,17 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-invalid-compression",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("invalid"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("invalid"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -389,17 +389,17 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-http-exporter",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("http://localhost:4318"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("http://localhost:4318"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -413,11 +413,11 @@ func TestLogProcessor(t *testing.T) {
 				Batch: &BatchLogRecordProcessor{
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &HttpTls{
-								CaFile: ptr(material.CACertPath),
+								CaFile: new(material.CACertPath),
 							},
 						},
 					},
@@ -431,11 +431,11 @@ func TestLogProcessor(t *testing.T) {
 				Batch: &BatchLogRecordProcessor{
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &HttpTls{
-								CaFile: ptr(material.BadCertPath),
+								CaFile: new(material.BadCertPath),
 							},
 						},
 					},
@@ -449,12 +449,12 @@ func TestLogProcessor(t *testing.T) {
 				Batch: &BatchLogRecordProcessor{
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &HttpTls{
-								KeyFile:  ptr(material.BadCertPath),
-								CertFile: ptr(material.BadCertPath),
+								KeyFile:  new(material.BadCertPath),
+								CertFile: new(material.BadCertPath),
 							},
 						},
 					},
@@ -468,10 +468,10 @@ func TestLogProcessor(t *testing.T) {
 				Batch: &BatchLogRecordProcessor{
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
-							HeadersList: ptr("==="),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
+							HeadersList: new("==="),
 						},
 					},
 				},
@@ -482,17 +482,17 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-http-exporter-with-path",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("http://localhost:4318/path/123"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("http://localhost:4318/path/123"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -504,16 +504,16 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-http-exporter-no-endpoint",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -525,17 +525,17 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-http-exporter-no-scheme",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -547,17 +547,17 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-http-invalid-endpoint",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr(" "),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new(" "),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -569,17 +569,17 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-http-none-compression",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -591,17 +591,17 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-http-invalid-compression",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("invalid"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("invalid"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -613,14 +613,14 @@ func TestLogProcessor(t *testing.T) {
 			name: "batch/otlp-http-invalid-encoding",
 			processor: LogRecordProcessor{
 				Batch: &BatchLogRecordProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint: ptr("http://localhost:4318"),
-							Encoding: ptr(OTLPHttpEncoding("json")),
+							Endpoint: new("http://localhost:4318"),
+							Encoding: new(OTLPHttpEncoding("json")),
 						},
 					},
 				},
@@ -676,11 +676,11 @@ func TestLogProcessor(t *testing.T) {
 				Simple: &SimpleLogRecordProcessor{
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -718,7 +718,7 @@ func TestLoggerProviderOptions(t *testing.T) {
 				Simple: &SimpleLogRecordProcessor{
 					Exporter: LogRecordExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint: ptr(srv.URL),
+							Endpoint: new(srv.URL),
 						},
 					},
 				},
@@ -770,13 +770,13 @@ func Test_otlpGRPCLogExporter(t *testing.T) {
 			args: args{
 				ctx: t.Context(),
 				otlpConfig: &OTLPGrpcExporter{
-					Compression: ptr("gzip"),
-					Timeout:     ptr(50000),
+					Compression: new("gzip"),
+					Timeout:     new(50000),
 					Tls: &GrpcTls{
-						Insecure: ptr(true),
+						Insecure: new(true),
 					},
 					Headers: []NameStringValuePair{
-						{Name: "test", Value: ptr("test1")},
+						{Name: "test", Value: new("test1")},
 					},
 				},
 			},
@@ -789,13 +789,13 @@ func Test_otlpGRPCLogExporter(t *testing.T) {
 			args: args{
 				ctx: t.Context(),
 				otlpConfig: &OTLPGrpcExporter{
-					Compression: ptr("gzip"),
-					Timeout:     ptr(50000),
+					Compression: new("gzip"),
+					Timeout:     new(50000),
 					Tls: &GrpcTls{
-						CaFile: ptr(material.CACertPath),
+						CaFile: new(material.CACertPath),
 					},
 					Headers: []NameStringValuePair{
-						{Name: "test", Value: ptr("test1")},
+						{Name: "test", Value: new("test1")},
 					},
 				},
 			},
@@ -814,15 +814,15 @@ func Test_otlpGRPCLogExporter(t *testing.T) {
 			args: args{
 				ctx: t.Context(),
 				otlpConfig: &OTLPGrpcExporter{
-					Compression: ptr("gzip"),
-					Timeout:     ptr(50000),
+					Compression: new("gzip"),
+					Timeout:     new(50000),
 					Tls: &GrpcTls{
-						CaFile:   ptr(material.CACertPath),
-						KeyFile:  ptr(material.ClientKeyPath),
-						CertFile: ptr(material.ClientCertPath),
+						CaFile:   new(material.CACertPath),
+						KeyFile:  new(material.ClientKeyPath),
+						CertFile: new(material.ClientCertPath),
 					},
 					Headers: []NameStringValuePair{
-						{Name: "test", Value: ptr("test1")},
+						{Name: "test", Value: new("test1")},
 					},
 				},
 			},
@@ -857,7 +857,7 @@ func Test_otlpGRPCLogExporter(t *testing.T) {
 			if tt.args.otlpConfig.Tls != nil && tt.args.otlpConfig.Tls.Insecure != nil && *tt.args.otlpConfig.Tls.Insecure {
 				scheme = "http"
 			}
-			tt.args.otlpConfig.Endpoint = ptr(scheme + "://" + n.Addr().String())
+			tt.args.otlpConfig.Endpoint = new(scheme + "://" + n.Addr().String())
 
 			serverOpts, err := tt.grpcServerOpts()
 			require.NoError(t, err)

--- a/otelconf/x/metric_test.go
+++ b/otelconf/x/metric_test.go
@@ -116,7 +116,7 @@ func TestMeterProviderOptions(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPHttp: &OTLPHttpMetricExporter{
-							Endpoint: ptr(srv.URL),
+							Endpoint: new(srv.URL),
 						},
 					},
 				},
@@ -201,7 +201,7 @@ func TestReader(t *testing.T) {
 				Pull: &PullMetricReader{
 					Exporter: PullMetricExporter{
 						PrometheusDevelopment: &ExperimentalPrometheusMetricExporter{
-							Host: ptr("localhost"),
+							Host: new("localhost"),
 						},
 					},
 				},
@@ -214,10 +214,10 @@ func TestReader(t *testing.T) {
 				Pull: &PullMetricReader{
 					Exporter: PullMetricExporter{
 						PrometheusDevelopment: &ExperimentalPrometheusMetricExporter{
-							Host:                ptr("localhost"),
-							Port:                ptr(0),
-							WithoutScopeInfo:    ptr(true),
-							TranslationStrategy: ptr(ExperimentalPrometheusTranslationStrategyUnderscoreEscapingWithoutSuffixes),
+							Host:                new("localhost"),
+							Port:                new(0),
+							WithoutScopeInfo:    new(true),
+							TranslationStrategy: new(ExperimentalPrometheusTranslationStrategyUnderscoreEscapingWithoutSuffixes),
 							WithResourceConstantLabels: &IncludeExclude{
 								Included: []string{"include"},
 								Excluded: []string{"exclude"},
@@ -234,10 +234,10 @@ func TestReader(t *testing.T) {
 				Pull: &PullMetricReader{
 					Exporter: PullMetricExporter{
 						PrometheusDevelopment: &ExperimentalPrometheusMetricExporter{
-							Host:                ptr("localhost"),
-							Port:                ptr(0),
-							WithoutScopeInfo:    ptr(true),
-							TranslationStrategy: ptr(ExperimentalPrometheusTranslationStrategy("invalid-strategy")),
+							Host:                new("localhost"),
+							Port:                new(0),
+							WithoutScopeInfo:    new(true),
+							TranslationStrategy: new(ExperimentalPrometheusTranslationStrategy("invalid-strategy")),
 							WithResourceConstantLabels: &IncludeExclude{
 								Included: []string{"include"},
 								Excluded: []string{"exclude"},
@@ -254,11 +254,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPGrpc: &OTLPGrpcMetricExporter{
-							Endpoint:    ptr("http://localhost:4318"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("http://localhost:4318"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -272,11 +272,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPGrpc: &OTLPGrpcMetricExporter{
-							Endpoint:    ptr("http://localhost:4318/path/123"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("http://localhost:4318/path/123"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -290,11 +290,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPGrpc: &OTLPGrpcMetricExporter{
-							Endpoint:    ptr("https://localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("https://localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &GrpcTls{
-								CaFile: ptr(material.CACertPath),
+								CaFile: new(material.CACertPath),
 							},
 						},
 					},
@@ -308,11 +308,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPGrpc: &OTLPGrpcMetricExporter{
-							Endpoint:    ptr("https://localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("https://localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &GrpcTls{
-								CaFile: ptr(material.BadCertPath),
+								CaFile: new(material.BadCertPath),
 							},
 						},
 					},
@@ -326,12 +326,12 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPGrpc: &OTLPGrpcMetricExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &GrpcTls{
-								KeyFile:  ptr(material.BadCertPath),
-								CertFile: ptr(material.BadCertPath),
+								KeyFile:  new(material.BadCertPath),
+								CertFile: new(material.BadCertPath),
 							},
 						},
 					},
@@ -345,10 +345,10 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPGrpc: &OTLPGrpcMetricExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
-							HeadersList: ptr("==="),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
+							HeadersList: new("==="),
 						},
 					},
 				},
@@ -361,10 +361,10 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPGrpc: &OTLPGrpcMetricExporter{
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -378,11 +378,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPGrpc: &OTLPGrpcMetricExporter{
-							Endpoint:    ptr("unix:collector.sock"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("unix:collector.sock"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -396,11 +396,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPGrpc: &OTLPGrpcMetricExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -414,11 +414,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPGrpc: &OTLPGrpcMetricExporter{
-							Endpoint:    ptr(" "),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new(" "),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -432,11 +432,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPGrpc: &OTLPGrpcMetricExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -450,13 +450,13 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPGrpc: &OTLPGrpcMetricExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
-							TemporalityPreference: ptr(ExporterTemporalityPreferenceDelta),
+							TemporalityPreference: new(ExporterTemporalityPreferenceDelta),
 						},
 					},
 				},
@@ -469,13 +469,13 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPGrpc: &OTLPGrpcMetricExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
-							TemporalityPreference: ptr(ExporterTemporalityPreferenceCumulative),
+							TemporalityPreference: new(ExporterTemporalityPreferenceCumulative),
 						},
 					},
 				},
@@ -488,13 +488,13 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPGrpc: &OTLPGrpcMetricExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
-							TemporalityPreference: ptr(ExporterTemporalityPreferenceLowMemory),
+							TemporalityPreference: new(ExporterTemporalityPreferenceLowMemory),
 						},
 					},
 				},
@@ -507,13 +507,13 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPGrpc: &OTLPGrpcMetricExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
-							TemporalityPreference: (*ExporterTemporalityPreference)(ptr("invalid")),
+							TemporalityPreference: (*ExporterTemporalityPreference)(new("invalid")),
 						},
 					},
 				},
@@ -526,11 +526,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPGrpc: &OTLPGrpcMetricExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("invalid"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("invalid"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -544,11 +544,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPHttp: &OTLPHttpMetricExporter{
-							Endpoint:    ptr("http://localhost:4318"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("http://localhost:4318"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -562,11 +562,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPHttp: &OTLPHttpMetricExporter{
-							Endpoint:    ptr("https://localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("https://localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &HttpTls{
-								CaFile: ptr(material.CACertPath),
+								CaFile: new(material.CACertPath),
 							},
 						},
 					},
@@ -580,11 +580,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPHttp: &OTLPHttpMetricExporter{
-							Endpoint:    ptr("https://localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("https://localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &HttpTls{
-								CaFile: ptr(material.BadCertPath),
+								CaFile: new(material.BadCertPath),
 							},
 						},
 					},
@@ -598,12 +598,12 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPHttp: &OTLPHttpMetricExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &HttpTls{
-								KeyFile:  ptr(material.BadCertPath),
-								CertFile: ptr(material.BadCertPath),
+								KeyFile:  new(material.BadCertPath),
+								CertFile: new(material.BadCertPath),
 							},
 						},
 					},
@@ -617,10 +617,10 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPHttp: &OTLPHttpMetricExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
-							HeadersList: ptr("==="),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
+							HeadersList: new("==="),
 						},
 					},
 				},
@@ -633,11 +633,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPHttp: &OTLPHttpMetricExporter{
-							Endpoint:    ptr("http://localhost:4318/path/123"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("http://localhost:4318/path/123"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -651,10 +651,10 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPHttp: &OTLPHttpMetricExporter{
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -668,11 +668,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPHttp: &OTLPHttpMetricExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -686,11 +686,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPHttp: &OTLPHttpMetricExporter{
-							Endpoint:    ptr(" "),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new(" "),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -704,11 +704,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPHttp: &OTLPHttpMetricExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -722,13 +722,13 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPHttp: &OTLPHttpMetricExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
-							TemporalityPreference: ptr(ExporterTemporalityPreferenceCumulative),
+							TemporalityPreference: new(ExporterTemporalityPreferenceCumulative),
 						},
 					},
 				},
@@ -741,13 +741,13 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPHttp: &OTLPHttpMetricExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
-							TemporalityPreference: ptr(ExporterTemporalityPreferenceLowMemory),
+							TemporalityPreference: new(ExporterTemporalityPreferenceLowMemory),
 						},
 					},
 				},
@@ -760,13 +760,13 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPHttp: &OTLPHttpMetricExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
-							TemporalityPreference: ptr(ExporterTemporalityPreferenceDelta),
+							TemporalityPreference: new(ExporterTemporalityPreferenceDelta),
 						},
 					},
 				},
@@ -779,13 +779,13 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPHttp: &OTLPHttpMetricExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
-							TemporalityPreference: (*ExporterTemporalityPreference)(ptr("invalid")),
+							TemporalityPreference: (*ExporterTemporalityPreference)(new("invalid")),
 						},
 					},
 				},
@@ -798,11 +798,11 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPHttp: &OTLPHttpMetricExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("invalid"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("invalid"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -816,8 +816,8 @@ func TestReader(t *testing.T) {
 				Periodic: &PeriodicMetricReader{
 					Exporter: PushMetricExporter{
 						OTLPHttp: &OTLPHttpMetricExporter{
-							Endpoint: ptr("http://localhost:4318"),
-							Encoding: ptr(OTLPHttpEncoding("json")),
+							Endpoint: new("http://localhost:4318"),
+							Encoding: new(OTLPHttpEncoding("json")),
 						},
 					},
 				},
@@ -838,13 +838,13 @@ func TestReader(t *testing.T) {
 			reader: MetricReader{
 				Periodic: &PeriodicMetricReader{
 					CardinalityLimits: &CardinalityLimits{
-						Counter:                 ptr(100),
-						UpDownCounter:           ptr(200),
-						Histogram:               ptr(300),
-						ObservableCounter:       ptr(400),
-						ObservableUpDownCounter: ptr(500),
-						ObservableGauge:         ptr(600),
-						Gauge:                   ptr(700),
+						Counter:                 new(100),
+						UpDownCounter:           new(200),
+						Histogram:               new(300),
+						ObservableCounter:       new(400),
+						ObservableUpDownCounter: new(500),
+						ObservableGauge:         new(600),
+						Gauge:                   new(700),
 					},
 					Exporter: PushMetricExporter{
 						Console: &ConsoleMetricExporter{},
@@ -879,7 +879,7 @@ func TestReader(t *testing.T) {
 			reader: MetricReader{
 				Periodic: &PeriodicMetricReader{
 					CardinalityLimits: &CardinalityLimits{
-						Default: ptr(50),
+						Default: new(50),
 					},
 					Exporter: PushMetricExporter{
 						Console: &ConsoleMetricExporter{},
@@ -908,8 +908,8 @@ func TestReader(t *testing.T) {
 			name: "periodic/console-exporter-with-extra-options",
 			reader: MetricReader{
 				Periodic: &PeriodicMetricReader{
-					Interval: ptr(30_000),
-					Timeout:  ptr(5_000),
+					Interval: new(30_000),
+					Timeout:  new(5_000),
 					Exporter: PushMetricExporter{
 						Console: &ConsoleMetricExporter{},
 					},
@@ -972,13 +972,13 @@ func TestCardinalityLimitSelector(t *testing.T) {
 
 	t.Run("per-kind limits", func(t *testing.T) {
 		cl := &CardinalityLimits{
-			Counter:                 ptr(100),
-			UpDownCounter:           ptr(200),
-			Histogram:               ptr(300),
-			ObservableCounter:       ptr(400),
-			ObservableUpDownCounter: ptr(500),
-			ObservableGauge:         ptr(600),
-			Gauge:                   ptr(700),
+			Counter:                 new(100),
+			UpDownCounter:           new(200),
+			Histogram:               new(300),
+			ObservableCounter:       new(400),
+			ObservableUpDownCounter: new(500),
+			ObservableGauge:         new(600),
+			Gauge:                   new(700),
 		}
 		sel := cardinalityLimitSelector(cl)
 		expected := map[sdkmetric.InstrumentKind]int{
@@ -999,7 +999,7 @@ func TestCardinalityLimitSelector(t *testing.T) {
 
 	t.Run("default limit used when kind not set", func(t *testing.T) {
 		cl := &CardinalityLimits{
-			Default: ptr(50),
+			Default: new(50),
 		}
 		sel := cardinalityLimitSelector(cl)
 		for _, ik := range allKinds {
@@ -1011,8 +1011,8 @@ func TestCardinalityLimitSelector(t *testing.T) {
 
 	t.Run("per-kind overrides default", func(t *testing.T) {
 		cl := &CardinalityLimits{
-			Default: ptr(50),
-			Counter: ptr(100),
+			Default: new(50),
+			Counter: new(100),
 		}
 		sel := cardinalityLimitSelector(cl)
 		limit, fallback := sel(sdkmetric.InstrumentKindCounter)
@@ -1047,7 +1047,7 @@ func TestMetricReaderCardinalityLimitsWired(t *testing.T) {
 	reader, err := metricReader(ctx, MetricReader{
 		Periodic: &PeriodicMetricReader{
 			CardinalityLimits: &CardinalityLimits{
-				Counter: ptr(1),
+				Counter: new(1),
 			},
 			Exporter: PushMetricExporter{
 				Console: &ConsoleMetricExporter{},
@@ -1094,7 +1094,7 @@ func TestView(t *testing.T) {
 			name: "selector/invalid_type",
 			view: View{
 				Selector: ViewSelector{
-					InstrumentType: (*InstrumentType)(ptr("invalid_type")),
+					InstrumentType: (*InstrumentType)(new("invalid_type")),
 				},
 			},
 			wantErr: "view_selector: instrument_type: invalid value",
@@ -1110,12 +1110,12 @@ func TestView(t *testing.T) {
 			name: "all selectors match",
 			view: View{
 				Selector: ViewSelector{
-					InstrumentName: ptr("test_name"),
-					InstrumentType: ptr(InstrumentTypeCounter),
-					Unit:           ptr("test_unit"),
-					MeterName:      ptr("test_meter_name"),
-					MeterVersion:   ptr("test_meter_version"),
-					MeterSchemaUrl: ptr("test_schema_url"),
+					InstrumentName: new("test_name"),
+					InstrumentType: new(InstrumentTypeCounter),
+					Unit:           new("test_unit"),
+					MeterName:      new("test_meter_name"),
+					MeterVersion:   new("test_meter_version"),
+					MeterSchemaUrl: new("test_schema_url"),
 				},
 			},
 			matchInstrument: &sdkmetric.Instrument{
@@ -1135,12 +1135,12 @@ func TestView(t *testing.T) {
 			name: "all selectors no match name",
 			view: View{
 				Selector: ViewSelector{
-					InstrumentName: ptr("test_name"),
-					InstrumentType: ptr(InstrumentTypeCounter),
-					Unit:           ptr("test_unit"),
-					MeterName:      ptr("test_meter_name"),
-					MeterVersion:   ptr("test_meter_version"),
-					MeterSchemaUrl: ptr("test_schema_url"),
+					InstrumentName: new("test_name"),
+					InstrumentType: new(InstrumentTypeCounter),
+					Unit:           new("test_unit"),
+					MeterName:      new("test_meter_name"),
+					MeterVersion:   new("test_meter_version"),
+					MeterSchemaUrl: new("test_schema_url"),
 				},
 			},
 			matchInstrument: &sdkmetric.Instrument{
@@ -1160,12 +1160,12 @@ func TestView(t *testing.T) {
 			name: "all selectors no match unit",
 			view: View{
 				Selector: ViewSelector{
-					InstrumentName: ptr("test_name"),
-					InstrumentType: ptr(InstrumentTypeCounter),
-					Unit:           ptr("test_unit"),
-					MeterName:      ptr("test_meter_name"),
-					MeterVersion:   ptr("test_meter_version"),
-					MeterSchemaUrl: ptr("test_schema_url"),
+					InstrumentName: new("test_name"),
+					InstrumentType: new(InstrumentTypeCounter),
+					Unit:           new("test_unit"),
+					MeterName:      new("test_meter_name"),
+					MeterVersion:   new("test_meter_version"),
+					MeterSchemaUrl: new("test_schema_url"),
 				},
 			},
 			matchInstrument: &sdkmetric.Instrument{
@@ -1185,12 +1185,12 @@ func TestView(t *testing.T) {
 			name: "all selectors no match kind",
 			view: View{
 				Selector: ViewSelector{
-					InstrumentName: ptr("test_name"),
-					InstrumentType: (*InstrumentType)(ptr("histogram")),
-					Unit:           ptr("test_unit"),
-					MeterName:      ptr("test_meter_name"),
-					MeterVersion:   ptr("test_meter_version"),
-					MeterSchemaUrl: ptr("test_schema_url"),
+					InstrumentName: new("test_name"),
+					InstrumentType: (*InstrumentType)(new("histogram")),
+					Unit:           new("test_unit"),
+					MeterName:      new("test_meter_name"),
+					MeterVersion:   new("test_meter_version"),
+					MeterSchemaUrl: new("test_schema_url"),
 				},
 			},
 			matchInstrument: &sdkmetric.Instrument{
@@ -1210,12 +1210,12 @@ func TestView(t *testing.T) {
 			name: "all selectors no match meter name",
 			view: View{
 				Selector: ViewSelector{
-					InstrumentName: ptr("test_name"),
-					InstrumentType: ptr(InstrumentTypeCounter),
-					Unit:           ptr("test_unit"),
-					MeterName:      ptr("test_meter_name"),
-					MeterVersion:   ptr("test_meter_version"),
-					MeterSchemaUrl: ptr("test_schema_url"),
+					InstrumentName: new("test_name"),
+					InstrumentType: new(InstrumentTypeCounter),
+					Unit:           new("test_unit"),
+					MeterName:      new("test_meter_name"),
+					MeterVersion:   new("test_meter_version"),
+					MeterSchemaUrl: new("test_schema_url"),
 				},
 			},
 			matchInstrument: &sdkmetric.Instrument{
@@ -1235,12 +1235,12 @@ func TestView(t *testing.T) {
 			name: "all selectors no match meter version",
 			view: View{
 				Selector: ViewSelector{
-					InstrumentName: ptr("test_name"),
-					InstrumentType: ptr(InstrumentTypeCounter),
-					Unit:           ptr("test_unit"),
-					MeterName:      ptr("test_meter_name"),
-					MeterVersion:   ptr("test_meter_version"),
-					MeterSchemaUrl: ptr("test_schema_url"),
+					InstrumentName: new("test_name"),
+					InstrumentType: new(InstrumentTypeCounter),
+					Unit:           new("test_unit"),
+					MeterName:      new("test_meter_name"),
+					MeterVersion:   new("test_meter_version"),
+					MeterSchemaUrl: new("test_schema_url"),
 				},
 			},
 			matchInstrument: &sdkmetric.Instrument{
@@ -1260,12 +1260,12 @@ func TestView(t *testing.T) {
 			name: "all selectors no match meter schema url",
 			view: View{
 				Selector: ViewSelector{
-					InstrumentName: ptr("test_name"),
-					InstrumentType: ptr(InstrumentTypeCounter),
-					Unit:           ptr("test_unit"),
-					MeterName:      ptr("test_meter_name"),
-					MeterVersion:   ptr("test_meter_version"),
-					MeterSchemaUrl: ptr("test_schema_url"),
+					InstrumentName: new("test_name"),
+					InstrumentType: new(InstrumentTypeCounter),
+					Unit:           new("test_unit"),
+					MeterName:      new("test_meter_name"),
+					MeterVersion:   new("test_meter_version"),
+					MeterSchemaUrl: new("test_schema_url"),
 				},
 			},
 			matchInstrument: &sdkmetric.Instrument{
@@ -1285,13 +1285,13 @@ func TestView(t *testing.T) {
 			name: "with stream",
 			view: View{
 				Selector: ViewSelector{
-					InstrumentName: ptr("test_name"),
-					Unit:           ptr("test_unit"),
+					InstrumentName: new("test_name"),
+					Unit:           new("test_unit"),
 				},
 				Stream: ViewStream{
-					Name:          ptr("new_name"),
-					Description:   ptr("new_description"),
-					AttributeKeys: ptr(IncludeExclude{Included: []string{"foo", "bar"}}),
+					Name:          new("new_name"),
+					Description:   new("new_description"),
+					AttributeKeys: new(IncludeExclude{Included: []string{"foo", "bar"}}),
 					Aggregation:   &Aggregation{Sum: make(SumAggregation)},
 				},
 			},
@@ -1340,37 +1340,37 @@ func TestInstrumentType(t *testing.T) {
 		},
 		{
 			name:     "counter",
-			instType: ptr(InstrumentTypeCounter),
+			instType: new(InstrumentTypeCounter),
 			wantKind: sdkmetric.InstrumentKindCounter,
 		},
 		{
 			name:     "up_down_counter",
-			instType: ptr(InstrumentTypeUpDownCounter),
+			instType: new(InstrumentTypeUpDownCounter),
 			wantKind: sdkmetric.InstrumentKindUpDownCounter,
 		},
 		{
 			name:     "histogram",
-			instType: ptr(InstrumentTypeHistogram),
+			instType: new(InstrumentTypeHistogram),
 			wantKind: sdkmetric.InstrumentKindHistogram,
 		},
 		{
 			name:     "observable_counter",
-			instType: ptr(InstrumentTypeObservableCounter),
+			instType: new(InstrumentTypeObservableCounter),
 			wantKind: sdkmetric.InstrumentKindObservableCounter,
 		},
 		{
 			name:     "observable_up_down_counter",
-			instType: ptr(InstrumentTypeObservableUpDownCounter),
+			instType: new(InstrumentTypeObservableUpDownCounter),
 			wantKind: sdkmetric.InstrumentKindObservableUpDownCounter,
 		},
 		{
 			name:     "observable_gauge",
-			instType: ptr(InstrumentTypeObservableGauge),
+			instType: new(InstrumentTypeObservableGauge),
 			wantKind: sdkmetric.InstrumentKindObservableGauge,
 		},
 		{
 			name:     "invalid",
-			instType: (*InstrumentType)(ptr("invalid")),
+			instType: (*InstrumentType)(new("invalid")),
 			wantErr:  errors.New("instrument_type: invalid value"),
 		},
 	}
@@ -1418,9 +1418,9 @@ func TestAggregation(t *testing.T) {
 			name: "Base2ExponentialBucketHistogram",
 			aggregation: &Aggregation{
 				Base2ExponentialBucketHistogram: &Base2ExponentialBucketHistogramAggregation{
-					MaxSize:      ptr(2),
-					MaxScale:     ptr(3),
-					RecordMinMax: ptr(true),
+					MaxSize:      new(2),
+					MaxScale:     new(3),
+					RecordMinMax: new(true),
 				},
 			},
 			wantAggregation: sdkmetric.AggregationBase2ExponentialHistogram{
@@ -1458,7 +1458,7 @@ func TestAggregation(t *testing.T) {
 			aggregation: &Aggregation{
 				ExplicitBucketHistogram: &ExplicitBucketHistogramAggregation{
 					Boundaries:   []float64{1, 2, 3},
-					RecordMinMax: ptr(true),
+					RecordMinMax: new(true),
 				},
 			},
 			wantAggregation: sdkmetric.AggregationExplicitBucketHistogram{
@@ -1504,7 +1504,7 @@ func TestNewIncludeExcludeFilter(t *testing.T) {
 		},
 		{
 			name: "filter-with-include",
-			attributeKeys: ptr(IncludeExclude{
+			attributeKeys: new(IncludeExclude{
 				Included: []string{"foo"},
 			}),
 			wantPass: []string{"foo"},
@@ -1512,7 +1512,7 @@ func TestNewIncludeExcludeFilter(t *testing.T) {
 		},
 		{
 			name: "filter-with-exclude",
-			attributeKeys: ptr(IncludeExclude{
+			attributeKeys: new(IncludeExclude{
 				Excluded: []string{"foo"},
 			}),
 			wantPass: []string{"bar"},
@@ -1520,7 +1520,7 @@ func TestNewIncludeExcludeFilter(t *testing.T) {
 		},
 		{
 			name: "filter-with-include-and-exclude",
-			attributeKeys: ptr(IncludeExclude{
+			attributeKeys: new(IncludeExclude{
 				Included: []string{"bar"},
 				Excluded: []string{"foo"},
 			}),
@@ -1543,7 +1543,7 @@ func TestNewIncludeExcludeFilter(t *testing.T) {
 }
 
 func TestNewIncludeExcludeFilterError(t *testing.T) {
-	_, err := newIncludeExcludeFilter(ptr(IncludeExclude{
+	_, err := newIncludeExcludeFilter(new(IncludeExclude{
 		Included: []string{"foo"},
 		Excluded: []string{"foo"},
 	}))
@@ -1564,8 +1564,8 @@ func TestPrometheusReaderOpts(t *testing.T) {
 		{
 			name: "all set",
 			cfg: ExperimentalPrometheusMetricExporter{
-				WithoutScopeInfo:           ptr(true),
-				TranslationStrategy:        ptr(ExperimentalPrometheusTranslationStrategyUnderscoreEscapingWithoutSuffixes),
+				WithoutScopeInfo:           new(true),
+				TranslationStrategy:        new(ExperimentalPrometheusTranslationStrategyUnderscoreEscapingWithoutSuffixes),
 				WithResourceConstantLabels: &IncludeExclude{},
 			},
 			wantOptions: 3,
@@ -1573,8 +1573,8 @@ func TestPrometheusReaderOpts(t *testing.T) {
 		{
 			name: "all set false",
 			cfg: ExperimentalPrometheusMetricExporter{
-				WithoutScopeInfo:           ptr(false),
-				TranslationStrategy:        ptr(ExperimentalPrometheusTranslationStrategyUnderscoreEscapingWithSuffixes),
+				WithoutScopeInfo:           new(false),
+				TranslationStrategy:        new(ExperimentalPrometheusTranslationStrategyUnderscoreEscapingWithSuffixes),
 				WithResourceConstantLabels: &IncludeExclude{},
 			},
 			wantOptions: 2,
@@ -1609,8 +1609,8 @@ func TestPrometheusIPv6(t *testing.T) {
 			cfg := ExperimentalPrometheusMetricExporter{
 				Host:                       &tt.host,
 				Port:                       &port,
-				WithoutScopeInfo:           ptr(true),
-				TranslationStrategy:        ptr(ExperimentalPrometheusTranslationStrategyUnderscoreEscapingWithSuffixes),
+				WithoutScopeInfo:           new(true),
+				TranslationStrategy:        new(ExperimentalPrometheusTranslationStrategyUnderscoreEscapingWithSuffixes),
 				WithResourceConstantLabels: &IncludeExclude{},
 			}
 
@@ -1655,13 +1655,13 @@ func Test_otlpGRPCMetricExporter(t *testing.T) {
 			args: args{
 				ctx: t.Context(),
 				otlpConfig: &OTLPGrpcMetricExporter{
-					Compression: ptr("gzip"),
-					Timeout:     ptr(50000),
+					Compression: new("gzip"),
+					Timeout:     new(50000),
 					Tls: &GrpcTls{
-						Insecure: ptr(true),
+						Insecure: new(true),
 					},
 					Headers: []NameStringValuePair{
-						{Name: "test", Value: ptr("test1")},
+						{Name: "test", Value: new("test1")},
 					},
 				},
 			},
@@ -1674,13 +1674,13 @@ func Test_otlpGRPCMetricExporter(t *testing.T) {
 			args: args{
 				ctx: t.Context(),
 				otlpConfig: &OTLPGrpcMetricExporter{
-					Compression: ptr("gzip"),
-					Timeout:     ptr(50000),
+					Compression: new("gzip"),
+					Timeout:     new(50000),
 					Tls: &GrpcTls{
-						CaFile: ptr(material.CACertPath),
+						CaFile: new(material.CACertPath),
 					},
 					Headers: []NameStringValuePair{
-						{Name: "test", Value: ptr("test1")},
+						{Name: "test", Value: new("test1")},
 					},
 				},
 			},
@@ -1699,15 +1699,15 @@ func Test_otlpGRPCMetricExporter(t *testing.T) {
 			args: args{
 				ctx: t.Context(),
 				otlpConfig: &OTLPGrpcMetricExporter{
-					Compression: ptr("gzip"),
-					Timeout:     ptr(50000),
+					Compression: new("gzip"),
+					Timeout:     new(50000),
 					Tls: &GrpcTls{
-						CaFile:   ptr(material.CACertPath),
-						KeyFile:  ptr(material.ClientKeyPath),
-						CertFile: ptr(material.ClientCertPath),
+						CaFile:   new(material.CACertPath),
+						KeyFile:  new(material.ClientKeyPath),
+						CertFile: new(material.ClientCertPath),
 					},
 					Headers: []NameStringValuePair{
-						{Name: "test", Value: ptr("test1")},
+						{Name: "test", Value: new("test1")},
 					},
 				},
 			},
@@ -1742,7 +1742,7 @@ func Test_otlpGRPCMetricExporter(t *testing.T) {
 			if tt.args.otlpConfig.Tls != nil && tt.args.otlpConfig.Tls.Insecure != nil && *tt.args.otlpConfig.Tls.Insecure {
 				scheme = "http"
 			}
-			tt.args.otlpConfig.Endpoint = ptr(scheme + "://" + n.Addr().String())
+			tt.args.otlpConfig.Endpoint = new(scheme + "://" + n.Addr().String())
 
 			serverOpts, err := tt.grpcServerOpts()
 			require.NoError(t, err)

--- a/otelconf/x/propagator_test.go
+++ b/otelconf/x/propagator_test.go
@@ -127,7 +127,7 @@ func TestPropagator(t *testing.T) {
 		{
 			name: "multiple propagators via composite_list",
 			cfg: &Propagator{
-				CompositeList: ptr("tracecontext,baggage,b3"),
+				CompositeList: new("tracecontext,baggage,b3"),
 			},
 			want:    []string{"tracestate", "baggage", "b3", "traceparent"},
 			wantErr: false,
@@ -135,7 +135,7 @@ func TestPropagator(t *testing.T) {
 		{
 			name: "valid xray",
 			cfg: &Propagator{
-				CompositeList: ptr("xray"),
+				CompositeList: new("xray"),
 			},
 			want:    []string{"X-Amzn-Trace-Id"},
 			wantErr: false,
@@ -143,7 +143,7 @@ func TestPropagator(t *testing.T) {
 		{
 			name: "empty propagator name",
 			cfg: &Propagator{
-				CompositeList: ptr(""),
+				CompositeList: new(""),
 			},
 			want:    []string{},
 			wantErr: true,
@@ -152,7 +152,7 @@ func TestPropagator(t *testing.T) {
 		{
 			name: "unsupported propagator",
 			cfg: &Propagator{
-				CompositeList: ptr("random-garbage,baggage,b3"),
+				CompositeList: new("random-garbage,baggage,b3"),
 			},
 			want:    []string{},
 			wantErr: true,

--- a/otelconf/x/resource_test.go
+++ b/otelconf/x/resource_test.go
@@ -44,7 +44,7 @@ func TestNewResource(t *testing.T) {
 		{
 			name: "resource-with-schema",
 			config: &Resource{
-				SchemaUrl: ptr(semconv.SchemaURL),
+				SchemaUrl: new(semconv.SchemaURL),
 			},
 			wantSchemaURL: semconv.SchemaURL,
 		},
@@ -64,7 +64,7 @@ func TestNewResource(t *testing.T) {
 				Attributes: []AttributeNameValue{
 					{Name: string(semconv.ServiceNameKey), Value: "service-a"},
 				},
-				SchemaUrl: ptr(semconv.SchemaURL),
+				SchemaUrl: new(semconv.SchemaURL),
 			},
 			wantSchemaURL: semconv.SchemaURL,
 			wantAttrs:     []attribute.KeyValue{semconv.ServiceName("service-a")},
@@ -76,7 +76,7 @@ func TestNewResource(t *testing.T) {
 					{Name: string(semconv.ServiceNameKey), Value: "service-a"},
 					{Name: "attr-bool", Value: true},
 				},
-				SchemaUrl: ptr(semconv.SchemaURL),
+				SchemaUrl: new(semconv.SchemaURL),
 			},
 			wantSchemaURL: semconv.SchemaURL,
 			wantAttrs: []attribute.KeyValue{
@@ -306,7 +306,7 @@ func TestNewResourceWithDetectionAttributesFilterDoesNotApplyToConfiguredAttribu
 func TestNewResourceWithDetectionAttributesFilterRemovesDetectedSchema(t *testing.T) {
 	schemaURL := "https://example.com/schema"
 	got, err := newResource(t.Context(), &Resource{
-		SchemaUrl: ptr(schemaURL),
+		SchemaUrl: new(schemaURL),
 		DetectionDevelopment: &ExperimentalResourceDetection{
 			Detectors: []ExperimentalResourceDetector{
 				{Host: ExperimentalHostResourceDetector{}},

--- a/otelconf/x/trace_test.go
+++ b/otelconf/x/trace_test.go
@@ -132,7 +132,7 @@ func TestTracerProviderOptions(t *testing.T) {
 				Simple: &SimpleSpanProcessor{
 					Exporter: SpanExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint: ptr(srv.URL),
+							Endpoint: new(srv.URL),
 						},
 					},
 				},
@@ -214,7 +214,7 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch processor invalid batch size console exporter",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(-1),
+					MaxExportBatchSize: new(-1),
 					Exporter: SpanExporter{
 						Console: ConsoleExporter{},
 					},
@@ -226,7 +226,7 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch processor invalid export timeout console exporter",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					ExportTimeout: ptr(-2),
+					ExportTimeout: new(-2),
 					Exporter: SpanExporter{
 						Console: ConsoleExporter{},
 					},
@@ -238,7 +238,7 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch processor invalid queue size console exporter",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxQueueSize: ptr(-3),
+					MaxQueueSize: new(-3),
 					Exporter: SpanExporter{
 						Console: ConsoleExporter{},
 					},
@@ -250,7 +250,7 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch processor invalid schedule delay console exporter",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					ScheduleDelay: ptr(-4),
+					ScheduleDelay: new(-4),
 					Exporter: SpanExporter{
 						Console: ConsoleExporter{},
 					},
@@ -274,10 +274,10 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch processor console exporter",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						Console: ConsoleExporter{},
 					},
@@ -289,16 +289,16 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-exporter-no-endpoint",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -310,17 +310,17 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-exporter",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr("http://localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("http://localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -332,17 +332,17 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-exporter-socket-endpoint",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr("unix:collector.sock"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("unix:collector.sock"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -356,11 +356,11 @@ func TestSpanProcessor(t *testing.T) {
 				Batch: &BatchSpanProcessor{
 					Exporter: SpanExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &GrpcTls{
-								CaFile: ptr(material.CACertPath),
+								CaFile: new(material.CACertPath),
 							},
 						},
 					},
@@ -374,11 +374,11 @@ func TestSpanProcessor(t *testing.T) {
 				Batch: &BatchSpanProcessor{
 					Exporter: SpanExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &GrpcTls{
-								CaFile: ptr(material.BadCertPath),
+								CaFile: new(material.BadCertPath),
 							},
 						},
 					},
@@ -392,12 +392,12 @@ func TestSpanProcessor(t *testing.T) {
 				Batch: &BatchSpanProcessor{
 					Exporter: SpanExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &GrpcTls{
-								KeyFile:  ptr(material.BadCertPath),
-								CertFile: ptr(material.BadCertPath),
+								KeyFile:  new(material.BadCertPath),
+								CertFile: new(material.BadCertPath),
 							},
 						},
 					},
@@ -411,10 +411,10 @@ func TestSpanProcessor(t *testing.T) {
 				Batch: &BatchSpanProcessor{
 					Exporter: SpanExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
-							HeadersList: ptr("==="),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
+							HeadersList: new("==="),
 						},
 					},
 				},
@@ -425,17 +425,17 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-exporter-no-scheme",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -447,17 +447,17 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-invalid-endpoint",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr(" "),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new(" "),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -469,17 +469,17 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-grpc-invalid-compression",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLPGrpc: &OTLPGrpcExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("invalid"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("invalid"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -491,17 +491,17 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-http-exporter",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("http://localhost:4318"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("http://localhost:4318"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -515,11 +515,11 @@ func TestSpanProcessor(t *testing.T) {
 				Batch: &BatchSpanProcessor{
 					Exporter: SpanExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &HttpTls{
-								CaFile: ptr(material.CACertPath),
+								CaFile: new(material.CACertPath),
 							},
 						},
 					},
@@ -533,11 +533,11 @@ func TestSpanProcessor(t *testing.T) {
 				Batch: &BatchSpanProcessor{
 					Exporter: SpanExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &HttpTls{
-								CaFile: ptr(material.BadCertPath),
+								CaFile: new(material.BadCertPath),
 							},
 						},
 					},
@@ -551,12 +551,12 @@ func TestSpanProcessor(t *testing.T) {
 				Batch: &BatchSpanProcessor{
 					Exporter: SpanExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Tls: &HttpTls{
-								KeyFile:  ptr(material.BadCertPath),
-								CertFile: ptr(material.BadCertPath),
+								KeyFile:  new(material.BadCertPath),
+								CertFile: new(material.BadCertPath),
 							},
 						},
 					},
@@ -570,10 +570,10 @@ func TestSpanProcessor(t *testing.T) {
 				Batch: &BatchSpanProcessor{
 					Exporter: SpanExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("localhost:4317"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
-							HeadersList: ptr("==="),
+							Endpoint:    new("localhost:4317"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
+							HeadersList: new("==="),
 						},
 					},
 				},
@@ -584,17 +584,17 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-http-exporter-with-path",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("http://localhost:4318/path/123"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("http://localhost:4318/path/123"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -606,16 +606,16 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-http-exporter-no-endpoint",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -627,17 +627,17 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-http-exporter-no-scheme",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -649,17 +649,17 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-http-invalid-endpoint",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr(" "),
-							Compression: ptr("gzip"),
-							Timeout:     ptr(1000),
+							Endpoint:    new(" "),
+							Compression: new("gzip"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -671,17 +671,17 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-http-none-compression",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("none"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("none"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -693,17 +693,17 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-http-invalid-compression",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint:    ptr("localhost:4318"),
-							Compression: ptr("invalid"),
-							Timeout:     ptr(1000),
+							Endpoint:    new("localhost:4318"),
+							Compression: new("invalid"),
+							Timeout:     new(1000),
 							Headers: []NameStringValuePair{
-								{Name: "test", Value: ptr("test1")},
+								{Name: "test", Value: new("test1")},
 							},
 						},
 					},
@@ -715,14 +715,14 @@ func TestSpanProcessor(t *testing.T) {
 			name: "batch/otlp-http-invalid-encoding",
 			processor: SpanProcessor{
 				Batch: &BatchSpanProcessor{
-					MaxExportBatchSize: ptr(1),
-					ExportTimeout:      ptr(0),
-					MaxQueueSize:       ptr(1),
-					ScheduleDelay:      ptr(0),
+					MaxExportBatchSize: new(1),
+					ExportTimeout:      new(0),
+					MaxQueueSize:       new(1),
+					ScheduleDelay:      new(0),
 					Exporter: SpanExporter{
 						OTLPHttp: &OTLPHttpExporter{
-							Endpoint: ptr("http://localhost:4318"),
-							Encoding: ptr(OTLPHttpEncoding("json")),
+							Endpoint: new("http://localhost:4318"),
+							Encoding: new(OTLPHttpEncoding("json")),
 						},
 					},
 				},
@@ -832,7 +832,7 @@ func TestSampler(t *testing.T) {
 			name: "sampler configuration trace ID ratio",
 			sampler: &Sampler{
 				TraceIDRatioBased: &TraceIDRatioBasedSampler{
-					Ratio: ptr(0.54),
+					Ratio: new(0.54),
 				},
 			},
 			wantSampler: sdktrace.TraceIDRatioBased(0.54),
@@ -863,7 +863,7 @@ func TestSampler(t *testing.T) {
 					},
 					RemoteParentSampled: &Sampler{
 						TraceIDRatioBased: &TraceIDRatioBasedSampler{
-							Ratio: ptr(0.009),
+							Ratio: new(0.009),
 						},
 					},
 					LocalParentNotSampled: &Sampler{
@@ -871,7 +871,7 @@ func TestSampler(t *testing.T) {
 					},
 					LocalParentSampled: &Sampler{
 						TraceIDRatioBased: &TraceIDRatioBasedSampler{
-							Ratio: ptr(0.05),
+							Ratio: new(0.05),
 						},
 					},
 				},
@@ -934,13 +934,13 @@ func Test_otlpGRPCTraceExporter(t *testing.T) {
 			args: args{
 				ctx: t.Context(),
 				otlpConfig: &OTLPGrpcExporter{
-					Compression: ptr("gzip"),
-					Timeout:     ptr(50000),
+					Compression: new("gzip"),
+					Timeout:     new(50000),
 					Tls: &GrpcTls{
-						Insecure: ptr(true),
+						Insecure: new(true),
 					},
 					Headers: []NameStringValuePair{
-						{Name: "test", Value: ptr("test1")},
+						{Name: "test", Value: new("test1")},
 					},
 				},
 			},
@@ -953,13 +953,13 @@ func Test_otlpGRPCTraceExporter(t *testing.T) {
 			args: args{
 				ctx: t.Context(),
 				otlpConfig: &OTLPGrpcExporter{
-					Compression: ptr("gzip"),
-					Timeout:     ptr(50000),
+					Compression: new("gzip"),
+					Timeout:     new(50000),
 					Tls: &GrpcTls{
-						CaFile: ptr(material.CACertPath),
+						CaFile: new(material.CACertPath),
 					},
 					Headers: []NameStringValuePair{
-						{Name: "test", Value: ptr("test1")},
+						{Name: "test", Value: new("test1")},
 					},
 				},
 			},
@@ -978,15 +978,15 @@ func Test_otlpGRPCTraceExporter(t *testing.T) {
 			args: args{
 				ctx: t.Context(),
 				otlpConfig: &OTLPGrpcExporter{
-					Compression: ptr("gzip"),
-					Timeout:     ptr(50000),
+					Compression: new("gzip"),
+					Timeout:     new(50000),
 					Tls: &GrpcTls{
-						CaFile:   ptr(material.CACertPath),
-						KeyFile:  ptr(material.ClientKeyPath),
-						CertFile: ptr(material.ClientCertPath),
+						CaFile:   new(material.CACertPath),
+						KeyFile:  new(material.ClientKeyPath),
+						CertFile: new(material.ClientCertPath),
 					},
 					Headers: []NameStringValuePair{
-						{Name: "test", Value: ptr("test1")},
+						{Name: "test", Value: new("test1")},
 					},
 				},
 			},
@@ -1021,7 +1021,7 @@ func Test_otlpGRPCTraceExporter(t *testing.T) {
 			if tt.args.otlpConfig.Tls != nil && tt.args.otlpConfig.Tls.Insecure != nil && *tt.args.otlpConfig.Tls.Insecure {
 				scheme = "http"
 			}
-			tt.args.otlpConfig.Endpoint = ptr(scheme + "://" + n.Addr().String())
+			tt.args.otlpConfig.Endpoint = new(scheme + "://" + n.Addr().String())
 
 			serverOpts, err := tt.grpcServerOpts()
 			require.NoError(t, err)

--- a/processors/baggagecopy/go.mod
+++ b/processors/baggagecopy/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/processors/baggagecopy
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.1

--- a/processors/minsev/go.mod
+++ b/processors/minsev/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/processors/minsev
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.1

--- a/propagators/autoprop/go.mod
+++ b/propagators/autoprop/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/propagators/autoprop
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.1

--- a/propagators/aws/go.mod
+++ b/propagators/aws/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/propagators/aws
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.1

--- a/propagators/b3/go.mod
+++ b/propagators/b3/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/propagators/b3
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/propagators/envcar/go.mod
+++ b/propagators/envcar/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/propagators/envcar
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.1

--- a/propagators/jaeger/go.mod
+++ b/propagators/jaeger/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/propagators/jaeger
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/propagators/opencensus/examples/go.mod
+++ b/propagators/opencensus/examples/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/propagators/opencensus/examples
 
-go 1.25.0
+go 1.26.0
 
 require (
 	go.opencensus.io v0.24.0

--- a/propagators/opencensus/go.mod
+++ b/propagators/opencensus/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/propagators/opencensus
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/propagators/ot/go.mod
+++ b/propagators/ot/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/propagators/ot
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/samplers/jaegerremote/example/go.mod
+++ b/samplers/jaegerremote/example/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/samplers/jaegerremote/example
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc

--- a/samplers/jaegerremote/go.mod
+++ b/samplers/jaegerremote/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/samplers/jaegerremote
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/go-logr/logr v1.4.4

--- a/samplers/probability/consistent/go.mod
+++ b/samplers/probability/consistent/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/samplers/probability/consistent
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.1

--- a/zpages/go.mod
+++ b/zpages/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/contrib/zpages
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.12.1


### PR DESCRIPTION
## Summary

- require Go 1.26 across repository modules and remove Go 1.25 compatibility testing
- update compatibility documentation, the bug-report template, and the changelog
- adopt Go 1.26 pointer expressions required by the modernize linter across affected modules

## Testing

- `make precommit`
- `make golangci-lint/./detectors/docker`
- `(cd detectors/docker && go test -race ./...)`