### PR TITLE
detectors/ibmcloud/vpc: Accept 2xx status for the instance identity token request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Format span attributes in `go.opentelemetry.io/contrib/zpages` using `attribute.Value.String` instead of the deprecated `attribute.Value.Emit`, following the OpenTelemetry AnyValue representation for non-OTLP protocols. (#9453)
 - Format span attributes in `go.opentelemetry.io/contrib/zpages` using `attribute.Value.String` instead of the deprecated `attribute.Value.Emit`, following the OpenTelemetry AnyValue representation for non-OTLP protocols. (#9453)
 - Set `error.type` on the span and on the request-duration, request-body-size, and response-body-size metrics when a client disconnects mid-request in `go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin`, using the request context's cancellation error as the classification source when the handler has not already recorded an error via `c.Error`. Previously a disconnect was recorded with span status `Error` and no `error.type`, indistinguishable from a genuine server fault. (#9394)
+- Accept any 2xx status for the instance identity token request in `go.opentelemetry.io/contrib/detectors/ibmcloud/vpc`. The IMDS Identity API returns 201 Created for the token PUT, which the detector previously rejected, silently returning an empty resource on real IBM Cloud VPC instances. (#9669)
 
 ### Removed
 

--- a/detectors/ibmcloud/vpc/vpc.go
+++ b/detectors/ibmcloud/vpc/vpc.go
@@ -241,7 +241,9 @@ func (d *ResourceDetector) getToken(ctx context.Context) (string, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	// The IMDS Identity API documents 201 Created for the token PUT; accept any
+	// 2xx like IBM's own SDK does.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
 		return "", fmt.Errorf("token request returned %d: %s", resp.StatusCode, string(body))
 	}

--- a/detectors/ibmcloud/vpc/vpc_test.go
+++ b/detectors/ibmcloud/vpc/vpc_test.go
@@ -97,6 +97,20 @@ func TestDetect(t *testing.T) {
 	assert.Equal(t, int32(1), tokenRequests.Load(), "second detection should reuse the metadata token")
 }
 
+func TestDetectTokenCreatedStatus(t *testing.T) {
+	var tokenRequests atomic.Int32
+	srv := newMetadataServerWithTokenResponse(t, &tokenRequests, http.StatusCreated, `{"access_token":"test-token","expires_in":300}`, http.StatusOK, testInstanceJSON)
+	defer srv.Close()
+
+	detector := NewResourceDetector()
+	detector.endpoint = srv.URL
+
+	res, err := detector.Detect(t.Context())
+	require.NoError(t, err)
+	assert.NotEmpty(t, res.Attributes(), "a 201 Created token response must be accepted")
+	assert.Equal(t, int32(1), tokenRequests.Load())
+}
+
 func TestDetectReusesShortLivedToken(t *testing.T) {
 	var tokenRequests atomic.Int32
 	srv := newMetadataServerWithTokenBody(t, &tokenRequests, http.StatusOK, testInstanceJSON, `{"access_token":"test-token","expires_in":1}`)


### PR DESCRIPTION
### Description

The IBM Cloud VPC Identity API documents 201 Created for the token PUT ([Create an identity token](https://cloud.ibm.com/docs/apis/vpc-identity/latest#create-identity-token)), but the detector required exactly 200, so `Detect()` silently returned an empty resource on real VPC instances. Accept the 2xx range instead, matching IBM's own go-sdk-core, and add a regression test with a 201 token response. The `GET /metadata/v1/instance` check stays 200 only, as that operation documents 200.

Fixes #9644