### PR TITLE
feat(otelhttp): add WithRedactedQueryParams to Transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Add `NewResourceDetectorWithOptions` and the `WithAWSLogger` option to `go.opentelemetry.io/contrib/detectors/aws/ec2/v2`, allowing a custom AWS SDK `logging.Logger` to be supplied to the EC2 resource detector. (#9132)
+- Add `WithRedactedQueryParams` to `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp`, redacting the values of the given query parameters in the `url.full` span attribute recorded by `Transport`. (#9643)
 
 ### Changed
 

--- a/instrumentation/net/http/otelhttp/config.go
+++ b/instrumentation/net/http/otelhttp/config.go
@@ -36,6 +36,8 @@ type config struct {
 	TracerProvider     trace.TracerProvider
 	MeterProvider      metric.MeterProvider
 	MetricAttributesFn func(*http.Request) []attribute.KeyValue
+
+	RedactedQueryParams []string
 }
 
 // Option interface used for setting optional config properties.
@@ -182,6 +184,24 @@ func WithSpanNameFormatter(f func(operation string, r *http.Request) string) Opt
 func WithClientTrace(f func(context.Context) *httptrace.ClientTrace) Option {
 	return optionFunc(func(c *config) {
 		c.ClientTrace = f
+	})
+}
+
+// WithRedactedQueryParams returns an Option that replaces the value of the
+// given query parameters with "REDACTED" in the url.full attribute recorded
+// by the otelhttp Transport, for parameters present on the outbound request.
+// It has no effect on the request that is actually sent; only the recorded
+// span attribute is changed.
+//
+// Query parameters not listed are left as-is, but the query string as a
+// whole is re-encoded (parameters may be reordered, and their values
+// percent-encoded canonically) as a side effect of the redaction.
+//
+// Use this for URLs that carry sensitive values in query parameters, such as
+// API tokens, that would otherwise be captured verbatim in span data.
+func WithRedactedQueryParams(keys ...string) Option {
+	return optionFunc(func(c *config) {
+		c.RedactedQueryParams = keys
 	})
 }
 

--- a/instrumentation/net/http/otelhttp/config.go
+++ b/instrumentation/net/http/otelhttp/config.go
@@ -195,7 +195,11 @@ func WithClientTrace(f func(context.Context) *httptrace.ClientTrace) Option {
 //
 // Query parameters not listed are left as-is, but the query string as a
 // whole is re-encoded (parameters may be reordered, and their values
-// percent-encoded canonically) as a side effect of the redaction.
+// percent-encoded canonically) as a side effect of the redaction. Any
+// parameter pair that fails to parse (a malformed percent-escape, for
+// example) is dropped rather than passed through raw, so a malformed pair
+// elsewhere in the query can never cause a value that should be redacted to
+// leak unredacted.
 //
 // Use this for URLs that carry sensitive values in query parameters, such as
 // API tokens, that would otherwise be captured verbatim in span data.

--- a/instrumentation/net/http/otelhttp/config.go
+++ b/instrumentation/net/http/otelhttp/config.go
@@ -203,9 +203,13 @@ func WithClientTrace(f func(context.Context) *httptrace.ClientTrace) Option {
 //
 // Use this for URLs that carry sensitive values in query parameters, such as
 // API tokens, that would otherwise be captured verbatim in span data.
+//
+// Like [WithFilter], keys accumulate across multiple calls to
+// WithRedactedQueryParams rather than the last call replacing the previous
+// ones.
 func WithRedactedQueryParams(keys ...string) Option {
 	return optionFunc(func(c *config) {
-		c.RedactedQueryParams = keys
+		c.RedactedQueryParams = append(c.RedactedQueryParams, keys...)
 	})
 }
 

--- a/instrumentation/net/http/otelhttp/transport.go
+++ b/instrumentation/net/http/otelhttp/transport.go
@@ -106,28 +106,40 @@ func (t *Transport) requestTraceAttrs(r *http.Request) []attribute.KeyValue {
 }
 
 // redactQueryParams returns rawQuery with the values of any parameter in
-// keys replaced with "REDACTED". If rawQuery cannot be parsed, or none of
-// keys are present, rawQuery is returned unchanged. Otherwise, the returned
-// query string is re-encoded as a whole: parameters may be reordered and
-// their values percent-encoded canonically.
+// keys replaced with "REDACTED". If none of keys are present, rawQuery is
+// returned unchanged. Otherwise, the returned query string is re-encoded as
+// a whole: parameters may be reordered and their values percent-encoded
+// canonically.
+//
+// url.ParseQuery returns the pairs it was able to parse alongside an error
+// for any it wasn't (e.g. a malformed percent-escape in an unrelated
+// parameter, or a "token=secret;x=1" query rejected for its semicolon
+// separator). A pair that failed to parse is dropped rather than passed
+// through raw: returning rawQuery unchanged on any parse error would risk
+// leaking a value we were asked to redact, if it happened to sit next to a
+// malformed pair.
 func redactQueryParams(rawQuery string, keys []string) string {
 	values, err := url.ParseQuery(rawQuery)
-	if err != nil {
+	if err == nil && !hasAny(values, keys) {
 		return rawQuery
 	}
 
-	var redacted bool
 	for _, key := range keys {
 		if _, ok := values[key]; ok {
 			values.Set(key, "REDACTED")
-			redacted = true
 		}
-	}
-	if !redacted {
-		return rawQuery
 	}
 
 	return values.Encode()
+}
+
+func hasAny(values url.Values, keys []string) bool {
+	for _, key := range keys {
+		if _, ok := values[key]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // RoundTrip creates a Span and propagates its context via the provided request's headers

--- a/instrumentation/net/http/otelhttp/transport.go
+++ b/instrumentation/net/http/otelhttp/transport.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptrace"
+	"net/url"
 	"sync/atomic"
 	"time"
 
@@ -35,6 +36,8 @@ type Transport struct {
 	spanNameFormatter  func(string, *http.Request) string
 	clientTrace        func(context.Context) *httptrace.ClientTrace
 	metricAttributesFn func(*http.Request) []attribute.KeyValue
+
+	redactedQueryParams []string
 
 	semconv semconv.HTTPClient
 }
@@ -76,10 +79,55 @@ func (t *Transport) applyConfig(c *config) {
 	t.clientTrace = c.ClientTrace
 	t.semconv = semconv.NewHTTPClient(c.Meter)
 	t.metricAttributesFn = c.MetricAttributesFn
+	t.redactedQueryParams = c.RedactedQueryParams
 }
 
 func defaultTransportFormatter(_ string, r *http.Request) string {
 	return "HTTP " + r.Method
+}
+
+// requestTraceAttrs returns the trace attributes for r, redacting any query
+// parameter values configured via WithRedactedQueryParams from the url.full
+// attribute.
+//
+// r.URL is temporarily mutated to build the redacted attributes and restored
+// before returning, so the request actually sent over the wire is unaffected.
+func (t *Transport) requestTraceAttrs(r *http.Request) []attribute.KeyValue {
+	if len(t.redactedQueryParams) == 0 || r.URL == nil || r.URL.RawQuery == "" {
+		return t.semconv.RequestTraceAttrs(r)
+	}
+
+	original := r.URL.RawQuery
+	r.URL.RawQuery = redactQueryParams(original, t.redactedQueryParams)
+	attrs := t.semconv.RequestTraceAttrs(r)
+	r.URL.RawQuery = original
+
+	return attrs
+}
+
+// redactQueryParams returns rawQuery with the values of any parameter in
+// keys replaced with "REDACTED". If rawQuery cannot be parsed, or none of
+// keys are present, rawQuery is returned unchanged. Otherwise, the returned
+// query string is re-encoded as a whole: parameters may be reordered and
+// their values percent-encoded canonically.
+func redactQueryParams(rawQuery string, keys []string) string {
+	values, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		return rawQuery
+	}
+
+	var redacted bool
+	for _, key := range keys {
+		if _, ok := values[key]; ok {
+			values.Set(key, "REDACTED")
+			redacted = true
+		}
+	}
+	if !redacted {
+		return rawQuery
+	}
+
+	return values.Encode()
 }
 
 // RoundTrip creates a Span and propagates its context via the provided request's headers
@@ -139,7 +187,7 @@ func (t *Transport) RoundTrip(r *http.Request) (*http.Response, error) {
 		}
 	}
 
-	span.SetAttributes(t.semconv.RequestTraceAttrs(r)...)
+	span.SetAttributes(t.requestTraceAttrs(r)...)
 	t.propagators.Inject(ctx, propagation.HeaderCarrier(r.Header))
 
 	res, err := t.rt.RoundTrip(r)

--- a/instrumentation/net/http/otelhttp/transport_test.go
+++ b/instrumentation/net/http/otelhttp/transport_test.go
@@ -1100,16 +1100,42 @@ func TestRedactQueryParams(t *testing.T) {
 			want:     "other=kept",
 		},
 		{
-			name:     "invalid query string is returned unchanged",
+			name:     "wholly unparseable query is dropped rather than leaked",
 			rawQuery: "%zz",
 			keys:     []string{"token"},
-			want:     "%zz",
+			want:     "",
 		},
 		{
 			name:     "redacts every value for a repeated key",
 			rawQuery: "token=a&token=b",
 			keys:     []string{"token"},
 			want:     "token=REDACTED",
+		},
+		{
+			// A malformed pair elsewhere in the query must not defeat
+			// redaction of a key that did parse successfully.
+			name:     "redacts a matching key despite an unrelated malformed pair",
+			rawQuery: "a=%zz&token=secret",
+			keys:     []string{"token"},
+			want:     "token=REDACTED",
+		},
+		{
+			// The key's own value is malformed, so it never makes it into
+			// the parsed values at all. It must not be passed through raw
+			// (which would leak most of the secret); dropping it is the
+			// safe outcome.
+			name:     "a key with a malformed value is dropped, not leaked",
+			rawQuery: "token=sec%zzret&a=1",
+			keys:     []string{"token"},
+			want:     "a=1",
+		},
+		{
+			// Go rejects ";" as a query separator outright, so nothing
+			// parses; the whole query is dropped rather than returned raw.
+			name:     "semicolon-separated query is dropped rather than leaked",
+			rawQuery: "token=secret;x=1",
+			keys:     []string{"token"},
+			want:     "",
 		},
 	}
 

--- a/instrumentation/net/http/otelhttp/transport_test.go
+++ b/instrumentation/net/http/otelhttp/transport_test.go
@@ -1140,7 +1140,7 @@ func TestRedactQueryParams(t *testing.T) {
 			want:     "other=kept",
 		},
 		{
-			name:     "wholly unparseable query is dropped rather than leaked",
+			name:     "wholly unparsable query is dropped rather than leaked",
 			rawQuery: "%zz",
 			keys:     []string{"token"},
 			want:     "",

--- a/instrumentation/net/http/otelhttp/transport_test.go
+++ b/instrumentation/net/http/otelhttp/transport_test.go
@@ -1040,6 +1040,46 @@ func TestTransportRedactsQueryParams(t *testing.T) {
 	assert.NotContains(t, gotURL, "secret")
 }
 
+func TestTransportRedactedQueryParamsAccumulateAcrossOptions(t *testing.T) {
+	// Like WithFilter, keys from multiple WithRedactedQueryParams calls
+	// should accumulate rather than the last call replacing the previous
+	// ones.
+	spanRecorder := tracetest.NewSpanRecorder()
+	tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	tr := NewTransport(
+		http.DefaultTransport,
+		WithTracerProvider(tracerProvider),
+		WithRedactedQueryParams("a"),
+		WithRedactedQueryParams("b"),
+	)
+	c := http.Client{Transport: tr}
+
+	r, err := http.NewRequestWithContext(t.Context(), http.MethodGet, ts.URL+"?a=1&b=2", http.NoBody)
+	require.NoError(t, err)
+
+	res, err := c.Do(r)
+	require.NoError(t, err)
+	require.NoError(t, res.Body.Close())
+
+	spans := spanRecorder.Ended()
+	require.Len(t, spans, 1)
+
+	var gotURL string
+	for _, kv := range spans[0].Attributes() {
+		if kv.Key == "url.full" {
+			gotURL = kv.Value.AsString()
+		}
+	}
+	assert.Contains(t, gotURL, "a=REDACTED")
+	assert.Contains(t, gotURL, "b=REDACTED")
+}
+
 func TestTransportNoRedactedQueryParamsLeavesURLUnchanged(t *testing.T) {
 	spanRecorder := tracetest.NewSpanRecorder()
 	tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))

--- a/instrumentation/net/http/otelhttp/transport_test.go
+++ b/instrumentation/net/http/otelhttp/transport_test.go
@@ -996,6 +996,130 @@ func TestTransportNetworkProtocolVersionFromResponse(t *testing.T) {
 	}
 }
 
+func TestTransportRedactsQueryParams(t *testing.T) {
+	spanRecorder := tracetest.NewSpanRecorder()
+	tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+
+	var gotRawQuery string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotRawQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	tr := NewTransport(
+		http.DefaultTransport,
+		WithTracerProvider(tracerProvider),
+		WithRedactedQueryParams("token", "absent"),
+	)
+	c := http.Client{Transport: tr}
+
+	r, err := http.NewRequestWithContext(t.Context(), http.MethodGet, ts.URL+"?token=secret&other=kept", http.NoBody)
+	require.NoError(t, err)
+
+	res, err := c.Do(r)
+	require.NoError(t, err)
+	require.NoError(t, res.Body.Close())
+
+	// The actual request sent over the wire must be unaffected by redaction.
+	assert.Equal(t, "token=secret&other=kept", gotRawQuery)
+	// So must the original *http.Request the caller passed in.
+	assert.Equal(t, "token=secret&other=kept", r.URL.RawQuery)
+
+	spans := spanRecorder.Ended()
+	require.Len(t, spans, 1)
+
+	var gotURL string
+	for _, kv := range spans[0].Attributes() {
+		if kv.Key == "url.full" {
+			gotURL = kv.Value.AsString()
+		}
+	}
+	assert.Contains(t, gotURL, "token=REDACTED")
+	assert.Contains(t, gotURL, "other=kept")
+	assert.NotContains(t, gotURL, "secret")
+}
+
+func TestTransportNoRedactedQueryParamsLeavesURLUnchanged(t *testing.T) {
+	spanRecorder := tracetest.NewSpanRecorder()
+	tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	// WithRedactedQueryParams is not configured, so the query string should
+	// pass through exactly as-is, without the reordering/re-encoding
+	// redaction performs.
+	tr := NewTransport(http.DefaultTransport, WithTracerProvider(tracerProvider))
+	c := http.Client{Transport: tr}
+
+	r, err := http.NewRequestWithContext(t.Context(), http.MethodGet, ts.URL+"?b=2&a=1", http.NoBody)
+	require.NoError(t, err)
+
+	res, err := c.Do(r)
+	require.NoError(t, err)
+	require.NoError(t, res.Body.Close())
+
+	spans := spanRecorder.Ended()
+	require.Len(t, spans, 1)
+
+	var gotURL string
+	for _, kv := range spans[0].Attributes() {
+		if kv.Key == "url.full" {
+			gotURL = kv.Value.AsString()
+		}
+	}
+	assert.Contains(t, gotURL, "b=2&a=1")
+}
+
+func TestRedactQueryParams(t *testing.T) {
+	testCases := []struct {
+		name     string
+		rawQuery string
+		keys     []string
+		want     string
+	}{
+		{
+			name:     "redacts a matching key",
+			rawQuery: "token=secret&other=kept",
+			keys:     []string{"token"},
+			want:     "other=kept&token=REDACTED",
+		},
+		{
+			name:     "no keys configured leaves query unchanged",
+			rawQuery: "token=secret",
+			keys:     nil,
+			want:     "token=secret",
+		},
+		{
+			name:     "no matching keys leaves query unchanged",
+			rawQuery: "other=kept",
+			keys:     []string{"token"},
+			want:     "other=kept",
+		},
+		{
+			name:     "invalid query string is returned unchanged",
+			rawQuery: "%zz",
+			keys:     []string{"token"},
+			want:     "%zz",
+		},
+		{
+			name:     "redacts every value for a repeated key",
+			rawQuery: "token=a&token=b",
+			keys:     []string{"token"},
+			want:     "token=REDACTED",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, redactQueryParams(tc.rawQuery, tc.keys))
+		})
+	}
+}
+
 func assertClientScopeMetrics(t *testing.T, sm metricdata.ScopeMetrics, attrs attribute.Set) {
 	assert.Equal(t, instrumentation.Scope{
 		Name:    "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",


### PR DESCRIPTION
## Summary

Fixes #6987.

`otelhttp.Transport` records the full outbound URL, including the query string, in the `url.full` span attribute. There's no way to keep sensitive values (API tokens, etc.) that are passed as query parameters out of that attribute without dropping the whole thing.

This adds `WithRedactedQueryParams(keys ...string)`, which replaces the value of the given query parameters with `"REDACTED"` in the recorded `url.full` attribute. It only affects what's recorded on the span; the request sent over the wire, and the original `*http.Request` passed to `RoundTrip`, are both untouched.

As discussed on the issue, the existing [`redact`](https://github.com/MrAlias/redact) plugin can't do this: it works by matching whole attribute keys or dropping spans by name, so there's no way to use it to mask just one query parameter's value while keeping the rest of the URL visible.

## Implementation notes

- Scoped to the `Transport` (client) side only, distinct from the server-side `url.query` capture work in #8869/#8867.
- Redaction is applied by briefly mutating the request's `URL.RawQuery` around the call that builds the trace attributes, then restoring it before the request is sent — a regression test (`TestTransportOriginRequestNotModify`-style assertion) confirms the original request is untouched and the real query string reaches the server unchanged.
- Query parameters not being redacted are left as-is in value, but since the query string is rebuilt via `url.Values.Encode()`, they may be reordered/canonically re-encoded. Documented on the option.

## Test plan

- [x] Added `TestTransportRedactsQueryParams` (end-to-end: real request unaffected, span attribute redacted)
- [x] Added `TestTransportNoRedactedQueryParamsLeavesURLUnchanged` (no-op when unconfigured)
- [x] Added `TestRedactQueryParams` (unit tests for the redaction helper, including invalid query strings and repeated keys)
- [x] `go build ./...`, `go vet ./...`, `go test ./... -race` pass
- [x] `golangci-lint run` passes with 0 issues