### PR TITLE
chore: fix gofumpt extra-rules warning

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -224,7 +224,8 @@ formatters:
     - goimports
   settings:
     gofumpt:
-      extra-rules: true
+      extra:
+        group-params: true
     goimports:
       local-prefixes:
         - go.opentelemetry.io/contrib


### PR DESCRIPTION
This is the contrib equivalent of https://github.com/open-telemetry/opentelemetry-go/pull/8942.