### PR TITLE
feat(otelhttp/filters): add Methods filter to match multiple HTTP methods

### DIFF
--- a/instrumentation/net/http/otelhttp/filters/filters.go
+++ b/instrumentation/net/http/otelhttp/filters/filters.go
@@ -111,3 +111,12 @@ func Method(m string) otelhttp.Filter {
 		return m == r.Method
 	}
 }
+
+// Methods returns a Filter that returns true if the request
+// method matches any of the provided values ms.
+func Methods(ms ...string) otelhttp.Filter {
+	return func(r *http.Request) bool {
+		return slices.Contains(ms, r.Method)
+	}
+}
+

--- a/instrumentation/net/http/otelhttp/filters/filters_test.go
+++ b/instrumentation/net/http/otelhttp/filters/filters_test.go
@@ -172,6 +172,41 @@ func TestMethod(t *testing.T) {
 	}
 }
 
+func TestMethods(t *testing.T) {
+	for _, s := range []scenario{
+		{
+			name:   "non-matching method",
+			filter: Methods(http.MethodGet, http.MethodPost),
+			req:    &http.Request{Method: http.MethodHead, URL: &url.URL{Path: "/boo/far", Host: "baz.bar:8080"}},
+			exp:    false,
+		},
+		{
+			name:   "matching first method",
+			filter: Methods(http.MethodGet, http.MethodPost),
+			req:    &http.Request{Method: http.MethodGet, URL: &url.URL{Path: "/boo/far", Host: "baz.bar:8080"}},
+			exp:    true,
+		},
+		{
+			name:   "matching second method",
+			filter: Methods(http.MethodGet, http.MethodPost),
+			req:    &http.Request{Method: http.MethodPost, URL: &url.URL{Path: "/boo/far", Host: "baz.bar:8080"}},
+			exp:    true,
+		},
+		{
+			name:   "no methods provided",
+			filter: Methods(),
+			req:    &http.Request{Method: http.MethodGet, URL: &url.URL{Path: "/boo/far", Host: "baz.bar:8080"}},
+			exp:    false,
+		},
+	} {
+		res := s.filter(s.req)
+		if s.exp != res {
+			t.Errorf("Failed testing %q. Expected %t, got %t", s.name, s.exp, res)
+		}
+	}
+}
+
+
 func TestQuery(t *testing.T) {
 	matching, _ := url.Parse("http://bar.baz:8080/foo/bar?key=value")
 	nonMatching, _ := url.Parse("http://bar.baz:8080/foo/bar?key=other")


### PR DESCRIPTION
## Description
Adds a `Methods(ms ...string)` filter to `instrumentation/net/http/otelhttp/filters` to allow matching multiple HTTP methods cleanly without needing to chain `Any(Method("GET"), Method("HEAD"))`.

Fixes #9014

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] Added godoc comments for exported function `Methods`.
- [x] Added unit tests in `filters_test.go`.
- [x] Verified unit tests pass locally (`PASS`).