### PR TITLE
exporters/autoexport: treat empty Prometheus env values as unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Treat empty Prometheus exporter environment variable values as unset in `go.opentelemetry.io/contrib/exporters/autoexport`, restoring the documented defaults. (#9636)
 - Format span attributes in `go.opentelemetry.io/contrib/zpages` using `attribute.Value.String` instead of the deprecated `attribute.Value.Emit`, following the OpenTelemetry AnyValue representation for non-OTLP protocols. (#9453)
 
 ### Removed

--- a/exporters/autoexport/metrics.go
+++ b/exporters/autoexport/metrics.go
@@ -242,8 +242,8 @@ func (rws readerWithServer) Shutdown(ctx context.Context) error {
 }
 
 func getenv(key, fallback string) string {
-	result, ok := os.LookupEnv(key)
-	if !ok {
+	result := os.Getenv(key)
+	if result == "" {
 		return fallback
 	}
 	return result

--- a/exporters/autoexport/metrics_test.go
+++ b/exporters/autoexport/metrics_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -125,6 +126,7 @@ func TestMetricExporterPrometheus(t *testing.T) {
 	assertNoOtelHandleErrors(t)
 
 	t.Setenv("OTEL_METRICS_EXPORTER", "prometheus")
+	t.Setenv("OTEL_EXPORTER_PROMETHEUS_HOST", "")
 	t.Setenv("OTEL_EXPORTER_PROMETHEUS_PORT", "0")
 
 	r, err := NewMetricReader(t.Context())
@@ -134,9 +136,12 @@ func TestMetricExporterPrometheus(t *testing.T) {
 	mp := metric.NewMeterProvider(metric.WithReader(r))
 
 	rws, ok := r.(readerWithServer)
-	if !ok {
-		t.Errorf("expected readerWithServer but got %v", r)
-	}
+	require.True(t, ok, "expected readerWithServer but got %v", r)
+	host, _, err := net.SplitHostPort(rws.addr.String())
+	require.NoError(t, err)
+	localhostIPs, err := net.DefaultResolver.LookupHost(t.Context(), "localhost")
+	require.NoError(t, err)
+	assert.Contains(t, localhostIPs, host)
 
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, fmt.Sprintf("http://%s/metrics", rws.addr), http.NoBody)
 	require.NoError(t, err)
@@ -150,6 +155,26 @@ func TestMetricExporterPrometheus(t *testing.T) {
 
 	assert.NoError(t, mp.Shutdown(t.Context()))
 	goleak.VerifyNone(t)
+}
+
+func TestMetricExporterPrometheusEmptyPort(t *testing.T) {
+	assertNoOtelHandleErrors(t)
+
+	t.Setenv("OTEL_METRICS_EXPORTER", "prometheus")
+	t.Setenv("OTEL_EXPORTER_PROMETHEUS_HOST", "127.0.0.1")
+	t.Setenv("OTEL_EXPORTER_PROMETHEUS_PORT", "")
+
+	r, err := NewMetricReader(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, r.Shutdown(t.Context()))
+	})
+
+	rws, ok := r.(readerWithServer)
+	require.True(t, ok)
+	_, port, err := net.SplitHostPort(rws.addr.String())
+	require.NoError(t, err)
+	assert.Equal(t, "9464", port)
 }
 
 func TestMetricExporterPrometheusInvalidPort(t *testing.T) {


### PR DESCRIPTION


Fix `go.opentelemetry.io/contrib/exporters/autoexport` so empty `OTEL_EXPORTER_PROMETHEUS_HOST` and `OTEL_EXPORTER_PROMETHEUS_PORT` values are treated the same as unset values.

Previously, `os.LookupEnv` distinguished an empty environment variable from an unset variable. This could produce an invalid Prometheus bind address such as:

```text
localhost:
```

The implementation now uses the documented defaults when either value is empty:

- host: `localhost`
- port: `9464`



