### PR TITLE
fix(detectors/aws/eks): bound Kubernetes API requests when the caller has no deadline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - Format span attributes in `go.opentelemetry.io/contrib/zpages` using `attribute.Value.String` instead of the deprecated `attribute.Value.Emit`, following the OpenTelemetry AnyValue representation for non-OTLP protocols. (#9453)
-- Format span attributes in `go.opentelemetry.io/contrib/zpages` using `attribute.Value.String` instead of the deprecated `attribute.Value.Emit`, following the OpenTelemetry AnyValue representation for non-OTLP protocols. (#9453)
 - Set `error.type` on the span and on the request-duration, request-body-size, and response-body-size metrics when a client disconnects mid-request in `go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin`, using the request context's cancellation error as the classification source when the handler has not already recorded an error via `c.Error`. Previously a disconnect was recorded with span status `Error` and no `error.type`, indistinguishable from a genuine server fault. (#9394)
+- Bound Kubernetes API calls made by `go.opentelemetry.io/contrib/detectors/aws/eks` to 5 seconds when the caller provides a context without a deadline, so resource detection cannot hang indefinitely at application startup. (#NNNN)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Format span attributes in `go.opentelemetry.io/contrib/zpages` using `attribute.Value.String` instead of the deprecated `attribute.Value.Emit`, following the OpenTelemetry AnyValue representation for non-OTLP protocols. (#9453)
 - Set `error.type` on the span and on the request-duration, request-body-size, and response-body-size metrics when a client disconnects mid-request in `go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin`, using the request context's cancellation error as the classification source when the handler has not already recorded an error via `c.Error`. Previously a disconnect was recorded with span status `Error` and no `error.type`, indistinguishable from a genuine server fault. (#9394)
-- Bound Kubernetes API calls made by `go.opentelemetry.io/contrib/detectors/aws/eks` to 5 seconds when the caller provides a context without a deadline, so resource detection cannot hang indefinitely at application startup. (#NNNN)
+- Bound Kubernetes API calls made by `go.opentelemetry.io/contrib/detectors/aws/eks` to 5 seconds when the caller provides a context without a deadline, so resource detection cannot hang indefinitely at application startup. (#9638)
 
 ### Removed
 

--- a/detectors/aws/eks/detector.go
+++ b/detectors/aws/eks/detector.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -30,6 +31,11 @@ const (
 	cwConfigmapName   = "cluster-info"
 	defaultCgroupPath = "/proc/self/cgroup"
 	containerIDLength = 64
+
+	// k8sRequestTimeout bounds each Kubernetes API call when the caller
+	// provides a context without a deadline, so resource detection cannot
+	// hang indefinitely at application startup.
+	k8sRequestTimeout = 5 * time.Second
 )
 
 // detectorUtils is used for testing the resourceDetector by abstracting functions that rely on external systems.
@@ -163,6 +169,14 @@ func (eksDetectorUtils) fileExists(filename string) bool {
 
 // getConfigMap retrieves the configuration map from the k8s API.
 func (eksUtils eksDetectorUtils) getConfigMap(ctx context.Context, namespace, name string) (map[string]string, error) {
+	// Bound the request duration when the caller provides no deadline so a
+	// non-responding Kubernetes API cannot block detection indefinitely.
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, k8sRequestTimeout)
+		defer cancel()
+	}
+
 	u, err := url.JoinPath(eksUtils.host, "api", "v1", "namespaces", namespace, "configmaps", name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build ConfigMap URL for %s/%s: %w", namespace, name, err)

--- a/detectors/aws/eks/detector_test.go
+++ b/detectors/aws/eks/detector_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -122,4 +123,23 @@ func TestGetConfigMapNon2xx(t *testing.T) {
 	_, err := utils.getConfigMap(t.Context(), authConfigmapNS, authConfigmapName)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "unexpected status")
+}
+
+// TestGetConfigMapBoundedWhenNoDeadline ensures a ConfigMap fetch cannot hang
+// indefinitely when the caller provides a context without a deadline, e.g. a
+// resource detection at application startup using context.Background().
+func TestGetConfigMapBoundedWhenNoDeadline(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	t.Cleanup(srv.Close)
+
+	utils := &eksDetectorUtils{host: srv.URL, client: srv.Client()}
+	start := time.Now()
+	_, err := utils.getConfigMap(context.Background(), authConfigmapNS, authConfigmapName)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "context deadline exceeded")
+	assert.Less(t, elapsed, k8sRequestTimeout*2, "request should be bounded by k8sRequestTimeout")
 }


### PR DESCRIPTION
Updates #9073

## What

`go.opentelemetry.io/contrib/detectors/aws/eks` made Kubernetes API calls (`getConfigMap`, used by both the EKS-environment check and the cluster-name lookup) with only the caller-provided context. When callers run detection with a context that has no deadline — e.g. `context.Background()` at application startup — a non-responding or unreachable Kubernetes API could block resource detection indefinitely.

This bounds each ConfigMap request: when the caller's context has no deadline, `getConfigMap` derives one with a 5 second timeout (`k8sRequestTimeout`), matching the existing convention in the `detectors/ibmcloud/vpc` and `detectors/vultr` detectors. A caller-provided deadline is still honored as-is, and caller cancellation continues to propagate immediately.

## Verification

- **Regression test added** (`TestGetConfigMapBoundedWhenNoDeadline`): a non-responding httptest server + `context.Background()`. Before the fix this test hangs until the test-timeout guard (confirmed via `go test -timeout 7s`); after the fix it returns in ~5.00s with a `context deadline exceeded` error.
- `go test -count=1 ./...`: pass (5.05s, includes the 5s bounded test)
- `go vet .`: clean
- `gofmt -l .`: clean
- `git diff --check`: clean
- `make precommit` was not run: `make` is not available in this (Windows) environment; the focused equivalents above were used instead.

## Checklist

- [x] Changelog entry added under `Unreleased` / `Fixed` (PR number to be filled once assigned).

## AI disclosure

Code authored with the assistance of an AI coding agent.