### PR TITLE
samplers/probability/consistent: Deprecate module and package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Deprecated
 
-- Deprecate `go.opentelemetry.io/contrib/samplers/probability/consistent`. There is no replacement.
+- Deprecate `go.opentelemetry.io/contrib/samplers/probability/consistent`. There is no replacement. (#9633)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Add `NewResourceDetectorWithOptions` and the `WithAWSLogger` option to `go.opentelemetry.io/contrib/detectors/aws/ec2/v2`, allowing a custom AWS SDK `logging.Logger` to be supplied to the EC2 resource detector. (#9132)
 
+### Deprecated
+
+- Deprecate `go.opentelemetry.io/contrib/samplers/probability/consistent`. There is no replacement.
+
 ### Fixed
 
 - Format span attributes in `go.opentelemetry.io/contrib/zpages` using `attribute.Value.String` instead of the deprecated `attribute.Value.Emit`, following the OpenTelemetry AnyValue representation for non-OTLP protocols. (#9453)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Deprecated
 
-- Deprecate `go.opentelemetry.io/contrib/samplers/probability/consistent`. There is no replacement. (#9633)
+- Deprecate `go.opentelemetry.io/contrib/samplers/probability/consistent`. (#9633)
 
 ### Fixed
 

--- a/samplers/probability/consistent/go.mod
+++ b/samplers/probability/consistent/go.mod
@@ -1,4 +1,4 @@
-// Deprecated: This module is no longer supported. There is no replacement.
+// Deprecated: This module is no longer supported.
 module go.opentelemetry.io/contrib/samplers/probability/consistent
 
 go 1.26.0

--- a/samplers/probability/consistent/go.mod
+++ b/samplers/probability/consistent/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: This module is no longer supported. There is no replacement.
 module go.opentelemetry.io/contrib/samplers/probability/consistent
 
 go 1.26.0

--- a/samplers/probability/consistent/sampler.go
+++ b/samplers/probability/consistent/sampler.go
@@ -3,7 +3,7 @@
 
 // Package consistent provides a consistent probability based sampler.
 //
-// Deprecated: This package is no longer supported. There is no replacement.
+// Deprecated: This package is no longer supported.
 package consistent
 
 import (

--- a/samplers/probability/consistent/sampler.go
+++ b/samplers/probability/consistent/sampler.go
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package consistent provides a consistent probability based sampler.
+//
+// Deprecated: This package is no longer supported. There is no replacement.
 package consistent
 
 import (


### PR DESCRIPTION
Fixes #8006
Towards #6176

Deprecate the `go.opentelemetry.io/contrib/samplers/probability/consistent` Go module and package.
The experimental specification it implements has been retired (https://github.com/open-telemetry/opentelemetry-specification/pull/4673), and there is currently no replacement available in OpenTelemetry Go.