### PR TITLE
otelhttp: Deprecate legacy keys and stop emitting legacy byte attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,19 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Add `NewResourceDetectorWithOptions` and the `WithAWSLogger` option to `go.opentelemetry.io/contrib/detectors/aws/ec2/v2`, allowing a custom AWS SDK `logging.Logger` to be supplied to the EC2 resource detector. (#9132)
 
+### Changed
+
+- Stop emitting the legacy `http.read_bytes` and `http.wrote_bytes` attributes on the per-operation span events enabled by `WithMessageEvents` in `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp`.
+  The `read` and `write` events remain, while total body sizes continue to be recorded on the server span as `http.request.body.size` and `http.response.body.size` according to HTTP semantic conventions. (#9624)
+
 ### Deprecated
 
 - Deprecate `go.opentelemetry.io/contrib/samplers/probability/consistent`. (#9633)
+- Deprecate `ReadBytesKey`, `ReadErrorKey`, `WroteBytesKey`, and `WriteErrorKey` in `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp`.
+  The identifiers remain available and their values are unchanged, but `WithMessageEvents` no longer emits `http.read_bytes` or `http.wrote_bytes`.
+  There is no semantic-convention replacement for per-read or per-write byte counts or the human-readable error fields.
+  Use `HTTPRequestBodySizeKey` and `HTTPResponseBodySizeKey` from `go.opentelemetry.io/otel/semconv/v1.43.0` to record total body sizes on the span.
+  If an error causes the HTTP request to fail, set the span status to Error and record `ErrorType(err)` from `go.opentelemetry.io/otel/semconv/v1.43.0` on the span. (#9624)
 
 ### Fixed
 

--- a/instrumentation/net/http/otelhttp/common.go
+++ b/instrumentation/net/http/otelhttp/common.go
@@ -10,12 +10,31 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// Attribute keys that can be added to a span.
+// Legacy HTTP attribute keys retained for compatibility.
 const (
-	ReadBytesKey  = attribute.Key("http.read_bytes")  // if anything was read from the request body, the total number of bytes read
-	ReadErrorKey  = attribute.Key("http.read_error")  // If an error occurred while reading a request, the string of the error (io.EOF is not recorded)
-	WroteBytesKey = attribute.Key("http.wrote_bytes") // if anything was written to the response writer, the total number of bytes written
-	WriteErrorKey = attribute.Key("http.write_error") // if an error occurred while writing a reply, the string of the error (io.EOF is not recorded)
+	// ReadBytesKey is the attribute key for the number of bytes returned by an
+	// individual read from an HTTP request body.
+	//
+	// Deprecated: there is no direct semantic-convention replacement.
+	ReadBytesKey = attribute.Key("http.read_bytes")
+
+	// ReadErrorKey is the attribute key for the string form of a non-EOF error
+	// returned while reading an HTTP request body.
+	//
+	// Deprecated: there is no direct semantic-convention replacement.
+	ReadErrorKey = attribute.Key("http.read_error")
+
+	// WroteBytesKey is the attribute key for the number of bytes returned by an
+	// individual write to an HTTP response body.
+	//
+	// Deprecated: there is no direct semantic-convention replacement.
+	WroteBytesKey = attribute.Key("http.wrote_bytes")
+
+	// WriteErrorKey is the attribute key for the string form of a non-EOF error
+	// returned while writing an HTTP response body.
+	//
+	// Deprecated: there is no direct semantic-convention replacement.
+	WriteErrorKey = attribute.Key("http.write_error")
 )
 
 // Filter is a predicate used to determine whether a given http.request should

--- a/instrumentation/net/http/otelhttp/common_test.go
+++ b/instrumentation/net/http/otelhttp/common_test.go
@@ -1,0 +1,31 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otelhttp
+
+import (
+	"testing"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func TestDeprecatedAttributeKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		got  attribute.Key
+		want attribute.Key
+	}{
+		{name: "read bytes", got: ReadBytesKey, want: attribute.Key("http.read_bytes")},
+		{name: "read error", got: ReadErrorKey, want: attribute.Key("http.read_error")},
+		{name: "wrote bytes", got: WroteBytesKey, want: attribute.Key("http.wrote_bytes")},
+		{name: "write error", got: WriteErrorKey, want: attribute.Key("http.write_error")},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.got != test.want {
+				t.Errorf("attribute key = %q, want %q", test.got, test.want)
+			}
+		})
+	}
+}

--- a/instrumentation/net/http/otelhttp/config.go
+++ b/instrumentation/net/http/otelhttp/config.go
@@ -143,14 +143,15 @@ const (
 )
 
 // WithMessageEvents configures the Handler to record the specified events
-// (span.AddEvent) on spans. By default only summary attributes are added at the
-// end of the request.
+// (span.AddEvent) on spans. By default, no read or write events are recorded.
 //
 // Valid events are:
-//   - ReadEvents: Record the number of bytes read after every http.Request.Body.Read
-//     using the ReadBytesKey
-//   - WriteEvents: Record the number of bytes written after every http.ResponeWriter.Write
-//     using the WriteBytesKey
+//   - ReadEvents: Record a "read" span event after every http.Request.Body.Read.
+//   - WriteEvents: Record a "write" span event after every http.ResponseWriter.Write.
+//
+// The events do not include per-call byte-count attributes. Total request and
+// response body sizes are recorded on the span according to HTTP semantic
+// conventions.
 func WithMessageEvents(events ...Event) Option {
 	return optionFunc(func(c *config) {
 		for _, e := range events {

--- a/instrumentation/net/http/otelhttp/handler.go
+++ b/instrumentation/net/http/otelhttp/handler.go
@@ -129,8 +129,8 @@ func (h *middleware) serveHTTP(w http.ResponseWriter, r *http.Request, next http
 
 	readRecordFunc := func(int64) {}
 	if h.readEvent {
-		readRecordFunc = func(n int64) {
-			span.AddEvent("read", trace.WithAttributes(ReadBytesKey.Int64(n)))
+		readRecordFunc = func(int64) {
+			span.AddEvent("read")
 		}
 	}
 
@@ -150,8 +150,8 @@ func (h *middleware) serveHTTP(w http.ResponseWriter, r *http.Request, next http
 
 	writeRecordFunc := func(int64) {}
 	if h.writeEvent {
-		writeRecordFunc = func(n int64) {
-			span.AddEvent("write", trace.WithAttributes(WroteBytesKey.Int64(n)))
+		writeRecordFunc = func(int64) {
+			span.AddEvent("write")
 		}
 	}
 

--- a/instrumentation/net/http/otelhttp/handler_test.go
+++ b/instrumentation/net/http/otelhttp/handler_test.go
@@ -751,6 +751,58 @@ func TestHandlerWithMetricAttributesFn(t *testing.T) {
 	}
 }
 
+func TestMessageEventAttributes(t *testing.T) {
+	spanRecorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(spanRecorder),
+	)
+
+	h := NewHandler(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			_, err = w.Write(body)
+			assert.NoError(t, err)
+		}),
+		"test_handler",
+		WithTracerProvider(provider),
+		WithMessageEvents(ReadEvents, WriteEvents),
+	)
+
+	const payload = "hello world"
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", strings.NewReader(payload))
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	require.Len(t, spanRecorder.Ended(), 1)
+
+	var readEvents, writeEvents int
+	span := spanRecorder.Ended()[0]
+	for _, event := range span.Events() {
+		switch event.Name {
+		case "read":
+			readEvents++
+			assert.Empty(t, event.Attributes)
+		case "write":
+			writeEvents++
+			assert.Empty(t, event.Attributes)
+		}
+	}
+
+	assert.Positive(t, readEvents)
+	assert.Positive(t, writeEvents)
+	assert.Contains(t, span.Attributes(), attribute.Int("http.request.body.size", len(payload)))
+	assert.Contains(t, span.Attributes(), attribute.Int("http.response.body.size", len(payload)))
+	for _, attr := range span.Attributes() {
+		assert.NotEqual(t, attribute.Key("http.read_bytes"), attr.Key)
+		assert.NotEqual(t, attribute.Key("http.read_error"), attr.Key)
+		assert.NotEqual(t, attribute.Key("http.wrote_bytes"), attr.Key)
+		assert.NotEqual(t, attribute.Key("http.write_error"), attr.Key)
+	}
+}
+
 func BenchmarkHandlerServeHTTP(b *testing.B) {
 	tp := sdktrace.NewTracerProvider()
 	mp := sdkmetric.NewMeterProvider()


### PR DESCRIPTION
Towards #8130.

## Summary

- deprecate `ReadBytesKey`, `ReadErrorKey`, `WroteBytesKey`, and `WriteErrorKey` without changing their values
- stop `WithMessageEvents` from emitting the legacy per-read and per-write byte attributes
- preserve the existing `read` and `write` event names and timing
- continue recording whole request and response body sizes on the server span with HTTP semantic-convention attributes
- add regression coverage for the exported values and emitted telemetry

## Compatibility

This is the deprecation phase of #8130. The exported identifiers and their exact key values remain available, preserving source compatibility and manual uses of those keys.

This does change emitted telemetry: `WithMessageEvents` no longer attaches `http.read_bytes` or `http.wrote_bytes` to its per-operation events. Consumers of those event attributes will need to migrate. The `read` and `write` events remain at the same operation points, but no longer contain byte-count attributes. There is no semantic-convention equivalent for per-read or per-write byte counts.

The standard `http.request.body.size` and `http.response.body.size` attributes describe whole-message totals and were already recorded on the server span. They continue to be emitted there and are deliberately not attached to individual read or write events, where the available values describe only a chunk.

The current semantic-conventions package no longer provides `ErrorMessageKey`. `ReadErrorKey` and `WriteErrorKey` consequently have no direct replacement; if an error causes the overall HTTP request to fail, use low-cardinality `error.type` classification and Error span status.

